### PR TITLE
feat: add bookmark folder sync via GraphQL

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,18 @@
 {
-  "name": "ft-bookmarks",
-  "version": "1.2.1",
+  "name": "fieldtheory",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "ft-bookmarks",
-      "version": "1.2.1",
+      "name": "fieldtheory",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
         "commander": "^14.0.3",
         "dotenv": "^17.3.1",
         "sql.js": "^1.14.1",
-        "sql.js-fts5": "^1.4.0",
-        "zod": "^4.3.6"
+        "sql.js-fts5": "^1.4.0"
       },
       "bin": {
         "ft": "bin/ft.mjs"
@@ -651,15 +650,6 @@
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/zod": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
     }
   }
 }

--- a/src/bookmarks-db.ts
+++ b/src/bookmarks-db.ts
@@ -741,6 +741,11 @@ export async function getFolderCounts(): Promise<Record<string, number>> {
   const db = await openDb(dbPath);
   ensureMigrations(db);
   try {
+    // Return empty if no bookmarks have folder data yet
+    const hasFolder = db.exec("SELECT 1 FROM bookmarks WHERE x_folder IS NOT NULL LIMIT 1");
+    if (!hasFolder.length || !hasFolder[0].values.length) {
+      return {};
+    }
     const rows = db.exec(
       `SELECT COALESCE(x_folder, '(unfiled)'), COUNT(*) as c FROM bookmarks
        GROUP BY COALESCE(x_folder, '(unfiled)') ORDER BY c DESC`

--- a/src/bookmarks-db.ts
+++ b/src/bookmarks-db.ts
@@ -6,7 +6,7 @@ import type { BookmarkRecord } from './types.js';
 import { classifyCorpus, formatClassificationSummary } from './bookmark-classify.js';
 import type { ClassificationSummary } from './bookmark-classify.js';
 
-const SCHEMA_VERSION = 3;
+const SCHEMA_VERSION = 4;
 
 export interface SearchResult {
   id: string;
@@ -50,6 +50,7 @@ export interface BookmarkTimelineItem {
   quoteCount?: number | null;
   bookmarkCount?: number | null;
   viewCount?: number | null;
+  xFolder?: string | null;
 }
 
 export interface BookmarkTimelineFilters {
@@ -107,6 +108,7 @@ function mapTimelineRow(row: unknown[]): BookmarkTimelineItem {
     quoteCount: row[20] as number | null,
     bookmarkCount: row[21] as number | null,
     viewCount: row[22] as number | null,
+    xFolder: (row[23] as string) ?? null,
   };
 }
 
@@ -194,7 +196,9 @@ function initSchema(db: Database): void {
     primary_category TEXT,
     github_urls TEXT,
     domains TEXT,
-    primary_domain TEXT
+    primary_domain TEXT,
+    x_folder TEXT,
+    x_folder_id TEXT
   )`);
 
   db.run(`CREATE INDEX IF NOT EXISTS idx_bookmarks_author ON bookmarks(author_handle)`);
@@ -202,6 +206,7 @@ function initSchema(db: Database): void {
   db.run(`CREATE INDEX IF NOT EXISTS idx_bookmarks_language ON bookmarks(language)`);
   db.run(`CREATE INDEX IF NOT EXISTS idx_bookmarks_category ON bookmarks(primary_category)`);
   db.run(`CREATE INDEX IF NOT EXISTS idx_bookmarks_domain ON bookmarks(primary_domain)`);
+  db.run(`CREATE INDEX IF NOT EXISTS idx_bookmarks_x_folder ON bookmarks(x_folder)`);
 
   db.run(`CREATE VIRTUAL TABLE IF NOT EXISTS bookmarks_fts USING fts5(
     text,
@@ -230,6 +235,15 @@ function ensureMigrations(db: Database): void {
     }
     db.run("REPLACE INTO meta VALUES ('schema_version', '3')");
   }
+  if (version < 4) {
+    const tableExists = db.exec("SELECT name FROM sqlite_master WHERE type='table' AND name='bookmarks'");
+    if (tableExists.length && tableExists[0].values.length > 0) {
+      try { db.run('ALTER TABLE bookmarks ADD COLUMN x_folder TEXT'); } catch { /* already exists */ }
+      try { db.run('ALTER TABLE bookmarks ADD COLUMN x_folder_id TEXT'); } catch { /* already exists */ }
+      db.run('CREATE INDEX IF NOT EXISTS idx_bookmarks_x_folder ON bookmarks(x_folder)');
+    }
+    db.run("REPLACE INTO meta VALUES ('schema_version', '4')");
+  }
 }
 
 function insertRecord(db: Database, r: BookmarkRecord): void {
@@ -240,7 +254,7 @@ function insertRecord(db: Database, r: BookmarkRecord): void {
   const githubUrls = [...new Set([...githubMatches.map((m) => `https://${m}`), ...githubFromLinks])];
 
   db.run(
-    `INSERT OR REPLACE INTO bookmarks VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+    `INSERT OR REPLACE INTO bookmarks VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
     [
       r.id,
       r.tweetId,
@@ -272,6 +286,8 @@ function insertRecord(db: Database, r: BookmarkRecord): void {
       githubUrls.length ? JSON.stringify(githubUrls) : null,
       null, // domains — populated by classify-domains pass
       null, // primary_domain
+      r.xFolder ?? null,
+      r.xFolderId ?? null,
     ]
   );
 }
@@ -432,7 +448,8 @@ export async function listBookmarks(
         b.reply_count,
         b.quote_count,
         b.bookmark_count,
-        b.view_count
+        b.view_count,
+        b.x_folder
       FROM bookmarks b
       ${where}
       ${bookmarkSortClause(filters.sort)}
@@ -567,7 +584,8 @@ export async function getBookmarkById(id: string): Promise<BookmarkTimelineItem 
         b.reply_count,
         b.quote_count,
         b.bookmark_count,
-        b.view_count
+        b.view_count,
+        b.x_folder
       FROM bookmarks b
       WHERE b.id = ?
       LIMIT 1`,
@@ -707,6 +725,25 @@ export async function getCategoryCounts(): Promise<Record<string, number>> {
       `SELECT primary_category, COUNT(*) as c FROM bookmarks
        WHERE primary_category IS NOT NULL
        GROUP BY primary_category ORDER BY c DESC`
+    );
+    const counts: Record<string, number> = {};
+    for (const row of rows[0]?.values ?? []) {
+      counts[row[0] as string] = row[1] as number;
+    }
+    return counts;
+  } finally {
+    db.close();
+  }
+}
+
+export async function getFolderCounts(): Promise<Record<string, number>> {
+  const dbPath = twitterBookmarksIndexPath();
+  const db = await openDb(dbPath);
+  ensureMigrations(db);
+  try {
+    const rows = db.exec(
+      `SELECT COALESCE(x_folder, '(unfiled)'), COUNT(*) as c FROM bookmarks
+       GROUP BY COALESCE(x_folder, '(unfiled)') ORDER BY c DESC`
     );
     const counts: Record<string, number> = {};
     for (const row of rows[0]?.values ?? []) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -277,6 +277,7 @@ export function buildCli() {
           console.log(`  ${friendlyStopReason(result.stopReason)}`);
           console.log(`  \u2713 Data: ${dataDir()}\n`);
 
+          let folderAdded = 0;
           if (options.folders) {
             process.stderr.write('\n  Syncing bookmark folders...\n');
             const folderResult = await syncFolders({
@@ -288,6 +289,7 @@ export function buildCli() {
               },
             });
             process.stderr.write('\n');
+            folderAdded = folderResult.added;
             if (folderResult.folders.length > 0) {
               console.log(`  \u2713 ${folderResult.folders.length} folders synced`);
               for (const f of folderResult.folders) {
@@ -299,7 +301,7 @@ export function buildCli() {
             }
           }
 
-          const newCount = await rebuildIndex(result.added);
+          const newCount = await rebuildIndex(result.added + folderAdded);
           if (options.classify && newCount > 0) {
             await classifyNew();
           }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -15,9 +15,11 @@ import {
   getCategoryCounts,
   sampleByCategory,
   getDomainCounts,
+  getFolderCounts,
   listBookmarks,
   getBookmarkById,
 } from './bookmarks-db.js';
+import { syncFolders } from './graphql-bookmark-folders.js';
 import { formatClassificationSummary } from './bookmark-classify.js';
 import { classifyWithLlm, classifyDomainsWithLlm } from './bookmark-classify-llm.js';
 import { renderViz } from './bookmarks-viz.js';
@@ -235,6 +237,7 @@ export function buildCli() {
     .option('--max-minutes <n>', 'Max runtime in minutes', (v: string) => Number(v), 30)
     .option('--chrome-user-data-dir <path>', 'Chrome user-data directory')
     .option('--chrome-profile-directory <name>', 'Chrome profile name')
+    .option('--folders', 'Also sync bookmark folder assignments', false)
     .action(async (options) => {
       const firstRun = isFirstRun();
       if (firstRun) showSyncWelcome();
@@ -273,6 +276,28 @@ export function buildCli() {
           console.log(`\n  \u2713 ${result.added} new bookmarks synced (${result.totalBookmarks} total)`);
           console.log(`  ${friendlyStopReason(result.stopReason)}`);
           console.log(`  \u2713 Data: ${dataDir()}\n`);
+
+          if (options.folders) {
+            process.stderr.write('\n  Syncing bookmark folders...\n');
+            const folderResult = await syncFolders({
+              chromeUserDataDir: options.chromeUserDataDir ? String(options.chromeUserDataDir) : undefined,
+              chromeProfileDirectory: options.chromeProfileDirectory ? String(options.chromeProfileDirectory) : undefined,
+              delayMs: Number(options.delayMs) || 600,
+              onProgress: (status) => {
+                process.stderr.write(`\r\x1b[K  ${status.folder}: page ${status.page}, ${status.added} new`);
+              },
+            });
+            process.stderr.write('\n');
+            if (folderResult.folders.length > 0) {
+              console.log(`  \u2713 ${folderResult.folders.length} folders synced`);
+              for (const f of folderResult.folders) {
+                const count = folderResult.addedPerFolder[f.name] ?? 0;
+                console.log(`    ${f.name}: ${count} new`);
+              }
+            } else {
+              console.log('  No bookmark folders found.');
+            }
+          }
 
           const newCount = await rebuildIndex(result.added);
           if (options.classify && newCount > 0) {
@@ -525,6 +550,25 @@ export function buildCli() {
       for (const [dom, count] of Object.entries(counts).sort((a, b) => b[1] - a[1])) {
         const pct = ((count / total) * 100).toFixed(1);
         console.log(`  ${dom.padEnd(20)} ${String(count).padStart(5)}  (${pct}%)`);
+      }
+    }));
+
+  // ── folders ─────────────────────────────────────────────────────────────
+
+  program
+    .command('folders')
+    .description('Show bookmark folder distribution')
+    .action(safe(async () => {
+      if (!requireIndex()) return;
+      const counts = await getFolderCounts();
+      if (Object.keys(counts).length === 0) {
+        console.log('  No folder data. Run: ft sync --folders');
+        return;
+      }
+      const total = Object.values(counts).reduce((a, b) => a + b, 0);
+      for (const [folder, count] of Object.entries(counts).sort((a, b) => b[1] - a[1])) {
+        const pct = ((count / total) * 100).toFixed(1);
+        console.log(`  ${folder.padEnd(20)} ${String(count).padStart(5)}  (${pct}%)`);
       }
     }));
 

--- a/src/graphql-bookmark-folders.ts
+++ b/src/graphql-bookmark-folders.ts
@@ -1,0 +1,249 @@
+import { ensureDataDir, twitterBookmarksCachePath } from './paths.js';
+import { readJsonLines, writeJsonLines } from './fs.js';
+import { loadChromeSessionConfig } from './config.js';
+import { extractChromeXCookies } from './chrome-cookies.js';
+import { convertTweetToRecord, mergeRecords, buildHeaders, GRAPHQL_FEATURES } from './graphql-bookmarks.js';
+import type { BookmarkFolder, BookmarkRecord } from './types.js';
+
+// Query IDs — sniff from X web client, override via env vars
+const FOLDERS_LIST_QUERY_ID = process.env.FT_FOLDERS_QUERY_ID ?? 'i78YDd0Tza-dV4SYs58kRg';
+const FOLDERS_LIST_OPERATION = 'BookmarkFoldersSlice';
+
+const FOLDER_TIMELINE_QUERY_ID = process.env.FT_FOLDER_TIMELINE_QUERY_ID ?? '13H7EUATwethsj-XxX5ohw';
+const FOLDER_TIMELINE_OPERATION = 'BookmarkFolderTimeline';
+
+export interface FolderSyncOptions {
+  chromeUserDataDir?: string;
+  chromeProfileDirectory?: string;
+  csrfToken?: string;
+  cookieHeader?: string;
+  delayMs?: number;
+  maxPagesPerFolder?: number;
+  onProgress?: (status: { folder: string; page: number; added: number }) => void;
+}
+
+export interface FolderSyncResult {
+  folders: BookmarkFolder[];
+  addedPerFolder: Record<string, number>;
+  added: number;
+  totalBookmarks: number;
+}
+
+// --- Folder list ---
+
+function buildFolderListUrl(): string {
+  const params = new URLSearchParams({
+    variables: JSON.stringify({}),
+    features: JSON.stringify(GRAPHQL_FEATURES),
+  });
+  return `https://x.com/i/api/graphql/${FOLDERS_LIST_QUERY_ID}/${FOLDERS_LIST_OPERATION}?${params}`;
+}
+
+export async function fetchFolderList(
+  csrfToken: string,
+  cookieHeader?: string,
+): Promise<BookmarkFolder[]> {
+  const response = await fetch(buildFolderListUrl(), {
+    headers: buildHeaders(csrfToken, cookieHeader),
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(
+      `BookmarkFolders API returned ${response.status}.\n` +
+        `Response: ${text.slice(0, 300)}\n\n` +
+        (response.status === 401 || response.status === 403
+          ? 'Your X session may have expired. Open Chrome, go to https://x.com, and make sure you are logged in.'
+          : 'This may be a temporary issue. Try again in a few minutes.'),
+    );
+  }
+
+  const json = await response.json();
+
+  // Response shape: data.viewer.user_results.result.bookmark_collections_slice.items[]
+  const items =
+    json?.data?.viewer?.user_results?.result?.bookmark_collections_slice?.items ??
+    json?.data?.viewer?.bookmark_collections_slice?.items ??
+    json?.data?.bookmark_collections_slice?.items ??
+    [];
+
+  return items.map((item: any) => ({
+    id: item.id ?? item.rest_id,
+    name: item.name,
+  }));
+}
+
+// --- Folder bookmark timeline ---
+
+function buildFolderTimelineUrl(folderId: string, cursor?: string): string {
+  const variables: Record<string, unknown> = {
+    bookmark_collection_id: folderId,
+    count: 20,
+  };
+  if (cursor) variables.cursor = cursor;
+
+  const params = new URLSearchParams({
+    variables: JSON.stringify(variables),
+    features: JSON.stringify(GRAPHQL_FEATURES),
+  });
+  return `https://x.com/i/api/graphql/${FOLDER_TIMELINE_QUERY_ID}/${FOLDER_TIMELINE_OPERATION}?${params}`;
+}
+
+interface FolderPageResult {
+  records: BookmarkRecord[];
+  nextCursor?: string;
+}
+
+function parseFolderTimelineResponse(json: any, folderName: string, folderId: string): FolderPageResult {
+  const now = new Date().toISOString();
+
+  // Response shape mirrors regular bookmarks but under bookmark_folder_timeline
+  const instructions =
+    json?.data?.bookmark_folder_timeline?.timeline?.instructions ??
+    json?.data?.bookmark_collection_timeline?.timeline?.instructions ??
+    [];
+
+  const entries: any[] = [];
+  for (const inst of instructions) {
+    if (inst.type === 'TimelineAddEntries' && Array.isArray(inst.entries)) {
+      entries.push(...inst.entries);
+    }
+  }
+
+  const records: BookmarkRecord[] = [];
+  let nextCursor: string | undefined;
+
+  for (const entry of entries) {
+    if (entry.entryId?.startsWith('cursor-bottom')) {
+      nextCursor = entry.content?.value;
+      continue;
+    }
+
+    const tweetResult = entry?.content?.itemContent?.tweet_results?.result;
+    if (!tweetResult) continue;
+
+    const record = convertTweetToRecord(tweetResult, now);
+    if (record) {
+      record.xFolder = folderName;
+      record.xFolderId = folderId;
+      records.push(record);
+    }
+  }
+
+  return { records, nextCursor };
+}
+
+async function fetchFolderPage(
+  csrfToken: string,
+  folderId: string,
+  folderName: string,
+  cursor?: string,
+  cookieHeader?: string,
+): Promise<FolderPageResult> {
+  let lastError: Error | undefined;
+
+  for (let attempt = 0; attempt < 4; attempt++) {
+    const response = await fetch(buildFolderTimelineUrl(folderId, cursor), {
+      headers: buildHeaders(csrfToken, cookieHeader),
+    });
+
+    if (response.status === 429) {
+      const waitSec = Math.min(15 * Math.pow(2, attempt), 120);
+      lastError = new Error(`Rate limited (429) on attempt ${attempt + 1}`);
+      await new Promise((r) => setTimeout(r, waitSec * 1000));
+      continue;
+    }
+
+    if (response.status >= 500) {
+      lastError = new Error(`Server error (${response.status}) on attempt ${attempt + 1}`);
+      await new Promise((r) => setTimeout(r, 5000 * (attempt + 1)));
+      continue;
+    }
+
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(
+        `BookmarkFolderTimeline API returned ${response.status}.\n` +
+          `Response: ${text.slice(0, 300)}`,
+      );
+    }
+
+    const json = await response.json();
+    return parseFolderTimelineResponse(json, folderName, folderId);
+  }
+
+  throw lastError ?? new Error('BookmarkFolderTimeline: all retry attempts failed.');
+}
+
+// --- Orchestrator ---
+
+export async function syncFolders(options: FolderSyncOptions = {}): Promise<FolderSyncResult> {
+  const delayMs = options.delayMs ?? 600;
+  const maxPagesPerFolder = options.maxPagesPerFolder ?? 100;
+
+  let csrfToken: string;
+  let cookieHeader: string | undefined;
+
+  if (options.csrfToken) {
+    csrfToken = options.csrfToken;
+    cookieHeader = options.cookieHeader;
+  } else {
+    const chromeConfig = loadChromeSessionConfig();
+    const chromeDir = options.chromeUserDataDir ?? chromeConfig.chromeUserDataDir;
+    const chromeProfile = options.chromeProfileDirectory ?? chromeConfig.chromeProfileDirectory;
+    const cookies = extractChromeXCookies(chromeDir, chromeProfile);
+    csrfToken = cookies.csrfToken;
+    cookieHeader = cookies.cookieHeader;
+  }
+
+  ensureDataDir();
+  const cachePath = twitterBookmarksCachePath();
+  let existing = await readJsonLines<BookmarkRecord>(cachePath);
+
+  // Step 1: Fetch folder list
+  const folders = await fetchFolderList(csrfToken, cookieHeader);
+
+  if (folders.length === 0) {
+    return { folders: [], addedPerFolder: {}, added: 0, totalBookmarks: existing.length };
+  }
+
+  const addedPerFolder: Record<string, number> = {};
+  let totalAdded = 0;
+
+  // Step 2: Fetch each folder's bookmarks
+  for (const folder of folders) {
+    let page = 0;
+    let cursor: string | undefined;
+    let folderAdded = 0;
+
+    while (page < maxPagesPerFolder) {
+      const result = await fetchFolderPage(csrfToken, folder.id, folder.name, cursor, cookieHeader);
+      page++;
+
+      if (result.records.length === 0 && !result.nextCursor) break;
+
+      const { merged, added } = mergeRecords(existing, result.records);
+      existing = merged;
+      folderAdded += added;
+
+      options.onProgress?.({ folder: folder.name, page, added: folderAdded });
+
+      if (!result.nextCursor) break;
+      cursor = result.nextCursor;
+      await new Promise((r) => setTimeout(r, delayMs));
+    }
+
+    addedPerFolder[folder.name] = folderAdded;
+    totalAdded += folderAdded;
+  }
+
+  // Write merged results
+  await writeJsonLines(cachePath, existing);
+
+  return {
+    folders,
+    addedPerFolder,
+    added: totalAdded,
+    totalBookmarks: existing.length,
+  };
+}

--- a/src/graphql-bookmarks.ts
+++ b/src/graphql-bookmarks.ts
@@ -5,13 +5,13 @@ import { extractChromeXCookies } from './chrome-cookies.js';
 import type { BookmarkBackfillState, BookmarkRecord } from './types.js';
 import { exportBookmarksForSyncSeed } from './bookmarks-db.js';
 
-const X_PUBLIC_BEARER =
+export const X_PUBLIC_BEARER =
   'AAAAAAAAAAAAAAAAAAAAANRILgAAAAAAnNwIzUejRCOuH5E6I8xnZz4puTs%3D1Zv7ttfk8LF81IUq16cHjhLTvJu4FA33AGWWjCpTnA';
 
 const BOOKMARKS_QUERY_ID = 'Z9GWmP0kP2dajyckAaDUBw';
 const BOOKMARKS_OPERATION = 'Bookmarks';
 
-const GRAPHQL_FEATURES = {
+export const GRAPHQL_FEATURES = {
   graphql_timeline_v2_bookmark_timeline: true,
   rweb_tipjar_consumption_enabled: true,
   responsive_web_graphql_exclude_directive_enabled: true,
@@ -139,7 +139,7 @@ function buildUrl(cursor?: string): string {
   return `https://x.com/i/api/graphql/${BOOKMARKS_QUERY_ID}/${BOOKMARKS_OPERATION}?${params}`;
 }
 
-function buildHeaders(csrfToken: string, cookieHeader?: string): Record<string, string> {
+export function buildHeaders(csrfToken: string, cookieHeader?: string): Record<string, string> {
   return {
     authorization: `Bearer ${X_PUBLIC_BEARER}`,
     'x-csrf-token': csrfToken,
@@ -327,9 +327,13 @@ export function scoreRecord(record: BookmarkRecord): number {
 
 export function mergeBookmarkRecord(existing: BookmarkRecord | undefined, incoming: BookmarkRecord): BookmarkRecord {
   if (!existing) return incoming;
-  return scoreRecord(incoming) >= scoreRecord(existing)
+  const merged = scoreRecord(incoming) >= scoreRecord(existing)
     ? { ...existing, ...incoming }
     : { ...incoming, ...existing };
+  // Preserve folder info from whichever side has it
+  merged.xFolder = incoming.xFolder ?? existing.xFolder;
+  merged.xFolderId = incoming.xFolderId ?? existing.xFolderId;
+  return merged;
 }
 
 export function mergeRecords(

--- a/src/types.ts
+++ b/src/types.ts
@@ -36,6 +36,11 @@ export interface BookmarkEngagementSnapshot {
   viewCount?: number;
 }
 
+export interface BookmarkFolder {
+  id: string;
+  name: string;
+}
+
 export interface BookmarkRecord {
   id: string;
   tweetId: string;
@@ -61,6 +66,8 @@ export interface BookmarkRecord {
   links?: string[];
   tags?: string[];
   ingestedVia?: 'api' | 'browser' | 'graphql';
+  xFolder?: string;
+  xFolderId?: string;
 }
 
 export interface BookmarkCacheMeta {


### PR DESCRIPTION
## Summary

- Add support for syncing X's native bookmark folder assignments (health, philosophy, predictions, etc.)
- New `ft sync --folders` flag fetches folder list via `BookmarkFoldersSlice` then each folder's bookmarks via `BookmarkFolderTimeline`, tagging records with `xFolder`/`xFolderId`
- New `ft folders` command shows folder distribution from the SQLite index
- Schema v3 → v4 migration adds `x_folder` and `x_folder_id` columns
- Query IDs configurable via `FT_FOLDERS_QUERY_ID` and `FT_FOLDER_TIMELINE_QUERY_ID` env vars
- Shared constants (`X_PUBLIC_BEARER`, `GRAPHQL_FEATURES`, `buildHeaders`) exported from `graphql-bookmarks.ts` to avoid duplication

## Usage

```bash
ft sync --folders --chrome-profile-directory "Profile 1"
ft folders
```

## Test plan

- [ ] Run `ft sync --folders` and verify JSONL contains `xFolder` fields
- [ ] Run `ft index --force && ft folders` and verify folder distribution
- [ ] Run `ft list --json` and verify `xFolder` appears in results
- [ ] Verify `ft sync` without `--folders` still works unchanged
- [ ] Verify schema migration from v3 DB works (don't use `--force`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new GraphQL-based syncing paths and a DB schema migration (v4) to persist folder metadata, which could affect sync reliability and existing SQLite indexes on upgrade.
> 
> **Overview**
> Adds support for syncing X bookmark folder assignments: `ft sync --folders` fetches folder lists and per-folder bookmark timelines via new GraphQL calls, then merges `xFolder`/`xFolderId` into the local JSONL cache.
> 
> Extends the SQLite index schema from v3 → v4 by adding `x_folder`/`x_folder_id` columns (with migration + index), includes `x_folder` in list/show queries, and introduces `ft folders` plus `getFolderCounts()` to view folder distribution.
> 
> Exports shared GraphQL constants/helpers (`X_PUBLIC_BEARER`, `GRAPHQL_FEATURES`, `buildHeaders`) for reuse, and updates `package-lock.json` metadata (rename/version) while dropping `zod` from locked deps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit acd00d0c7a2effe3ff7527be6d966b69cc85ef38. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->