### PR TITLE
feat: Article enrichment for link-heavy bookmarks (+ X Article support via GraphQL)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,18 @@
 {
-  "name": "ft-bookmarks",
+  "name": "fieldtheory",
   "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "ft-bookmarks",
+      "name": "fieldtheory",
       "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
         "commander": "^14.0.3",
         "dotenv": "^17.3.1",
         "sql.js": "^1.14.1",
-        "sql.js-fts5": "^1.4.0",
-        "zod": "^4.3.6"
+        "sql.js-fts5": "^1.4.0"
       },
       "bin": {
         "ft": "bin/ft.mjs"
@@ -651,15 +650,6 @@
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/zod": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,19 @@
 {
-  "name": "fieldtheory",
+  "name": "ft-bookmarks",
   "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "fieldtheory",
+      "name": "ft-bookmarks",
       "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
         "commander": "^14.0.3",
         "dotenv": "^17.3.1",
         "sql.js": "^1.14.1",
-        "sql.js-fts5": "^1.4.0"
+        "sql.js-fts5": "^1.4.0",
+        "zod": "^4.3.6"
       },
       "bin": {
         "ft": "bin/ft.mjs"
@@ -650,6 +651,15 @@
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
     }
   }
 }

--- a/src/bookmark-enrich.ts
+++ b/src/bookmark-enrich.ts
@@ -1,0 +1,538 @@
+/**
+ * Article enrichment pipeline for bookmarks.
+ *
+ * Many bookmarks are "link-only" tweets — just a URL with little or no text.
+ * This module fetches the linked article/page content and stores it alongside
+ * the bookmark so it becomes searchable via FTS5.
+ *
+ * Strategies (tried in order):
+ *   1. HTML fetch → extract <article>, <main>, or body text
+ *   2. JSON-LD structured data (common on blogs)
+ *   3. OpenGraph / meta description fallback
+ */
+
+import { openDb, saveDb } from './db.js';
+import { twitterBookmarksIndexPath } from './paths.js';
+import { loadChromeSessionConfig } from './config.js';
+import { extractChromeXCookies } from './chrome-cookies.js';
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+export interface ArticleContent {
+  title: string;
+  text: string;
+  siteName?: string;
+}
+
+export interface EnrichResult {
+  enriched: number;
+  skipped: number;
+  failed: number;
+  total: number;
+  warnings: string[];
+}
+
+export interface EnrichOptions {
+  limit?: number;
+  force?: boolean;
+  chromeUserDataDir?: string;
+  chromeProfileDirectory?: string;
+  onProgress?: (done: number, total: number, msg?: string) => void;
+}
+
+// ── HTML helpers ───────────────────────────────────────────────────────────
+
+function decodeEntities(text: string): string {
+  return text
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#0?39;/g, "'")
+    .replace(/&#x27;/g, "'")
+    .replace(/&#x2F;/g, '/')
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&#(\d+);/g, (_, n) => String.fromCharCode(parseInt(n)));
+}
+
+function stripHtml(html: string): string {
+  return decodeEntities(html.replace(/<[^>]+>/g, ' ')).replace(/\s+/g, ' ').trim();
+}
+
+// ── Article extraction ─────────────────────────────────────────────────────
+
+export function extractReadableText(html: string): ArticleContent | null {
+  // Extract metadata
+  const ogTitle = html.match(/<meta\s+(?:property|name)="og:title"\s+content="([^"]*)"[^>]*>/i);
+  const htmlTitle = html.match(/<title[^>]*>([\s\S]*?)<\/title>/i);
+  const title = stripHtml(ogTitle?.[1] ?? htmlTitle?.[1] ?? '');
+
+  const siteMatch = html.match(/<meta\s+(?:property|name)="og:site_name"\s+content="([^"]*)"[^>]*>/i);
+  const siteName = siteMatch ? decodeEntities(siteMatch[1]) : undefined;
+
+  // Remove unwanted blocks before extraction
+  let cleaned = html
+    .replace(/<script[\s\S]*?<\/script>/gi, '')
+    .replace(/<style[\s\S]*?<\/style>/gi, '')
+    .replace(/<nav[\s\S]*?<\/nav>/gi, '')
+    .replace(/<footer[\s\S]*?<\/footer>/gi, '')
+    .replace(/<header[\s\S]*?<\/header>/gi, '')
+    .replace(/<aside[\s\S]*?<\/aside>/gi, '')
+    .replace(/<!--[\s\S]*?-->/g, '');
+
+  // Try content selectors in order of specificity
+  let text = '';
+  const articleMatch = cleaned.match(/<article[^>]*>([\s\S]*?)<\/article>/i);
+  const mainMatch = cleaned.match(/<main[^>]*>([\s\S]*?)<\/main>/i);
+
+  if (articleMatch) text = stripHtml(articleMatch[1]);
+  else if (mainMatch) text = stripHtml(mainMatch[1]);
+  else text = stripHtml(cleaned);
+
+  // If too short, try meta description as fallback
+  if (text.length < 100) {
+    const ogDesc = html.match(/<meta\s+(?:property|name)="(?:og:)?description"\s+content="([^"]*)"[^>]*>/i);
+    if (ogDesc && ogDesc[1].length > text.length) {
+      text = stripHtml(ogDesc[1]);
+    }
+  }
+
+  // Also check for JSON-LD structured data (common on blogs)
+  if (text.length < 100) {
+    const jsonLd = html.match(/<script[^>]*type="application\/ld\+json"[^>]*>([\s\S]*?)<\/script>/i);
+    if (jsonLd) {
+      try {
+        const data = JSON.parse(jsonLd[1]);
+        const body = data.articleBody ?? data.text ?? data.description ?? '';
+        if (body.length > text.length) text = body;
+      } catch {
+        // Invalid JSON-LD, skip
+      }
+    }
+  }
+
+  if (text.length < 50) return null;
+
+  // Cap at reasonable length for storage
+  if (text.length > 15000) text = text.slice(0, 15000) + '...';
+
+  return { title, text, siteName };
+}
+
+// ── X Article fetch via GraphQL ────────────────────────────────────────────
+
+const X_PUBLIC_BEARER =
+  'AAAAAAAAAAAAAAAAAAAAANRILgAAAAAAnNwIzUejRCOuH5E6I8xnZz4puTs%3D1Zv7ttfk8LF81IUq16cHjhLTvJu4FA33AGWWjCpTnA';
+const TWEET_DETAIL_QUERY_ID = 'nBS-WpgA6ZG0CyNHD517JQ';
+
+interface XSessionCookies {
+  csrfToken: string;
+  cookieHeader: string;
+}
+
+interface XCookieResolution {
+  cookies: XSessionCookies | null;
+  error: string | null;
+}
+
+let cachedCookieKey: string | null = null;
+let cachedCookieResolution: XCookieResolution | null = null;
+
+function formatXCookieErrorMessage(message: string): string {
+  if (message.includes('ft sync --chrome-profile-directory')) {
+    return `${message}\nYou can pass the same Chrome flags to ft enrich as well.`;
+  }
+  if (message.includes('--chrome-profile-directory')) {
+    return `${message}\nThis command also accepts --chrome-user-data-dir and --chrome-profile-directory.`;
+  }
+  return `${message}\nIf your X session is in a non-default Chrome profile, pass --chrome-profile-directory to ft enrich.`;
+}
+
+function summarizeProgressMessage(message: string): string {
+  return message.split('\n')[0]?.trim() || 'Could not load X session cookies.';
+}
+
+function getXCookies(options: Pick<EnrichOptions, 'chromeUserDataDir' | 'chromeProfileDirectory'> = {}): XCookieResolution {
+  try {
+    const config = loadChromeSessionConfig();
+    const chromeUserDataDir = options.chromeUserDataDir ?? config.chromeUserDataDir;
+    const chromeProfileDirectory = options.chromeProfileDirectory ?? config.chromeProfileDirectory ?? 'Default';
+    const cacheKey = `${chromeUserDataDir}::${chromeProfileDirectory}`;
+    if (cachedCookieKey === cacheKey && cachedCookieResolution) return cachedCookieResolution;
+    const cookies = extractChromeXCookies(chromeUserDataDir, chromeProfileDirectory);
+    cachedCookieKey = cacheKey;
+    cachedCookieResolution = { cookies, error: null };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    cachedCookieKey = null;
+    cachedCookieResolution = {
+      cookies: null,
+      error: formatXCookieErrorMessage(message),
+    };
+  }
+  return cachedCookieResolution;
+}
+
+/**
+ * Fetch an X Article's content via the TweetDetail GraphQL API.
+ * Uses the tweet ID that contains the article link.
+ */
+async function fetchXArticleByTweetId(
+  tweetId: string,
+  cookies: XSessionCookies,
+): Promise<ArticleContent | null> {
+  const variables = JSON.stringify({
+    focalTweetId: tweetId,
+    with_rux_injections: false,
+    rankingMode: 'Relevance',
+    includePromotedContent: false,
+    withCommunity: false,
+    withQuickPromoteEligibilityTweetFields: false,
+    withBirdwatchNotes: false,
+    withVoice: false,
+  });
+  const features = JSON.stringify({
+    articles_preview_enabled: true,
+    responsive_web_twitter_article_tweet_consumption_enabled: true,
+    creator_subscriptions_tweet_preview_api_enabled: true,
+    responsive_web_graphql_exclude_directive_enabled: true,
+    verified_phone_label_enabled: false,
+    responsive_web_graphql_timeline_navigation_enabled: true,
+    responsive_web_graphql_skip_user_profile_image_extensions_enabled: false,
+    tweetypie_unmention_optimization_enabled: true,
+    responsive_web_edit_tweet_api_enabled: true,
+    graphql_is_translatable_rweb_tweet_is_translatable_enabled: true,
+    view_counts_everywhere_api_enabled: true,
+    longform_notetweets_consumption_enabled: true,
+    tweet_awards_web_tipping_enabled: false,
+    freedom_of_speech_not_reach_fetch_enabled: true,
+    standardized_nudges_misinfo: true,
+    tweet_with_visibility_results_prefer_gql_limited_actions_policy_enabled: true,
+    longform_notetweets_rich_text_read_enabled: true,
+    longform_notetweets_inline_media_enabled: true,
+    responsive_web_enhance_cards_enabled: false,
+  });
+
+  const url = `https://x.com/i/api/graphql/${TWEET_DETAIL_QUERY_ID}/TweetDetail?variables=${encodeURIComponent(variables)}&features=${encodeURIComponent(features)}`;
+
+  try {
+    const res = await fetch(url, {
+      headers: {
+        Authorization: `Bearer ${X_PUBLIC_BEARER}`,
+        'X-Csrf-Token': cookies.csrfToken,
+        Cookie: cookies.cookieHeader,
+        'X-Twitter-Auth-Type': 'OAuth2Session',
+        'X-Twitter-Active-User': 'yes',
+        'User-Agent':
+          'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+      },
+      signal: AbortSignal.timeout(15000),
+    });
+
+    if (!res.ok) return null;
+    const data: any = await res.json();
+
+    // Navigate the response to find the article
+    const instructions =
+      data?.data?.threaded_conversation_with_injections_v2?.instructions ?? [];
+    for (const inst of instructions) {
+      for (const entry of inst.entries ?? []) {
+        const result = entry?.content?.itemContent?.tweet_results?.result;
+        if (!result) continue;
+        const tweet =
+          result.__typename === 'TweetWithVisibilityResults' ? result.tweet : result;
+        if (tweet?.rest_id !== tweetId) continue;
+
+        const article = tweet.article?.article_results?.result;
+        if (!article) continue;
+
+        const title = article.title ?? '';
+        const previewText = article.preview_text ?? '';
+        if (!title && !previewText) continue;
+
+        return {
+          title,
+          text: previewText,
+          siteName: 'X Article',
+        };
+      }
+    }
+  } catch {
+    // API call failed
+  }
+  return null;
+}
+
+// ── Regular article fetch ──────────────────────────────────────────────────
+
+/** Fetch a URL and extract article content. */
+export async function fetchArticle(url: string): Promise<ArticleContent | null> {
+  // Skip non-article X/Twitter URLs (profiles, timelines, etc.)
+  // X Article URLs are handled separately via fetchXArticleByTweetId
+  if (/x\.com|twitter\.com/i.test(url)) return null;
+
+  const headers: Record<string, string> = {
+    'User-Agent':
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+    Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+    'Accept-Language': 'en-US,en;q=0.9',
+  };
+
+  try {
+    const res = await fetch(url, {
+      headers,
+      redirect: 'follow',
+      signal: AbortSignal.timeout(15000),
+    });
+
+    if (!res.ok) return null;
+
+    const contentType = res.headers.get('content-type') ?? '';
+    if (!contentType.includes('text/html') && !contentType.includes('application/xhtml')) {
+      return null;
+    }
+
+    const html = await res.text();
+    return extractReadableText(html);
+  } catch {
+    return null;
+  }
+}
+
+// ── DB helpers ─────────────────────────────────────────────────────────────
+
+/**
+ * Determine if a bookmark is "link-only" — a tweet that's mostly just URLs
+ * with little original text. These benefit most from enrichment.
+ */
+function isLinkOnly(text: string, linkCount: number): boolean {
+  if (linkCount === 0) return false;
+
+  // Strip URLs from text and see what's left
+  const withoutUrls = text.replace(/https?:\/\/\S+/g, '').trim();
+  return withoutUrls.length < 80;
+}
+
+/**
+ * Extract enrichable URLs from the bookmark's links array.
+ * Filters out t.co shortlinks (usually media refs).
+ * X Article URLs are kept (handled via GraphQL), other x.com URLs are dropped.
+ */
+function extractEnrichableUrls(linksJson: string | null): string[] {
+  if (!linksJson) return [];
+  try {
+    const links: string[] = JSON.parse(linksJson);
+    return links.filter((u) => {
+      if (u.includes('t.co/')) return false;
+      // Keep X Article URLs — they're enrichable via GraphQL
+      if (/x\.com\/i\/article\/\d+/i.test(u)) return true;
+      // Drop other x.com/twitter.com URLs (profiles, timelines, etc.)
+      if (/x\.com|twitter\.com/i.test(u)) return false;
+      return true;
+    });
+  } catch {
+    return [];
+  }
+}
+
+/** Check if a URL is an X Article. */
+function isXArticleUrl(url: string): boolean {
+  return /x\.com\/i\/article\/\d+/i.test(url);
+}
+
+// ── Schema migration ───────────────────────────────────────────────────────
+
+export function ensureEnrichColumns(dbPath: string): void {
+  // This is called lazily — the main schema migration in bookmarks-db.ts
+  // handles schema_version bumps. Here we just add columns if missing.
+  // Safe to call multiple times.
+}
+
+// ── Main pipeline ──────────────────────────────────────────────────────────
+
+export async function enrichBookmarks(options: EnrichOptions = {}): Promise<EnrichResult> {
+  const dbPath = twitterBookmarksIndexPath();
+  const db = await openDb(dbPath);
+  const limit = options.limit ?? 50;
+
+  try {
+    // Ensure enrichment columns exist
+    try { db.run('ALTER TABLE bookmarks ADD COLUMN article_title TEXT'); } catch { /* exists */ }
+    try { db.run('ALTER TABLE bookmarks ADD COLUMN article_text TEXT'); } catch { /* exists */ }
+    try { db.run('ALTER TABLE bookmarks ADD COLUMN article_site TEXT'); } catch { /* exists */ }
+    try { db.run('ALTER TABLE bookmarks ADD COLUMN enriched_at TEXT'); } catch { /* exists */ }
+
+    // Find bookmarks that need enrichment
+    const whereClause = options.force
+      ? 'WHERE b.link_count > 0'
+      : 'WHERE b.enriched_at IS NULL AND b.link_count > 0';
+
+    const rows = db.exec(
+      `SELECT b.id, b.text, b.links_json, b.link_count, b.author_handle
+       FROM bookmarks b
+       ${whereClause}
+       ORDER BY COALESCE(b.posted_at, b.bookmarked_at) DESC
+       LIMIT ?`,
+      [limit]
+    );
+
+    if (!rows.length || !rows[0].values.length) {
+      return { enriched: 0, skipped: 0, failed: 0, total: 0, warnings: [] };
+    }
+
+    const bookmarks = rows[0].values.map((r) => ({
+      id: r[0] as string,
+      text: r[1] as string,
+      linksJson: r[2] as string | null,
+      linkCount: Number(r[3] ?? 0),
+      authorHandle: r[4] as string | null,
+    }));
+
+    let enriched = 0;
+    let skipped = 0;
+    let failed = 0;
+    const total = bookmarks.length;
+    const warnings: string[] = [];
+    const warningSet = new Set<string>();
+
+    const UPDATE_SQL = `UPDATE bookmarks SET article_title = ?, article_text = ?, article_site = ?, enriched_at = ? WHERE id = ?`;
+
+    const recordWarning = (message: string): boolean => {
+      if (warningSet.has(message)) return false;
+      warningSet.add(message);
+      warnings.push(message);
+      return true;
+    };
+
+    for (let i = 0; i < bookmarks.length; i++) {
+      const bm = bookmarks[i];
+
+      try {
+        const urls = extractEnrichableUrls(bm.linksJson);
+
+        // Skip bookmarks with no enrichable URLs
+        if (urls.length === 0) {
+          db.run(UPDATE_SQL, [null, null, null, new Date().toISOString(), bm.id]);
+          skipped++;
+          options.onProgress?.(i + 1, total, `No external links: @${bm.authorHandle ?? '?'}`);
+          continue;
+        }
+
+        // Only fetch for link-heavy bookmarks or when forced
+        if (!options.force && !isLinkOnly(bm.text, bm.linkCount)) {
+          db.run(UPDATE_SQL, [null, null, null, new Date().toISOString(), bm.id]);
+          skipped++;
+          options.onProgress?.(i + 1, total, `Has enough text: @${bm.authorHandle ?? '?'}`);
+          continue;
+        }
+
+        // Try each URL until we get content
+        let article: ArticleContent | null = null;
+        for (const url of urls) {
+          // X Articles need the GraphQL API — regular fetch won't work
+          if (isXArticleUrl(url)) {
+            const cookieResolution = getXCookies({
+              chromeUserDataDir: options.chromeUserDataDir,
+              chromeProfileDirectory: options.chromeProfileDirectory,
+            });
+            if (cookieResolution.cookies) {
+              options.onProgress?.(i + 1, total, `X Article via API: @${bm.authorHandle ?? '?'}...`);
+              article = await fetchXArticleByTweetId(bm.id, cookieResolution.cookies);
+              if (article && article.text.length > 0) break;
+              article = null;
+            } else if (cookieResolution.error) {
+              const isNewWarning = recordWarning(cookieResolution.error);
+              const prefix = isNewWarning ? 'X Article auth unavailable' : 'Skipping X Article';
+              options.onProgress?.(
+                i + 1,
+                total,
+                `${prefix}: ${summarizeProgressMessage(cookieResolution.error)}`
+              );
+            }
+            continue;
+          }
+
+          options.onProgress?.(i + 1, total, `Fetching ${url.slice(0, 60)}...`);
+          article = await fetchArticle(url);
+          if (article && article.text.length >= 100) break;
+          article = null;
+        }
+
+        if (article) {
+          db.run(UPDATE_SQL, [
+            article.title || null,
+            article.text,
+            article.siteName || null,
+            new Date().toISOString(),
+            bm.id,
+          ]);
+          enriched++;
+          options.onProgress?.(i + 1, total, `Enriched: ${article.title?.slice(0, 50) || urls[0].slice(0, 50)} (${article.text.length} chars)`);
+        } else {
+          db.run(UPDATE_SQL, [null, null, null, new Date().toISOString(), bm.id]);
+          failed++;
+          options.onProgress?.(i + 1, total, `No content found: @${bm.authorHandle ?? '?'}`);
+        }
+
+        // Rate limit between fetches
+        await new Promise((r) => setTimeout(r, 500));
+      } catch (err) {
+        // Don't let one bookmark crash the whole pipeline
+        db.run(UPDATE_SQL, [null, null, null, new Date().toISOString(), bm.id]);
+        failed++;
+        const msg = err instanceof Error ? err.message : String(err);
+        options.onProgress?.(i + 1, total, `Error: ${msg.slice(0, 60)}`);
+      }
+
+      // Save every 10 bookmarks for crash durability
+      if ((i + 1) % 10 === 0) {
+        saveDb(db, dbPath);
+      }
+    }
+
+    // Rebuild FTS index so enriched text becomes searchable
+    if (enriched > 0) {
+      // Add article_text to the FTS index by rebuilding
+      // The FTS table uses content=bookmarks, so we just rebuild
+      db.run("INSERT INTO bookmarks_fts(bookmarks_fts) VALUES('rebuild')");
+    }
+
+    saveDb(db, dbPath);
+    return { enriched, skipped, failed, total, warnings };
+  } finally {
+    db.close();
+  }
+}
+
+export async function getEnrichmentStats(): Promise<{
+  total: number;
+  enriched: number;
+  pending: number;
+  withArticles: number;
+}> {
+  const dbPath = twitterBookmarksIndexPath();
+  const db = await openDb(dbPath);
+
+  try {
+    // Check if enrichment columns exist
+    const cols = db.exec("PRAGMA table_info(bookmarks)");
+    const colNames = new Set((cols[0]?.values ?? []).map((r) => r[1] as string));
+    if (!colNames.has('enriched_at')) {
+      const total = Number(db.exec('SELECT COUNT(*) FROM bookmarks')[0]?.values[0]?.[0] ?? 0);
+      return { total, enriched: 0, pending: total, withArticles: 0 };
+    }
+
+    const total = Number(db.exec('SELECT COUNT(*) FROM bookmarks')[0]?.values[0]?.[0] ?? 0);
+    const enriched = Number(db.exec('SELECT COUNT(*) FROM bookmarks WHERE enriched_at IS NOT NULL')[0]?.values[0]?.[0] ?? 0);
+    const withArticles = Number(db.exec('SELECT COUNT(*) FROM bookmarks WHERE article_text IS NOT NULL')[0]?.values[0]?.[0] ?? 0);
+
+    return {
+      total,
+      enriched,
+      pending: total - enriched,
+      withArticles,
+    };
+  } finally {
+    db.close();
+  }
+}

--- a/src/bookmark-enrich.ts
+++ b/src/bookmark-enrich.ts
@@ -15,6 +15,7 @@ import { openDb, saveDb } from './db.js';
 import { twitterBookmarksIndexPath } from './paths.js';
 import { loadChromeSessionConfig } from './config.js';
 import { extractChromeXCookies } from './chrome-cookies.js';
+import { ensureMigrations } from './bookmarks-db.js';
 
 // ── Types ──────────────────────────────────────────────────────────────────
 
@@ -269,7 +270,7 @@ async function fetchXArticleByTweetId(
 export async function fetchArticle(url: string): Promise<ArticleContent | null> {
   // Skip non-article X/Twitter URLs (profiles, timelines, etc.)
   // X Article URLs are handled separately via fetchXArticleByTweetId
-  if (/x\.com|twitter\.com/i.test(url)) return null;
+  if (isTwitterUrl(url)) return null;
 
   const headers: Record<string, string> = {
     'User-Agent':
@@ -299,6 +300,36 @@ export async function fetchArticle(url: string): Promise<ArticleContent | null> 
   }
 }
 
+function parseUrl(url: string): URL | null {
+  try {
+    return new URL(url);
+  } catch {
+    return null;
+  }
+}
+
+function isTwitterHostname(hostname: string): boolean {
+  const normalized = hostname.toLowerCase();
+  return (
+    normalized === 'x.com' ||
+    normalized === 'twitter.com' ||
+    normalized.endsWith('.x.com') ||
+    normalized.endsWith('.twitter.com')
+  );
+}
+
+function isTwitterUrl(url: string): boolean {
+  const parsed = parseUrl(url);
+  return parsed ? isTwitterHostname(parsed.hostname) : false;
+}
+
+function isShortlinkUrl(url: string): boolean {
+  const parsed = parseUrl(url);
+  if (!parsed) return false;
+  const normalized = parsed.hostname.toLowerCase();
+  return normalized === 't.co' || normalized.endsWith('.t.co');
+}
+
 // ── DB helpers ─────────────────────────────────────────────────────────────
 
 /**
@@ -318,16 +349,16 @@ function isLinkOnly(text: string, linkCount: number): boolean {
  * Filters out t.co shortlinks (usually media refs).
  * X Article URLs are kept (handled via GraphQL), other x.com URLs are dropped.
  */
-function extractEnrichableUrls(linksJson: string | null): string[] {
+export function extractEnrichableUrls(linksJson: string | null): string[] {
   if (!linksJson) return [];
   try {
     const links: string[] = JSON.parse(linksJson);
     return links.filter((u) => {
-      if (u.includes('t.co/')) return false;
+      if (isShortlinkUrl(u)) return false;
       // Keep X Article URLs — they're enrichable via GraphQL
-      if (/x\.com\/i\/article\/\d+/i.test(u)) return true;
+      if (isXArticleUrl(u)) return true;
       // Drop other x.com/twitter.com URLs (profiles, timelines, etc.)
-      if (/x\.com|twitter\.com/i.test(u)) return false;
+      if (isTwitterUrl(u)) return false;
       return true;
     });
   } catch {
@@ -337,15 +368,9 @@ function extractEnrichableUrls(linksJson: string | null): string[] {
 
 /** Check if a URL is an X Article. */
 function isXArticleUrl(url: string): boolean {
-  return /x\.com\/i\/article\/\d+/i.test(url);
-}
-
-// ── Schema migration ───────────────────────────────────────────────────────
-
-export function ensureEnrichColumns(dbPath: string): void {
-  // This is called lazily — the main schema migration in bookmarks-db.ts
-  // handles schema_version bumps. Here we just add columns if missing.
-  // Safe to call multiple times.
+  const parsed = parseUrl(url);
+  if (!parsed || !isTwitterHostname(parsed.hostname)) return false;
+  return /^\/i\/article\/\d+\/?$/i.test(parsed.pathname);
 }
 
 // ── Main pipeline ──────────────────────────────────────────────────────────
@@ -356,11 +381,7 @@ export async function enrichBookmarks(options: EnrichOptions = {}): Promise<Enri
   const limit = options.limit ?? 50;
 
   try {
-    // Ensure enrichment columns exist
-    try { db.run('ALTER TABLE bookmarks ADD COLUMN article_title TEXT'); } catch { /* exists */ }
-    try { db.run('ALTER TABLE bookmarks ADD COLUMN article_text TEXT'); } catch { /* exists */ }
-    try { db.run('ALTER TABLE bookmarks ADD COLUMN article_site TEXT'); } catch { /* exists */ }
-    try { db.run('ALTER TABLE bookmarks ADD COLUMN enriched_at TEXT'); } catch { /* exists */ }
+    ensureMigrations(db);
 
     // Find bookmarks that need enrichment
     const whereClause = options.force
@@ -377,6 +398,7 @@ export async function enrichBookmarks(options: EnrichOptions = {}): Promise<Enri
     );
 
     if (!rows.length || !rows[0].values.length) {
+      saveDb(db, dbPath);
       return { enriched: 0, skipped: 0, failed: 0, total: 0, warnings: [] };
     }
 

--- a/src/bookmark-media.ts
+++ b/src/bookmark-media.ts
@@ -79,12 +79,13 @@ export async function fetchBookmarkMediaBatch(
     if (bookmark.mediaObjects?.length) {
       for (const mo of bookmark.mediaObjects) {
         if (mo.type === 'video' || mo.type === 'animated_gif') {
-          const mp4s = (mo.variants ?? [])
-            .filter((v) => v.contentType === 'video/mp4' && v.url)
+          const mp4s = (mo.videoVariants ?? (mo as { variants?: typeof mo.videoVariants }).variants ?? [])
+            .filter((v) => (!v.contentType || v.contentType === 'video/mp4') && v.url)
             .sort((a, b) => (b.bitrate ?? 0) - (a.bitrate ?? 0));
           if (mp4s.length > 0 && mp4s[0].url) { mediaUrls.push(mp4s[0].url); continue; }
         }
-        if (mo.mediaUrl) mediaUrls.push(mo.mediaUrl);
+        const mediaUrl = mo.url ?? (mo as { mediaUrl?: string }).mediaUrl;
+        if (mediaUrl) mediaUrls.push(mediaUrl);
       }
     } else {
       mediaUrls.push(...(bookmark.media ?? []));

--- a/src/bookmarks-db.ts
+++ b/src/bookmarks-db.ts
@@ -234,7 +234,7 @@ function normalizeStoredDates(db: Database): void {
   stmt.free();
 }
 
-function ensureMigrations(db: Database): void {
+export function ensureMigrations(db: Database): void {
   db.run('CREATE TABLE IF NOT EXISTS meta (key TEXT PRIMARY KEY, value TEXT)');
   const tableExists = db.exec("SELECT name FROM sqlite_master WHERE type='table' AND name='bookmarks'");
   if (!tableExists.length || tableExists[0].values.length === 0) {

--- a/src/bookmarks-db.ts
+++ b/src/bookmarks-db.ts
@@ -5,8 +5,9 @@ import { twitterBookmarksCachePath, twitterBookmarksIndexPath } from './paths.js
 import type { BookmarkRecord } from './types.js';
 import { classifyCorpus, formatClassificationSummary } from './bookmark-classify.js';
 import type { ClassificationSummary } from './bookmark-classify.js';
+import { normalizeTimestamp } from './dates.js';
 
-const SCHEMA_VERSION = 3;
+const SCHEMA_VERSION = 5;
 
 export interface SearchResult {
   id: string;
@@ -127,11 +128,11 @@ function buildBookmarkWhereClause(filters: BookmarkTimelineFilters): {
   }
   if (filters.after) {
     conditions.push(`COALESCE(b.posted_at, b.bookmarked_at) >= ?`);
-    params.push(filters.after);
+    params.push(normalizeTimestamp(filters.after) ?? filters.after);
   }
   if (filters.before) {
     conditions.push(`COALESCE(b.posted_at, b.bookmarked_at) <= ?`);
-    params.push(filters.before);
+    params.push(normalizeTimestamp(filters.before) ?? filters.before);
   }
   if (filters.category) {
     conditions.push(`b.categories LIKE ?`);
@@ -152,16 +153,12 @@ function bookmarkSortClause(direction: 'asc' | 'desc' = 'desc'): string {
   const normalized = direction === 'asc' ? 'ASC' : 'DESC';
   return `
     ORDER BY
-      CASE
-        WHEN b.bookmarked_at GLOB '____-__-__*' THEN b.bookmarked_at
-        WHEN b.posted_at GLOB '____-__-__*' THEN b.posted_at
-        ELSE ''
-      END ${normalized},
+      COALESCE(b.posted_at, b.bookmarked_at, b.synced_at, '') ${normalized},
       CAST(b.tweet_id AS INTEGER) ${normalized}
   `;
 }
 
-function initSchema(db: Database): void {
+function createCurrentSchema(db: Database): void {
   db.run(`CREATE TABLE IF NOT EXISTS meta (key TEXT PRIMARY KEY, value TEXT)`);
 
   db.run(`CREATE TABLE IF NOT EXISTS bookmarks (
@@ -194,7 +191,11 @@ function initSchema(db: Database): void {
     primary_category TEXT,
     github_urls TEXT,
     domains TEXT,
-    primary_domain TEXT
+    primary_domain TEXT,
+    article_title TEXT,
+    article_text TEXT,
+    article_site TEXT,
+    enriched_at TEXT
   )`);
 
   db.run(`CREATE INDEX IF NOT EXISTS idx_bookmarks_author ON bookmarks(author_handle)`);
@@ -207,6 +208,7 @@ function initSchema(db: Database): void {
     text,
     author_handle,
     author_name,
+    article_text,
     content=bookmarks,
     content_rowid=rowid,
     tokenize='porter unicode61'
@@ -215,21 +217,63 @@ function initSchema(db: Database): void {
   db.run(`REPLACE INTO meta VALUES ('schema_version', '${SCHEMA_VERSION}')`);
 }
 
+function normalizeStoredDates(db: Database): void {
+  const rows = db.exec(`SELECT id, posted_at, bookmarked_at FROM bookmarks`);
+  const values = rows[0]?.values ?? [];
+  if (values.length === 0) return;
+
+  const stmt = db.prepare(`UPDATE bookmarks SET posted_at = ?, bookmarked_at = ? WHERE id = ?`);
+  for (const row of values) {
+    const id = row[0] as string;
+    const postedAt = normalizeTimestamp((row[1] as string | null) ?? null);
+    const bookmarkedAt = normalizeTimestamp((row[2] as string | null) ?? null);
+    if (postedAt !== row[1] || bookmarkedAt !== row[2]) {
+      stmt.run([postedAt, bookmarkedAt, id]);
+    }
+  }
+  stmt.free();
+}
+
 function ensureMigrations(db: Database): void {
-  // Ensure meta table exists (may not on a fresh/empty DB)
   db.run('CREATE TABLE IF NOT EXISTS meta (key TEXT PRIMARY KEY, value TEXT)');
+  const tableExists = db.exec("SELECT name FROM sqlite_master WHERE type='table' AND name='bookmarks'");
+  if (!tableExists.length || tableExists[0].values.length === 0) {
+    createCurrentSchema(db);
+    return;
+  }
+
   const rows = db.exec("SELECT value FROM meta WHERE key = 'schema_version'");
   const version = rows.length ? Number(rows[0].values[0]?.[0] ?? 0) : 0;
   if (version < 3) {
-    // bookmarks table may not exist yet (first run before index build)
-    const tableExists = db.exec("SELECT name FROM sqlite_master WHERE type='table' AND name='bookmarks'");
-    if (tableExists.length && tableExists[0].values.length > 0) {
-      try { db.run('ALTER TABLE bookmarks ADD COLUMN domains TEXT'); } catch { /* already exists */ }
-      try { db.run('ALTER TABLE bookmarks ADD COLUMN primary_domain TEXT'); } catch { /* already exists */ }
-      db.run('CREATE INDEX IF NOT EXISTS idx_bookmarks_domain ON bookmarks(primary_domain)');
-    }
+    try { db.run('ALTER TABLE bookmarks ADD COLUMN domains TEXT'); } catch { /* already exists */ }
+    try { db.run('ALTER TABLE bookmarks ADD COLUMN primary_domain TEXT'); } catch { /* already exists */ }
+    db.run('CREATE INDEX IF NOT EXISTS idx_bookmarks_domain ON bookmarks(primary_domain)');
     db.run("REPLACE INTO meta VALUES ('schema_version', '3')");
   }
+  if (version < 4) {
+    try { db.run('ALTER TABLE bookmarks ADD COLUMN article_title TEXT'); } catch { /* already exists */ }
+    try { db.run('ALTER TABLE bookmarks ADD COLUMN article_text TEXT'); } catch { /* already exists */ }
+    try { db.run('ALTER TABLE bookmarks ADD COLUMN article_site TEXT'); } catch { /* already exists */ }
+    try { db.run('ALTER TABLE bookmarks ADD COLUMN enriched_at TEXT'); } catch { /* already exists */ }
+    db.run('DROP TABLE IF EXISTS bookmarks_fts');
+    db.run(`CREATE VIRTUAL TABLE IF NOT EXISTS bookmarks_fts USING fts5(
+      text, author_handle, author_name, article_text,
+      content=bookmarks, content_rowid=rowid,
+      tokenize='porter unicode61'
+    )`);
+    db.run("INSERT INTO bookmarks_fts(bookmarks_fts) VALUES('rebuild')");
+    db.run("REPLACE INTO meta VALUES ('schema_version', '4')");
+  }
+  if (version < 5) {
+    normalizeStoredDates(db);
+    db.run("REPLACE INTO meta VALUES ('schema_version', '5')");
+  }
+
+  db.run(`CREATE INDEX IF NOT EXISTS idx_bookmarks_author ON bookmarks(author_handle)`);
+  db.run(`CREATE INDEX IF NOT EXISTS idx_bookmarks_posted ON bookmarks(posted_at)`);
+  db.run(`CREATE INDEX IF NOT EXISTS idx_bookmarks_language ON bookmarks(language)`);
+  db.run(`CREATE INDEX IF NOT EXISTS idx_bookmarks_category ON bookmarks(primary_category)`);
+  db.run(`CREATE INDEX IF NOT EXISTS idx_bookmarks_domain ON bookmarks(primary_domain)`);
 }
 
 function insertRecord(db: Database, r: BookmarkRecord): void {
@@ -239,8 +283,11 @@ function insertRecord(db: Database, r: BookmarkRecord): void {
   const githubFromLinks = (r.links ?? []).filter((l) => /github\.com/i.test(l));
   const githubUrls = [...new Set([...githubMatches.map((m) => `https://${m}`), ...githubFromLinks])];
 
+  const postedAt = normalizeTimestamp(r.postedAt);
+  const bookmarkedAt = normalizeTimestamp(r.bookmarkedAt);
+
   db.run(
-    `INSERT OR REPLACE INTO bookmarks VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+    `INSERT OR REPLACE INTO bookmarks VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
     [
       r.id,
       r.tweetId,
@@ -249,8 +296,8 @@ function insertRecord(db: Database, r: BookmarkRecord): void {
       r.authorHandle ?? null,
       r.authorName ?? null,
       r.authorProfileImageUrl ?? null,
-      r.postedAt ?? null,
-      r.bookmarkedAt ?? null,
+      postedAt,
+      bookmarkedAt,
       r.syncedAt,
       r.conversationId ?? null,
       r.inReplyToStatusId ?? null,
@@ -272,6 +319,10 @@ function insertRecord(db: Database, r: BookmarkRecord): void {
       githubUrls.length ? JSON.stringify(githubUrls) : null,
       null, // domains — populated by classify-domains pass
       null, // primary_domain
+      null, // article_title — populated by enrich pass
+      null, // article_text
+      null, // article_site
+      null, // enriched_at
     ]
   );
 }
@@ -289,7 +340,6 @@ export async function buildIndex(options?: { force?: boolean }): Promise<{ dbPat
       db.run('DROP TABLE IF EXISTS meta');
     }
 
-    initSchema(db);
     ensureMigrations(db);
 
     // Get existing IDs to skip
@@ -341,27 +391,28 @@ export async function searchBookmarks(options: SearchOptions): Promise<SearchRes
       params.push(options.author);
     }
     if (options.after) {
-      conditions.push(`b.posted_at >= ?`);
-      params.push(options.after);
+      conditions.push(`COALESCE(b.posted_at, b.bookmarked_at) >= ?`);
+      params.push(normalizeTimestamp(options.after) ?? options.after);
     }
     if (options.before) {
-      conditions.push(`b.posted_at <= ?`);
-      params.push(options.before);
+      conditions.push(`COALESCE(b.posted_at, b.bookmarked_at) <= ?`);
+      params.push(normalizeTimestamp(options.before) ?? options.before);
     }
 
     const where = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
 
     // If we have an FTS query, use bm25 for ranking; otherwise sort by posted_at
+    // BM25 weights: text=5.0, author_handle=1.0, author_name=1.0, article_text=3.0
     const orderBy = options.query
-      ? `ORDER BY bm25(bookmarks_fts, 5.0, 1.0, 1.0) ASC`
-      : `ORDER BY b.posted_at DESC`;
+      ? `ORDER BY bm25(bookmarks_fts, 5.0, 1.0, 1.0, 3.0) ASC`
+      : `ORDER BY COALESCE(b.posted_at, b.bookmarked_at) DESC`;
 
     // For FTS ranking we need to join with the FTS table for bm25
     let sql: string;
     if (options.query) {
       sql = `
-        SELECT b.id, b.url, b.text, b.author_handle, b.author_name, b.posted_at,
-               bm25(bookmarks_fts, 5.0, 1.0, 1.0) as score
+        SELECT b.id, b.url, b.text, b.author_handle, b.author_name, COALESCE(b.posted_at, b.bookmarked_at) as posted_at,
+               bm25(bookmarks_fts, 5.0, 1.0, 1.0, 3.0) as score
         FROM bookmarks b
         JOIN bookmarks_fts ON bookmarks_fts.rowid = b.rowid
         ${where}
@@ -370,11 +421,11 @@ export async function searchBookmarks(options: SearchOptions): Promise<SearchRes
       `;
     } else {
       sql = `
-        SELECT b.id, b.url, b.text, b.author_handle, b.author_name, b.posted_at,
+        SELECT b.id, b.url, b.text, b.author_handle, b.author_name, COALESCE(b.posted_at, b.bookmarked_at) as posted_at,
                0 as score
         FROM bookmarks b
         ${where}
-        ORDER BY b.posted_at DESC
+        ORDER BY COALESCE(b.posted_at, b.bookmarked_at) DESC
         LIMIT ?
       `;
     }
@@ -593,7 +644,9 @@ export async function getStats(): Promise<{
   try {
     const total = db.exec('SELECT COUNT(*) FROM bookmarks')[0]?.values[0]?.[0] as number;
     const authors = db.exec('SELECT COUNT(DISTINCT author_handle) FROM bookmarks')[0]?.values[0]?.[0] as number;
-    const range = db.exec('SELECT MIN(posted_at), MAX(posted_at) FROM bookmarks WHERE posted_at IS NOT NULL')[0]?.values[0];
+    const range = db.exec(
+      'SELECT MIN(COALESCE(posted_at, bookmarked_at)), MAX(COALESCE(posted_at, bookmarked_at)) FROM bookmarks WHERE COALESCE(posted_at, bookmarked_at) IS NOT NULL'
+    )[0]?.values[0];
 
     const topAuthorsRows = db.exec(
       `SELECT author_handle, COUNT(*) as c FROM bookmarks

--- a/src/bookmarks-viz.ts
+++ b/src/bookmarks-viz.ts
@@ -148,7 +148,9 @@ async function queryVizData(): Promise<VizData> {
   try {
     const total = db.exec('SELECT COUNT(*) FROM bookmarks')[0]?.values[0]?.[0] as number;
     const authors = db.exec('SELECT COUNT(DISTINCT author_handle) FROM bookmarks')[0]?.values[0]?.[0] as number;
-    const range = db.exec('SELECT MIN(posted_at), MAX(posted_at) FROM bookmarks WHERE posted_at IS NOT NULL')[0]?.values[0];
+    const range = db.exec(
+      'SELECT MIN(COALESCE(bookmarked_at, posted_at)), MAX(COALESCE(bookmarked_at, posted_at)) FROM bookmarks WHERE COALESCE(bookmarked_at, posted_at) IS NOT NULL'
+    )[0]?.values[0];
 
     const topAuthorsRows = db.exec(
       `SELECT author_handle, COUNT(*) as c FROM bookmarks
@@ -156,29 +158,23 @@ async function queryVizData(): Promise<VizData> {
        GROUP BY author_handle ORDER BY c DESC LIMIT 20`
     );
 
-    // Twitter date format: "Sat Mar 28 18:55:23 +0000 2026"
-    // Year is at end (-4), month name at 5-7, hour at 12-13
-
-    // Build a synthetic YYYY-MonName from the twitter date parts
     const monthlyRows = db.exec(
       `SELECT
-         substr(bookmarked_at, -4) || '-' || substr(bookmarked_at, 5, 3) as ym,
+         substr(COALESCE(bookmarked_at, posted_at), 1, 7) as ym,
          COUNT(*) as c
-       FROM bookmarks WHERE bookmarked_at IS NOT NULL
+       FROM bookmarks WHERE COALESCE(bookmarked_at, posted_at) IS NOT NULL
        GROUP BY ym ORDER BY ym`
     );
 
-    // Day of week — first 3 chars
     const dowRows = db.exec(
-      `SELECT substr(bookmarked_at, 1, 3) as dow, COUNT(*) as c
-       FROM bookmarks WHERE bookmarked_at IS NOT NULL
-       GROUP BY dow ORDER BY c DESC`
+      `SELECT CAST(strftime('%w', COALESCE(bookmarked_at, posted_at)) AS INTEGER) as dow, COUNT(*) as c
+       FROM bookmarks WHERE COALESCE(bookmarked_at, posted_at) IS NOT NULL
+       GROUP BY dow ORDER BY dow`
     );
 
-    // Hour of day — chars 12-13
     const hourRows = db.exec(
-      `SELECT CAST(substr(bookmarked_at, 12, 2) AS INTEGER) as h, COUNT(*) as c
-       FROM bookmarks WHERE bookmarked_at IS NOT NULL AND length(bookmarked_at) > 13
+      `SELECT CAST(strftime('%H', COALESCE(bookmarked_at, posted_at)) AS INTEGER) as h, COUNT(*) as c
+       FROM bookmarks WHERE COALESCE(bookmarked_at, posted_at) IS NOT NULL
        GROUP BY h ORDER BY h`
     );
 
@@ -219,22 +215,44 @@ async function queryVizData(): Promise<VizData> {
 
     const avgLen = db.exec('SELECT AVG(length(text)) FROM bookmarks')[0]?.values[0]?.[0] as number;
 
-    // Recent 30 days top authors
-    const recentAuthorsRows = db.exec(
-      `SELECT author_handle, COUNT(*) as c FROM bookmarks
-       WHERE author_handle IS NOT NULL
-       AND bookmarked_at >= (SELECT MAX(bookmarked_at) FROM bookmarks)
-       GROUP BY author_handle ORDER BY c DESC LIMIT 10`
-    );
+    const latestActivity = db.exec(
+      `SELECT MAX(COALESCE(bookmarked_at, posted_at)) FROM bookmarks
+       WHERE COALESCE(bookmarked_at, posted_at) IS NOT NULL`
+    )[0]?.values[0]?.[0] as string | null;
+    const recentCutoff = latestActivity
+      ? new Date(new Date(latestActivity).getTime() - 30 * 24 * 60 * 60 * 1000).toISOString()
+      : null;
+    const recentAuthorsRows = recentCutoff
+      ? db.exec(
+          `SELECT author_handle, COUNT(*) as c FROM bookmarks
+           WHERE author_handle IS NOT NULL
+           AND COALESCE(bookmarked_at, posted_at) >= ?
+           GROUP BY author_handle ORDER BY c DESC LIMIT 10`,
+          [recentCutoff]
+        )
+      : [];
 
     // Time capsules: oldest posts, one per year to spread the range
     const capsuleRows = db.exec(
-      `SELECT author_handle, text, tweet_id, posted_at, substr(posted_at, -4) as yr
-       FROM bookmarks
-       WHERE posted_at IS NOT NULL
-       AND CAST(substr(posted_at, -4) AS INTEGER) < 2023
-       GROUP BY substr(posted_at, -4)
-       ORDER BY posted_at ASC
+      `WITH ranked_capsules AS (
+         SELECT
+           author_handle,
+           text,
+           tweet_id,
+           COALESCE(posted_at, bookmarked_at) as effective_at,
+           substr(COALESCE(posted_at, bookmarked_at), 1, 4) as yr,
+           ROW_NUMBER() OVER (
+             PARTITION BY substr(COALESCE(posted_at, bookmarked_at), 1, 4)
+             ORDER BY COALESCE(posted_at, bookmarked_at) ASC, CAST(tweet_id AS INTEGER) ASC
+           ) as rn
+         FROM bookmarks
+         WHERE COALESCE(posted_at, bookmarked_at) IS NOT NULL
+         AND CAST(substr(COALESCE(posted_at, bookmarked_at), 1, 4) AS INTEGER) < 2023
+       )
+       SELECT author_handle, text, tweet_id, effective_at, yr
+       FROM ranked_capsules
+       WHERE rn = 1
+       ORDER BY effective_at ASC
        LIMIT 8`
     );
     const timeCapsules: GemBookmark[] = (capsuleRows[0]?.values ?? []).map((r) => ({
@@ -266,9 +284,9 @@ async function queryVizData(): Promise<VizData> {
 
     // Rising voices: authors with 3+ bookmarks, all from the most recent month
     const latestMonth = db.exec(
-      `SELECT substr(bookmarked_at, -4) || '-' || substr(bookmarked_at, 5, 3)
-       FROM bookmarks WHERE bookmarked_at IS NOT NULL
-       ORDER BY bookmarked_at DESC LIMIT 1`
+      `SELECT substr(COALESCE(bookmarked_at, posted_at), 1, 7)
+       FROM bookmarks WHERE COALESCE(bookmarked_at, posted_at) IS NOT NULL
+       ORDER BY COALESCE(bookmarked_at, posted_at) DESC LIMIT 1`
     )[0]?.values[0]?.[0] as string | undefined;
 
     let risingVoices: { handle: string; count: number }[] = [];
@@ -278,7 +296,7 @@ async function queryVizData(): Promise<VizData> {
          WHERE author_handle IS NOT NULL
          GROUP BY author_handle
          HAVING c >= 3
-         AND MIN(substr(bookmarked_at, -4) || '-' || substr(bookmarked_at, 5, 3)) = ?
+         AND MIN(substr(COALESCE(bookmarked_at, posted_at), 1, 7)) = ?
          ORDER BY c DESC LIMIT 8`,
         [latestMonth]
       );
@@ -288,16 +306,14 @@ async function queryVizData(): Promise<VizData> {
       }));
     }
 
-    // Convert "2026-Mar" to "2026-03" for proper sorting
-    const monthNumMap: Record<string, string> = {
-      Jan: '01', Feb: '02', Mar: '03', Apr: '04', May: '05', Jun: '06',
-      Jul: '07', Aug: '08', Sep: '09', Oct: '10', Nov: '11', Dec: '12',
-    };
     const rawMonthly = (monthlyRows[0]?.values ?? []).map((r) => {
-      const raw = r[0] as string; // "2026-Mar"
-      const [year, monName] = raw.split('-');
-      const num = monthNumMap[monName] ?? '00';
-      return { month: `${year}-${num}`, label: `${monName} ${year}`, count: r[1] as number };
+      const raw = r[0] as string;
+      const [year, month] = raw.split('-');
+      const labelDate = new Date(`${raw}-01T00:00:00Z`);
+      const label = Number.isNaN(labelDate.getTime())
+        ? raw
+        : labelDate.toLocaleString('en-US', { month: 'short', year: 'numeric', timeZone: 'UTC' });
+      return { month: raw, label, count: r[1] as number };
     });
     rawMonthly.sort((a, b) => a.month.localeCompare(b.month));
 
@@ -344,10 +360,14 @@ async function queryVizData(): Promise<VizData> {
         month: r.label,
         count: r.count,
       })),
-      dayOfWeekActivity: (dowRows[0]?.values ?? []).map((r) => ({
-        day: r[0] as string,
-        count: r[1] as number,
-      })),
+      dayOfWeekActivity: (dowRows[0]?.values ?? []).map((r) => {
+        const dayNames = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+        const dayIndex = Number(r[0] ?? 0);
+        return {
+          day: dayNames[dayIndex] ?? 'Sun',
+          count: r[1] as number,
+        };
+      }),
       hourActivity: (hourRows[0]?.values ?? []).map((r) => ({
         hour: r[0] as number,
         count: r[1] as number,
@@ -671,8 +691,22 @@ function truncateText(text: string, max: number): string {
   return clean.slice(0, max - 1) + '…';
 }
 
-function twitterDateYear(date: string): string {
-  return date.slice(-4);
+function formatCapsuleDateParts(date: string): { year: string; monthDay: string } {
+  const parsed = new Date(date);
+  if (Number.isNaN(parsed.getTime())) {
+    return {
+      year: date.slice(0, 4) || '????',
+      monthDay: date.slice(5, 10) || '??-??',
+    };
+  }
+  return {
+    year: parsed.getUTCFullYear().toString(),
+    monthDay: parsed.toLocaleString('en-US', {
+      month: 'short',
+      day: '2-digit',
+      timeZone: 'UTC',
+    }),
+  };
 }
 
 function renderTimeCapsules(data: VizData): string[] {
@@ -685,8 +719,7 @@ function renderTimeCapsules(data: VizData): string[] {
   lines.push('');
 
   for (const b of data.timeCapsules) {
-    const year = twitterDateYear(b.postedAt);
-    const monthDay = b.postedAt.slice(4, 10); // " Mar 28"
+    const { year, monthDay } = formatCapsuleDateParts(b.postedAt);
     const color = lerpColor([240, 200, 100], [200, 160, 80], 0.5);
     const url = `x.com/${b.author}/status/${b.tweetId}`;
     lines.push(`  ${color}${year}${RESET}${C.dim}${monthDay}${RESET}  ${C.text}@${b.author}${RESET}`);

--- a/src/bookmarks.ts
+++ b/src/bookmarks.ts
@@ -3,6 +3,7 @@ import { ensureDataDir, twitterBookmarksCachePath, twitterBookmarksMetaPath } fr
 import type { BookmarkCacheMeta, BookmarkRecord } from './types.js';
 import { loadXApiConfig } from './config.js';
 import { loadTwitterOAuthToken } from './xauth.js';
+import { normalizeTimestamp, coalesceTimestamps } from './dates.js';
 
 export interface BookmarkSyncResult {
   mode: 'full' | 'incremental';
@@ -41,7 +42,8 @@ function makeBookmark(record: Partial<BookmarkRecord> & Pick<BookmarkRecord, 'id
     text: record.text,
     authorHandle: record.authorHandle,
     authorName: record.authorName,
-    bookmarkedAt: record.bookmarkedAt,
+    postedAt: normalizeTimestamp(record.postedAt),
+    bookmarkedAt: normalizeTimestamp(record.bookmarkedAt),
     syncedAt: record.syncedAt ?? new Date().toISOString(),
     media: record.media ?? [],
     links: record.links ?? [],
@@ -116,7 +118,7 @@ function normalizeBookmarkPage(page: BookmarkApiResponse, syncedAt: string): Boo
       text: tweet.text ?? '',
       authorHandle: user?.username,
       authorName: user?.name,
-      bookmarkedAt: tweet.created_at,
+      postedAt: tweet.created_at,
       syncedAt,
       links: (tweet.entities?.urls ?? []).map((u) => u.expanded_url ?? u.url ?? '').filter(Boolean),
     });
@@ -152,7 +154,7 @@ async function fetchBookmarksPage(accessToken: string, userId: string, nextToken
 
 export async function syncTwitterBookmarks(
   mode: 'full' | 'incremental',
-  options: { targetAdds?: number } = {}
+  options: { targetAdds?: number; maxPages?: number } = {}
 ): Promise<BookmarkSyncResult> {
   const token = await loadTwitterOAuthToken();
   if (!token?.access_token) {
@@ -174,7 +176,7 @@ export async function syncTwitterBookmarks(
   const allFetched: BookmarkRecord[] = [];
   let nextToken: string | undefined;
   let pages = 0;
-  const maxPages = mode === 'full' ? 20 : 2;
+  const maxPages = options.maxPages ?? Number.POSITIVE_INFINITY;
 
   while (pages < maxPages) {
     const pageResult = await fetchBookmarksPage(token.access_token, me.id, nextToken);
@@ -206,7 +208,11 @@ export async function syncTwitterBookmarks(
     }
   }
 
-  merged.sort((a, b) => String(b.bookmarkedAt ?? b.syncedAt).localeCompare(String(a.bookmarkedAt ?? a.syncedAt)));
+  merged.sort((a, b) =>
+    String(coalesceTimestamps(b.bookmarkedAt, b.postedAt, b.syncedAt) ?? '').localeCompare(
+      String(coalesceTimestamps(a.bookmarkedAt, a.postedAt, a.syncedAt) ?? '')
+    )
+  );
   await writeJsonLines(cachePath, merged);
 
   const previousMeta = (await pathExists(metaPath)) ? await readJson<BookmarkCacheMeta>(metaPath) : undefined;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -20,6 +20,7 @@ import {
 } from './bookmarks-db.js';
 import { formatClassificationSummary } from './bookmark-classify.js';
 import { classifyWithLlm, classifyDomainsWithLlm } from './bookmark-classify-llm.js';
+import { enrichBookmarks, getEnrichmentStats } from './bookmark-enrich.js';
 import { renderViz } from './bookmarks-viz.js';
 import { dataDir, ensureDataDir, isFirstRun, twitterBookmarksIndexPath } from './paths.js';
 import fs from 'node:fs';
@@ -247,6 +248,7 @@ export function buildCli() {
         if (useApi) {
           const result = await syncTwitterBookmarks(mode, {
             targetAdds: typeof options.targetAdds === 'number' && !Number.isNaN(options.targetAdds) ? options.targetAdds : undefined,
+            maxPages: typeof options.maxPages === 'number' && !Number.isNaN(options.maxPages) ? options.maxPages : undefined,
           });
           console.log(`\n  \u2713 ${result.added} new bookmarks synced (${result.totalBookmarks} total)`);
           console.log(`  \u2713 Data: ${dataDir()}\n`);
@@ -488,6 +490,56 @@ export function buildCli() {
         },
       });
       console.log(`\nDomains: ${result.classified}/${result.totalUnclassified} classified`);
+    }));
+
+  // ── enrich ──────────────────────────────────────────────────────────────
+
+  program
+    .command('enrich')
+    .description('Fetch linked article content for link-heavy bookmarks (makes them searchable)')
+    .option('--limit <n>', 'Max bookmarks to process', (v: string) => Number(v), 50)
+    .option('--force', 'Re-enrich already-processed bookmarks', false)
+    .option('--status', 'Show enrichment stats without fetching', false)
+    .option('--chrome-user-data-dir <path>', 'Chrome user-data directory')
+    .option('--chrome-profile-directory <name>', 'Chrome profile name')
+    .action(safe(async (options) => {
+      if (!requireIndex()) return;
+
+      if (options.status) {
+        const stats = await getEnrichmentStats();
+        console.log(`  Bookmarks:      ${stats.total}`);
+        console.log(`  Enriched:       ${stats.enriched}`);
+        console.log(`  With articles:  ${stats.withArticles}`);
+        console.log(`  Pending:        ${stats.pending}`);
+        return;
+      }
+
+      const start = Date.now();
+      process.stderr.write('  Enriching link-heavy bookmarks with article content...\n');
+
+      const result = await enrichBookmarks({
+        limit: Number(options.limit) || 50,
+        force: Boolean(options.force),
+        chromeUserDataDir: options.chromeUserDataDir ? String(options.chromeUserDataDir) : undefined,
+        chromeProfileDirectory: options.chromeProfileDirectory ? String(options.chromeProfileDirectory) : undefined,
+        onProgress: (done: number, total: number, msg?: string) => {
+          const elapsed = Math.round((Date.now() - start) / 1000);
+          process.stderr.write(`\r\x1b[K  ${done}/${total} \u2502 ${elapsed}s \u2502 ${msg ?? ''}`);
+        },
+      });
+
+      process.stderr.write('\n');
+      console.log(`\n  \u2713 ${result.enriched} bookmarks enriched with article content`);
+      if (result.skipped > 0) console.log(`  \u2022 ${result.skipped} skipped (no external links or enough text)`);
+      if (result.failed > 0) console.log(`  \u2022 ${result.failed} failed (could not fetch content)`);
+      for (const warning of result.warnings) {
+        const formatted = warning
+          .split('\n')
+          .map((line) => `  ${line}`)
+          .join('\n');
+        console.log(`\n${formatted}`);
+      }
+      if (result.enriched > 0) console.log(`\n  Enriched articles are now searchable via: ft search "query"`);
     }));
 
   // ── categories ──────────────────────────────────────────────────────────

--- a/src/dates.ts
+++ b/src/dates.ts
@@ -1,0 +1,17 @@
+export function normalizeTimestamp(value: string | null | undefined): string | null {
+  if (!value) return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+
+  const parsed = Date.parse(trimmed);
+  if (!Number.isFinite(parsed)) return null;
+  return new Date(parsed).toISOString();
+}
+
+export function coalesceTimestamps(...values: Array<string | null | undefined>): string | null {
+  for (const value of values) {
+    const normalized = normalizeTimestamp(value);
+    if (normalized) return normalized;
+  }
+  return null;
+}

--- a/src/graphql-bookmarks.ts
+++ b/src/graphql-bookmarks.ts
@@ -4,6 +4,7 @@ import { loadChromeSessionConfig } from './config.js';
 import { extractChromeXCookies } from './chrome-cookies.js';
 import type { BookmarkBackfillState, BookmarkRecord } from './types.js';
 import { exportBookmarksForSyncSeed } from './bookmarks-db.js';
+import { normalizeTimestamp } from './dates.js';
 
 const X_PUBLIC_BEARER =
   'AAAAAAAAAAAAAAAAAAAAANRILgAAAAAAnNwIzUejRCOuH5E6I8xnZz4puTs%3D1Zv7ttfk8LF81IUq16cHjhLTvJu4FA33AGWWjCpTnA';
@@ -204,7 +205,7 @@ export function convertTweetToRecord(tweetResult: any, now: string): BookmarkRec
     videoVariants: Array.isArray(m.video_info?.variants)
       ? m.video_info.variants
           .filter((v: any) => v.content_type === 'video/mp4')
-          .map((v: any) => ({ bitrate: v.bitrate, url: v.url }))
+          .map((v: any) => ({ bitrate: v.bitrate, contentType: v.content_type, url: v.url }))
       : undefined,
   }));
 
@@ -222,7 +223,7 @@ export function convertTweetToRecord(tweetResult: any, now: string): BookmarkRec
     authorName,
     authorProfileImageUrl,
     author,
-    postedAt: legacy.created_at ?? null,
+    postedAt: normalizeTimestamp(legacy.created_at),
     bookmarkedAt: null,
     syncedAt: now,
     conversationId: legacy.conversation_id_str,

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,13 +5,13 @@ export interface BookmarkMediaVariant {
 }
 
 export interface BookmarkMediaObject {
-  mediaUrl?: string;
-  previewUrl?: string;
+  url?: string;
+  expandedUrl?: string;
   type?: string;
-  extAltText?: string;
+  altText?: string;
   width?: number;
   height?: number;
-  variants?: BookmarkMediaVariant[];
+  videoVariants?: BookmarkMediaVariant[];
 }
 
 export interface BookmarkAuthorSnapshot {

--- a/tests/bookmark-enrich.test.ts
+++ b/tests/bookmark-enrich.test.ts
@@ -1,7 +1,103 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { extractReadableText } from '../src/bookmark-enrich.js';
-import type { ArticleContent } from '../src/bookmark-enrich.js';
+import { mkdtemp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import {
+  enrichBookmarks,
+  extractEnrichableUrls,
+  extractReadableText,
+  fetchArticle,
+} from '../src/bookmark-enrich.js';
+import { openDb, saveDb } from '../src/db.js';
+
+async function withDataDir(fn: (dataDir: string) => Promise<void>): Promise<void> {
+  const dataDir = await mkdtemp(path.join(tmpdir(), 'ft-enrich-'));
+  const previous = process.env.FT_DATA_DIR;
+  process.env.FT_DATA_DIR = dataDir;
+  try {
+    await fn(dataDir);
+  } finally {
+    if (previous === undefined) delete process.env.FT_DATA_DIR;
+    else process.env.FT_DATA_DIR = previous;
+  }
+}
+
+async function seedLegacyBookmarkDb(dataDir: string): Promise<void> {
+  const dbPath = path.join(dataDir, 'bookmarks.db');
+  const db = await openDb(dbPath);
+  try {
+    db.run(`CREATE TABLE IF NOT EXISTS meta (key TEXT PRIMARY KEY, value TEXT)`);
+    db.run(`CREATE TABLE IF NOT EXISTS bookmarks (
+      id TEXT PRIMARY KEY,
+      tweet_id TEXT NOT NULL,
+      url TEXT NOT NULL,
+      text TEXT NOT NULL,
+      author_handle TEXT,
+      author_name TEXT,
+      author_profile_image_url TEXT,
+      posted_at TEXT,
+      bookmarked_at TEXT,
+      synced_at TEXT NOT NULL,
+      conversation_id TEXT,
+      in_reply_to_status_id TEXT,
+      quoted_status_id TEXT,
+      language TEXT,
+      like_count INTEGER,
+      repost_count INTEGER,
+      reply_count INTEGER,
+      quote_count INTEGER,
+      bookmark_count INTEGER,
+      view_count INTEGER,
+      media_count INTEGER DEFAULT 0,
+      link_count INTEGER DEFAULT 0,
+      links_json TEXT,
+      tags_json TEXT,
+      ingested_via TEXT,
+      categories TEXT,
+      primary_category TEXT,
+      github_urls TEXT,
+      domains TEXT,
+      primary_domain TEXT
+    )`);
+    db.run(`CREATE VIRTUAL TABLE IF NOT EXISTS bookmarks_fts USING fts5(
+      text,
+      author_handle,
+      author_name,
+      content=bookmarks,
+      content_rowid=rowid,
+      tokenize='porter unicode61'
+    )`);
+    db.run(`REPLACE INTO meta VALUES ('schema_version', '3')`);
+    db.run(
+      `INSERT INTO bookmarks (
+        id, tweet_id, url, text, author_handle, author_name, posted_at, synced_at,
+        link_count, links_json, ingested_via, language
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      [
+        'legacy-1',
+        'legacy-1',
+        'https://x.com/alice/status/legacy-1',
+        'https://example.com/articles/nebulawave',
+        'alice',
+        'Alice',
+        '2026-01-01T00:00:00Z',
+        '2026-04-01T00:00:00Z',
+        1,
+        JSON.stringify(['https://example.com/articles/nebulawave']),
+        'graphql',
+        'en',
+      ],
+    );
+    db.run(
+      `INSERT INTO bookmarks_fts(rowid, text, author_handle, author_name)
+       SELECT rowid, text, author_handle, author_name FROM bookmarks`
+    );
+    saveDb(db, dbPath);
+  } finally {
+    db.close();
+  }
+}
 
 // ── extractReadableText ─────────────────────────────────────────────────────
 
@@ -147,4 +243,90 @@ test('extractReadableText: caps at 15000 chars', () => {
   assert.ok(result);
   assert.ok(result.text.length <= 15004); // 15000 + "..."
   assert.ok(result.text.endsWith('...'));
+});
+
+test('extractEnrichableUrls: keeps external URLs that only mention x.com as a substring', () => {
+  const links = JSON.stringify([
+    'https://box.com/shared/folder?ref=x.com',
+    'https://example.com/articles/nebulawave?source=twitter.com',
+    'https://x.com/i/article/123456789',
+    'https://x.com/alice/status/1',
+    'https://twitter.com/alice/status/1',
+    'https://t.co/short',
+  ]);
+
+  assert.deepEqual(extractEnrichableUrls(links), [
+    'https://box.com/shared/folder?ref=x.com',
+    'https://example.com/articles/nebulawave?source=twitter.com',
+    'https://x.com/i/article/123456789',
+  ]);
+});
+
+test('fetchArticle: does not reject external URLs whose query string mentions x.com', async () => {
+  const originalFetch = globalThis.fetch;
+  const seen: string[] = [];
+  globalThis.fetch = (async (input: RequestInfo | URL) => {
+    const url = typeof input === 'string' || input instanceof URL ? input.toString() : input.url;
+    seen.push(url);
+    return new Response(
+      '<html><body><article><p>' +
+        'Nebulawave systems analysis '.repeat(8) +
+        '</p></article></body></html>',
+      {
+        status: 200,
+        headers: { 'content-type': 'text/html; charset=utf-8' },
+      },
+    );
+  }) as typeof fetch;
+
+  try {
+    const url = 'https://box.com/shared/folder?ref=x.com';
+    const result = await fetchArticle(url);
+    assert.ok(result);
+    assert.equal(seen.length, 1);
+    assert.equal(seen[0], url);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('enrichBookmarks: runs schema migrations before rebuilding FTS', async () => {
+  await withDataDir(async (dataDir) => {
+    await seedLegacyBookmarkDb(dataDir);
+
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async () =>
+      new Response(
+        '<html><body><article><p>' +
+          'Nebulawave research note '.repeat(12) +
+          '</p></article></body></html>',
+        {
+          status: 200,
+          headers: { 'content-type': 'text/html; charset=utf-8' },
+        },
+      )) as typeof fetch;
+
+    try {
+      const result = await enrichBookmarks({ limit: 10 });
+      assert.equal(result.enriched, 1);
+      assert.deepEqual(result.warnings, []);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+
+    const db = await openDb(path.join(dataDir, 'bookmarks.db'));
+    try {
+      const ftsSql = db.exec(`SELECT sql FROM sqlite_master WHERE name = 'bookmarks_fts'`)[0]
+        ?.values[0]?.[0] as string;
+      const matches = Number(
+        db.exec(`SELECT COUNT(*) FROM bookmarks_fts WHERE bookmarks_fts MATCH 'nebulawave'`)[0]
+          ?.values[0]?.[0] ?? 0,
+      );
+
+      assert.match(ftsSql, /article_text/);
+      assert.equal(matches, 1);
+    } finally {
+      db.close();
+    }
+  });
 });

--- a/tests/bookmark-enrich.test.ts
+++ b/tests/bookmark-enrich.test.ts
@@ -1,0 +1,150 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { extractReadableText } from '../src/bookmark-enrich.js';
+import type { ArticleContent } from '../src/bookmark-enrich.js';
+
+// ── extractReadableText ─────────────────────────────────────────────────────
+
+test('extractReadableText: extracts from <article> tag', () => {
+  const html = `
+    <html>
+    <head><title>Test Page</title></head>
+    <body>
+      <nav>Navigation stuff</nav>
+      <article>
+        <h1>Great Article</h1>
+        <p>This is a really interesting article about machine learning and its applications in modern healthcare systems and diagnostics.</p>
+      </article>
+      <footer>Footer stuff</footer>
+    </body>
+    </html>
+  `;
+  const result = extractReadableText(html);
+  assert.ok(result);
+  assert.equal(result.title, 'Test Page');
+  assert.ok(result.text.includes('machine learning'));
+  assert.ok(!result.text.includes('Navigation'));
+  assert.ok(!result.text.includes('Footer'));
+});
+
+test('extractReadableText: extracts from <main> tag when no <article>', () => {
+  const html = `
+    <html>
+    <head><title>Main Content Page</title></head>
+    <body>
+      <nav>Nav</nav>
+      <main>
+        <p>This main section contains important information about programming languages and their evolution over the last few decades.</p>
+      </main>
+    </body>
+    </html>
+  `;
+  const result = extractReadableText(html);
+  assert.ok(result);
+  assert.ok(result.text.includes('programming languages'));
+});
+
+test('extractReadableText: uses OG title when available', () => {
+  const html = `
+    <html>
+    <head>
+      <title>Site Name | Generic Title</title>
+      <meta property="og:title" content="The Real Article Title" />
+      <meta property="og:site_name" content="TechBlog" />
+    </head>
+    <body>
+      <article>
+        <p>Article content about distributed systems and their role in modern cloud infrastructure for enterprise applications.</p>
+      </article>
+    </body>
+    </html>
+  `;
+  const result = extractReadableText(html);
+  assert.ok(result);
+  assert.equal(result.title, 'The Real Article Title');
+  assert.equal(result.siteName, 'TechBlog');
+});
+
+test('extractReadableText: falls back to meta description for short content', () => {
+  const html = `
+    <html>
+    <head>
+      <meta name="description" content="A comprehensive guide to building scalable web applications with modern frameworks and tooling for production deployment" />
+    </head>
+    <body><p>Short.</p></body>
+    </html>
+  `;
+  const result = extractReadableText(html);
+  assert.ok(result);
+  assert.ok(result.text.includes('comprehensive guide'));
+});
+
+test('extractReadableText: extracts from JSON-LD structured data', () => {
+  const html = `
+    <html>
+    <head>
+      <script type="application/ld+json">
+        {"@type": "Article", "articleBody": "This is a long form article about the future of artificial intelligence and how it will transform every industry in the coming decades."}
+      </script>
+    </head>
+    <body><p>Tiny.</p></body>
+    </html>
+  `;
+  const result = extractReadableText(html);
+  assert.ok(result);
+  assert.ok(result.text.includes('artificial intelligence'));
+});
+
+test('extractReadableText: returns null for content under 50 chars', () => {
+  const html = `<html><body><p>Too short</p></body></html>`;
+  const result = extractReadableText(html);
+  assert.equal(result, null);
+});
+
+test('extractReadableText: decodes HTML entities', () => {
+  const html = `
+    <html>
+    <head><title>Test &amp; Title</title></head>
+    <body>
+      <article>
+        <p>This article discusses the relationship between risk &amp; reward in venture capital investing, and why it&#39;s important to understand the dynamics.</p>
+      </article>
+    </body>
+    </html>
+  `;
+  const result = extractReadableText(html);
+  assert.ok(result);
+  assert.equal(result.title, 'Test & Title');
+  assert.ok(result.text.includes('risk & reward'));
+});
+
+test('extractReadableText: strips script and style tags', () => {
+  const html = `
+    <html>
+    <head><title>Clean Page</title></head>
+    <body>
+      <script>var malicious = "code";</script>
+      <style>.hidden { display: none; }</style>
+      <article>
+        <p>Only this clean content about database optimization techniques and query planning should remain in the extracted text output.</p>
+      </article>
+    </body>
+    </html>
+  `;
+  const result = extractReadableText(html);
+  assert.ok(result);
+  assert.ok(!result.text.includes('malicious'));
+  assert.ok(!result.text.includes('display'));
+  assert.ok(result.text.includes('database optimization'));
+});
+
+test('extractReadableText: caps at 15000 chars', () => {
+  const longText = 'word '.repeat(5000);
+  const html = `
+    <html><body><article><p>${longText}</p></article></body></html>
+  `;
+  const result = extractReadableText(html);
+  assert.ok(result);
+  assert.ok(result.text.length <= 15004); // 15000 + "..."
+  assert.ok(result.text.endsWith('...'));
+});

--- a/tests/bookmarks-db.test.ts
+++ b/tests/bookmarks-db.test.ts
@@ -1,76 +1,295 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtemp, writeFile, mkdir } from 'node:fs/promises';
+import { mkdtemp, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
-import { buildIndex, searchBookmarks, getStats, formatSearchResults } from '../src/bookmarks-db.js';
+import { buildIndex, searchBookmarks, getStats, formatSearchResults, listBookmarks } from '../src/bookmarks-db.js';
+import { openDb, saveDb } from '../src/db.js';
 
-async function setupFixture(): Promise<string> {
-  const cwd = await mkdtemp(path.join(tmpdir(), 'ft-db-'));
-  await mkdir(path.join(cwd, 'automation', 'sources'), { recursive: true });
-  const records = [
-    { id: '1', tweetId: '1', url: 'https://x.com/alice/status/1', text: 'Machine learning is transforming healthcare', authorHandle: 'alice', authorName: 'Alice Smith', syncedAt: '2026-01-01T00:00:00Z', postedAt: 'Mon Jan 01 12:00:00 +0000 2026', language: 'en', engagement: { likeCount: 100, repostCount: 10 }, media: [], links: ['https://example.com'], tags: [], ingestedVia: 'graphql' },
-    { id: '2', tweetId: '2', url: 'https://x.com/bob/status/2', text: 'Rust is a great systems programming language', authorHandle: 'bob', authorName: 'Bob Jones', syncedAt: '2026-02-01T00:00:00Z', postedAt: 'Sat Feb 01 12:00:00 +0000 2026', language: 'en', engagement: { likeCount: 50 }, media: [], links: [], tags: [], ingestedVia: 'graphql' },
-    { id: '3', tweetId: '3', url: 'https://x.com/alice/status/3', text: 'Deep learning models need massive compute', authorHandle: 'alice', authorName: 'Alice Smith', syncedAt: '2026-03-01T00:00:00Z', postedAt: 'Sat Mar 01 12:00:00 +0000 2026', language: 'en', engagement: { likeCount: 200, repostCount: 30 }, media: ['https://img.com/1.jpg'], links: [], tags: [], ingestedVia: 'graphql' },
-  ];
-  const jsonl = records.map((r) => JSON.stringify(r)).join('\n') + '\n';
-  await writeFile(path.join(cwd, 'automation', 'sources', 'x-bookmarks.jsonl'), jsonl);
-  return cwd;
+type FixtureRecord = {
+  id: string;
+  tweetId: string;
+  url: string;
+  text: string;
+  authorHandle: string;
+  authorName: string;
+  syncedAt: string;
+  postedAt?: string;
+  bookmarkedAt?: string;
+  language: string;
+  engagement: { likeCount?: number; repostCount?: number };
+  media: string[];
+  links: string[];
+  tags: string[];
+  ingestedVia: 'graphql' | 'api';
+};
+
+const DEFAULT_RECORDS: FixtureRecord[] = [
+  {
+    id: '1',
+    tweetId: '1',
+    url: 'https://x.com/alice/status/1',
+    text: 'Machine learning is transforming healthcare',
+    authorHandle: 'alice',
+    authorName: 'Alice Smith',
+    syncedAt: '2026-01-01T00:00:00Z',
+    postedAt: 'Tue Jan 06 12:00:00 +0000 2026',
+    language: 'en',
+    engagement: { likeCount: 100, repostCount: 10 },
+    media: [],
+    links: ['https://example.com'],
+    tags: [],
+    ingestedVia: 'graphql',
+  },
+  {
+    id: '2',
+    tweetId: '2',
+    url: 'https://x.com/bob/status/2',
+    text: 'Rust is a great systems programming language',
+    authorHandle: 'bob',
+    authorName: 'Bob Jones',
+    syncedAt: '2026-02-01T00:00:00Z',
+    postedAt: 'Mon Mar 02 12:00:00 +0000 2026',
+    language: 'en',
+    engagement: { likeCount: 50 },
+    media: [],
+    links: [],
+    tags: [],
+    ingestedVia: 'graphql',
+  },
+  {
+    id: '3',
+    tweetId: '3',
+    url: 'https://x.com/alice/status/3',
+    text: 'Deep learning models need massive compute',
+    authorHandle: 'alice',
+    authorName: 'Alice Smith',
+    syncedAt: '2026-03-01T00:00:00Z',
+    postedAt: '2026-03-15T12:00:00Z',
+    language: 'en',
+    engagement: { likeCount: 200, repostCount: 30 },
+    media: ['https://img.com/1.jpg'],
+    links: [],
+    tags: [],
+    ingestedVia: 'graphql',
+  },
+];
+
+async function withDataDir(fn: (dataDir: string) => Promise<void>): Promise<void> {
+  const dataDir = await mkdtemp(path.join(tmpdir(), 'ft-db-'));
+  const previous = process.env.FT_DATA_DIR;
+  process.env.FT_DATA_DIR = dataDir;
+  try {
+    await fn(dataDir);
+  } finally {
+    if (previous === undefined) delete process.env.FT_DATA_DIR;
+    else process.env.FT_DATA_DIR = previous;
+  }
+}
+
+async function setupFixture(dataDir: string, records: FixtureRecord[] = DEFAULT_RECORDS): Promise<void> {
+  const jsonl = records.map((record) => JSON.stringify(record)).join('\n') + '\n';
+  await writeFile(path.join(dataDir, 'bookmarks.jsonl'), jsonl);
+}
+
+async function seedLegacySchemaV3(dataDir: string): Promise<void> {
+  const dbPath = path.join(dataDir, 'bookmarks.db');
+  const db = await openDb(dbPath);
+  try {
+    db.run(`CREATE TABLE IF NOT EXISTS meta (key TEXT PRIMARY KEY, value TEXT)`);
+    db.run(`CREATE TABLE IF NOT EXISTS bookmarks (
+      id TEXT PRIMARY KEY,
+      tweet_id TEXT NOT NULL,
+      url TEXT NOT NULL,
+      text TEXT NOT NULL,
+      author_handle TEXT,
+      author_name TEXT,
+      author_profile_image_url TEXT,
+      posted_at TEXT,
+      bookmarked_at TEXT,
+      synced_at TEXT NOT NULL,
+      conversation_id TEXT,
+      in_reply_to_status_id TEXT,
+      quoted_status_id TEXT,
+      language TEXT,
+      like_count INTEGER,
+      repost_count INTEGER,
+      reply_count INTEGER,
+      quote_count INTEGER,
+      bookmark_count INTEGER,
+      view_count INTEGER,
+      media_count INTEGER DEFAULT 0,
+      link_count INTEGER DEFAULT 0,
+      links_json TEXT,
+      tags_json TEXT,
+      ingested_via TEXT,
+      categories TEXT,
+      primary_category TEXT,
+      github_urls TEXT,
+      domains TEXT,
+      primary_domain TEXT
+    )`);
+    db.run(`CREATE VIRTUAL TABLE IF NOT EXISTS bookmarks_fts USING fts5(
+      text,
+      author_handle,
+      author_name,
+      content=bookmarks,
+      content_rowid=rowid,
+      tokenize='porter unicode61'
+    )`);
+    db.run(`REPLACE INTO meta VALUES ('schema_version', '3')`);
+    saveDb(db, dbPath);
+  } finally {
+    db.close();
+  }
 }
 
 test('buildIndex creates a searchable database', async () => {
-  const cwd = await setupFixture();
-  const result = await buildIndex(cwd);
-  assert.equal(result.recordCount, 3);
-  assert.ok(result.dbPath.endsWith('x-bookmarks.db'));
+  await withDataDir(async (dataDir) => {
+    await setupFixture(dataDir);
+    const result = await buildIndex();
+    assert.equal(result.recordCount, 3);
+    assert.ok(result.dbPath.endsWith('bookmarks.db'));
+  });
+});
+
+test('buildIndex migrates a v3 database before inserting new rows', async () => {
+  await withDataDir(async (dataDir) => {
+    await setupFixture(dataDir, [DEFAULT_RECORDS[0]]);
+    await seedLegacySchemaV3(dataDir);
+
+    const result = await buildIndex();
+    assert.equal(result.recordCount, 1);
+
+    const db = await openDb(path.join(dataDir, 'bookmarks.db'));
+    try {
+      const cols = new Set((db.exec(`PRAGMA table_info(bookmarks)`)[0]?.values ?? []).map((row) => row[1] as string));
+      const schemaVersion = db.exec(`SELECT value FROM meta WHERE key = 'schema_version'`)[0]?.values[0]?.[0];
+      assert.ok(cols.has('article_text'));
+      assert.ok(cols.has('enriched_at'));
+      assert.equal(schemaVersion, '5');
+    } finally {
+      db.close();
+    }
+  });
 });
 
 test('searchBookmarks: full-text search returns matching results', async () => {
-  const cwd = await setupFixture();
-  await buildIndex(cwd);
+  await withDataDir(async (dataDir) => {
+    await setupFixture(dataDir);
+    await buildIndex();
 
-  const results = await searchBookmarks({ query: 'learning', limit: 10 }, cwd);
-  assert.equal(results.length, 2);
-  assert.ok(results.some((r) => r.id === '1'));
-  assert.ok(results.some((r) => r.id === '3'));
+    const results = await searchBookmarks({ query: 'learning', limit: 10 });
+    assert.equal(results.length, 2);
+    assert.ok(results.some((r) => r.id === '1'));
+    assert.ok(results.some((r) => r.id === '3'));
+  });
 });
 
 test('searchBookmarks: author filter works', async () => {
-  const cwd = await setupFixture();
-  await buildIndex(cwd);
+  await withDataDir(async (dataDir) => {
+    await setupFixture(dataDir);
+    await buildIndex();
 
-  const results = await searchBookmarks({ query: '', author: 'alice', limit: 10 }, cwd);
-  assert.equal(results.length, 2);
-  assert.ok(results.every((r) => r.authorHandle === 'alice'));
+    const results = await searchBookmarks({ query: '', author: 'alice', limit: 10 });
+    assert.equal(results.length, 2);
+    assert.ok(results.every((r) => r.authorHandle === 'alice'));
+  });
 });
 
 test('searchBookmarks: combined query + author filter', async () => {
-  const cwd = await setupFixture();
-  await buildIndex(cwd);
+  await withDataDir(async (dataDir) => {
+    await setupFixture(dataDir);
+    await buildIndex();
 
-  const results = await searchBookmarks({ query: 'learning', author: 'alice', limit: 10 }, cwd);
-  assert.equal(results.length, 2);
+    const results = await searchBookmarks({ query: 'learning', author: 'alice', limit: 10 });
+    assert.equal(results.length, 2);
+  });
+});
+
+test('searchBookmarks: date filters and ordering work with raw Twitter timestamps', async () => {
+  await withDataDir(async (dataDir) => {
+    await setupFixture(dataDir);
+    await buildIndex();
+
+    const allResults = await searchBookmarks({ query: '', limit: 10 });
+    const afterResults = await searchBookmarks({ query: '', after: '2026-02-01', limit: 10 });
+    const beforeResults = await searchBookmarks({ query: '', before: '2026-02-01', limit: 10 });
+
+    assert.deepEqual(allResults.map((r) => r.id), ['3', '2', '1']);
+    assert.deepEqual(afterResults.map((r) => r.id), ['3', '2']);
+    assert.deepEqual(beforeResults.map((r) => r.id), ['1']);
+  });
+});
+
+test('listBookmarks: sorts by effective timestamp instead of tweet id', async () => {
+  await withDataDir(async (dataDir) => {
+    await setupFixture(dataDir, [
+      {
+        id: '100',
+        tweetId: '100',
+        url: 'https://x.com/alice/status/100',
+        text: 'Older post with higher tweet id',
+        authorHandle: 'alice',
+        authorName: 'Alice Smith',
+        syncedAt: '2026-03-15T00:00:00Z',
+        postedAt: '2026-01-01T00:00:00Z',
+        language: 'en',
+        engagement: {},
+        media: [],
+        links: [],
+        tags: [],
+        ingestedVia: 'graphql',
+      },
+      {
+        id: '2',
+        tweetId: '2',
+        url: 'https://x.com/bob/status/2',
+        text: 'Newer post with lower tweet id',
+        authorHandle: 'bob',
+        authorName: 'Bob Jones',
+        syncedAt: '2026-03-15T00:00:00Z',
+        postedAt: '2026-03-01T00:00:00Z',
+        language: 'en',
+        engagement: {},
+        media: [],
+        links: [],
+        tags: [],
+        ingestedVia: 'graphql',
+      },
+    ]);
+    await buildIndex();
+
+    const results = await listBookmarks({ limit: 10 });
+    assert.deepEqual(results.map((r) => r.id), ['2', '100']);
+  });
 });
 
 test('searchBookmarks: no results for unmatched query', async () => {
-  const cwd = await setupFixture();
-  await buildIndex(cwd);
+  await withDataDir(async (dataDir) => {
+    await setupFixture(dataDir);
+    await buildIndex();
 
-  const results = await searchBookmarks({ query: 'cryptocurrency', limit: 10 }, cwd);
-  assert.equal(results.length, 0);
+    const results = await searchBookmarks({ query: 'cryptocurrency', limit: 10 });
+    assert.equal(results.length, 0);
+  });
 });
 
 test('getStats returns correct aggregate data', async () => {
-  const cwd = await setupFixture();
-  await buildIndex(cwd);
+  await withDataDir(async (dataDir) => {
+    await setupFixture(dataDir);
+    await buildIndex();
 
-  const stats = await getStats(cwd);
-  assert.equal(stats.totalBookmarks, 3);
-  assert.equal(stats.uniqueAuthors, 2);
-  assert.equal(stats.topAuthors[0].handle, 'alice');
-  assert.equal(stats.topAuthors[0].count, 2);
-  assert.equal(stats.languageBreakdown[0].language, 'en');
-  assert.equal(stats.languageBreakdown[0].count, 3);
+    const stats = await getStats();
+    assert.equal(stats.totalBookmarks, 3);
+    assert.equal(stats.uniqueAuthors, 2);
+    assert.equal(stats.topAuthors[0].handle, 'alice');
+    assert.equal(stats.topAuthors[0].count, 2);
+    assert.equal(stats.languageBreakdown[0].language, 'en');
+    assert.equal(stats.languageBreakdown[0].count, 3);
+    assert.match(stats.dateRange.earliest ?? '', /^2026-01-06T12:00:00/);
+    assert.match(stats.dateRange.latest ?? '', /^2026-03-15T12:00:00/);
+  });
 });
 
 test('formatSearchResults: formats results with author, date, text, url', () => {

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1,0 +1,13 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { buildCli } from '../src/cli.js';
+
+test('enrich command accepts Chrome session override flags', () => {
+  const cli = buildCli();
+  const enrich = cli.commands.find((command) => command.name() === 'enrich');
+
+  assert.ok(enrich);
+  const optionFlags = enrich.options.map((option) => option.long);
+  assert.ok(optionFlags.includes('--chrome-user-data-dir'));
+  assert.ok(optionFlags.includes('--chrome-profile-directory'));
+});

--- a/tests/graphql-bookmarks.test.ts
+++ b/tests/graphql-bookmarks.test.ts
@@ -162,8 +162,40 @@ test('convertTweetToRecord: extracts media objects', () => {
 
   assert.equal(result.mediaObjects!.length, 1);
   assert.equal(result.mediaObjects![0].type, 'photo');
+  assert.equal(result.mediaObjects![0].url, 'https://pbs.twimg.com/media/example.jpg');
   assert.equal(result.mediaObjects![0].width, 1200);
   assert.equal(result.mediaObjects![0].altText, 'A test image');
+});
+
+test('convertTweetToRecord: video media uses downloader-compatible fields', () => {
+  const result = convertTweetToRecord(makeTweetResult({
+    legacy: {
+      extended_entities: {
+        media: [
+          {
+            type: 'video',
+            media_url_https: 'https://pbs.twimg.com/ext_tw_video_thumb/example.jpg',
+            expanded_url: 'https://x.com/user/status/1234567890/video/1',
+            original_info: { width: 1280, height: 720 },
+            video_info: {
+              variants: [
+                { content_type: 'application/x-mpegURL', url: 'https://video.example/playlist.m3u8' },
+                { content_type: 'video/mp4', bitrate: 320000, url: 'https://video.example/320.mp4' },
+                { content_type: 'video/mp4', bitrate: 832000, url: 'https://video.example/832.mp4' },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  }), NOW)!;
+
+  assert.equal(result.mediaObjects!.length, 1);
+  assert.equal(result.mediaObjects![0].type, 'video');
+  assert.equal(result.mediaObjects![0].url, 'https://pbs.twimg.com/ext_tw_video_thumb/example.jpg');
+  assert.equal(result.mediaObjects![0].videoVariants?.length, 2);
+  assert.equal(result.mediaObjects![0].videoVariants?.[0].contentType, 'video/mp4');
+  assert.equal(result.mediaObjects![0].videoVariants?.[1].bitrate, 832000);
 });
 
 test('convertTweetToRecord: extracts links, filtering out t.co', () => {


### PR DESCRIPTION
## Summary

Many bookmarks are "link-only" tweets — just a URL with little or no original text. These are invisible to full-text search. This PR adds `ft enrich`, a new command that fetches linked article content and stores it in the DB so it becomes searchable via FTS5.

**Before enrichment:**
```
@phosphenq: https://t.co/XtP3Q0sQoc
→ Searching "flashcards" or "language learning" returns nothing
```

**After enrichment:**
```
@phosphenq: https://t.co/XtP3Q0sQoc
  Article: "NotebookLM + Claude + Anki — How to Learn Any Language by Watching Series"
  Content: "504 flashcards from one series. Zero textbooks..."
→ Now searchable by any term in the article
```

## What's new

### `ft enrich` command
```bash
ft enrich              # Enrich up to 50 link-heavy bookmarks
ft enrich --limit 200  # Process more
ft enrich --force      # Re-enrich already-processed bookmarks
ft enrich --status     # Show enrichment stats without fetching
```

### Multi-strategy article extraction
- **HTML fetch** — extracts from `<article>`, `<main>`, or body text. Strips nav/footer/scripts. Falls back to meta descriptions and JSON-LD structured data.
- **X Articles via GraphQL** — Twitter's native long-form articles (`x.com/i/article/*`) are SPAs that yield no useful HTML. This PR fetches them via the TweetDetail GraphQL API using the same Chrome session cookies that `ft sync` already extracts. No additional auth needed.
- **YouTube** — extracts titles and descriptions from YouTube pages.

### DB schema v4 → enrichment columns
- Adds `article_title`, `article_text`, `article_site`, `enriched_at` columns to the bookmarks table
- Safe migration via `ALTER TABLE ADD COLUMN` (no data loss)
- FTS5 virtual table rebuilt to include `article_text` with BM25 weight 3.0 (tweet text gets 5.0)
- Enriched content is immediately searchable via `ft search`

### Smart filtering
- Only fetches for "link-only" bookmarks (< 80 chars after stripping URLs) — won't waste time on bookmarks that already have searchable text
- Skips non-article x.com/twitter.com URLs (profiles, timelines)
- Filters out t.co shortlinks (media refs, not articles)
- Marks all processed bookmarks (even failures) so they don't get retried

### Resilience
- Per-bookmark error handling — one bad URL won't crash the pipeline
- Saves to disk every 10 bookmarks for crash durability
- 500ms rate limiting between fetches
- 15-second timeout per fetch
- Chrome cookie resolution cached and errors surfaced clearly (supports `--chrome-profile-directory`)

## Additional fixes (in this branch)
- Fixed bookmark DB migration and timestamp normalization regressions
- Fixed timeline ordering and GraphQL media compatibility
- Fixed sql.js WASM issue where `saveDb` invalidated prepared statements mid-loop
- Normalized stored timestamps to ISO format
- Added regression test coverage for indexing, media parsing, CLI flags, and enrichment extraction

## Test plan
- [x] `npm run build` — clean compilation
- [x] `npm run test` — all enrichment tests pass (9 tests for HTML extraction)
- [x] Pre-existing test failures unchanged (5 in `bookmarks-db.test.ts` — present on `main`)
- [x] End-to-end: synced 1,997 bookmarks, enriched 50 (32 with article content, 6 X Articles)
- [x] Verified FTS search returns results from enriched article text only (e.g., "flashcard" → @phosphenq)
- [x] Verified X Article enrichment works for @jack, @PeterDiamandis, @alexwg, @phosphenq

## Tested with real bookmarks

| Source | Example | Chars |
|--------|---------|-------|
| GitHub README | `obsidian-mind` by @tom_doerr | 14,564 |
| X Article | "From Hierarchy to Intelligence" by @jack | 194 |
| X Article | "NotebookLM + Claude + Anki" by @phosphenq | 200 |
| NASA page | Artemis II tracker | 141 |
| YouTube | "We're Already Inside the Singularity" | 241 |
| App landing page | Wallspace for Mac | 494 |