### PR TITLE
feat: add HTTP/HTTPS proxy support for ft sync

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "ft-bookmarks",
+  "name": "fieldtheory",
   "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "ft-bookmarks",
+      "name": "fieldtheory",
       "version": "1.2.1",
       "license": "MIT",
       "dependencies": {
@@ -13,7 +13,7 @@
         "dotenv": "^17.3.1",
         "sql.js": "^1.14.1",
         "sql.js-fts5": "^1.4.0",
-        "zod": "^4.3.6"
+        "undici": "^8.0.2"
       },
       "bin": {
         "ft": "bin/ft.mjs"
@@ -645,21 +645,21 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/undici": {
+      "version": "8.0.2",
+      "resolved": "https://repo.huaweicloud.com/repository/npm/undici/-/undici-8.0.2.tgz",
+      "integrity": "sha512-B9MeU5wuFhkFAuNeA19K2GDFcQXZxq33fL0nRy2Aq30wdufZbyyvxW3/ChaeipXVfy/wUweZyzovQGk39+9k2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
     "node_modules/undici-types": {
       "version": "7.18.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/zod": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "commander": "^14.0.3",
     "dotenv": "^17.3.1",
     "sql.js": "^1.14.1",
-    "sql.js-fts5": "^1.4.0"
+    "sql.js-fts5": "^1.4.0",
+    "undici": "^8.0.2"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",

--- a/src/graphql-bookmarks.ts
+++ b/src/graphql-bookmarks.ts
@@ -4,6 +4,20 @@ import { loadChromeSessionConfig } from './config.js';
 import { extractChromeXCookies } from './chrome-cookies.js';
 import type { BookmarkBackfillState, BookmarkRecord } from './types.js';
 import { exportBookmarksForSyncSeed } from './bookmarks-db.js';
+import { ProxyAgent, setGlobalDispatcher } from 'undici';
+
+// Set up proxy if environment variable is set
+const proxyUrl =
+  process.env.HTTPS_PROXY ||
+  process.env.https_proxy ||
+  process.env.HTTP_PROXY ||
+  process.env.http_proxy ||
+  process.env.ALL_PROXY ||
+  process.env.all_proxy;
+
+if (proxyUrl) {
+  setGlobalDispatcher(new ProxyAgent(proxyUrl));
+}
 
 const X_PUBLIC_BEARER =
   'AAAAAAAAAAAAAAAAAAAAANRILgAAAAAAnNwIzUejRCOuH5E6I8xnZz4puTs%3D1Zv7ttfk8LF81IUq16cHjhLTvJu4FA33AGWWjCpTnA';


### PR DESCRIPTION
## Summary

Add HTTP/HTTPS proxy support for `ft sync` command using Node.js built-in `undici` ProxyAgent.

## Changes

- Add `undici` as a dependency for proxy support
- Import `ProxyAgent` and `setGlobalDispatcher` from `undici`
- Support standard proxy environment variables:
  - `HTTPS_PROXY` / `https_proxy`
  - `HTTP_PROXY` / `http_proxy`
  - `ALL_PROXY` / `all_proxy`

## Problem

The `ft sync` command uses Node.js built-in `fetch` API to make requests to X's GraphQL API. However, the current implementation does not support HTTP/HTTPS proxy configuration, making it impossible to use the CLI in network environments that require a proxy to access external services.

## Solution

Use `undici`'s `ProxyAgent` with `setGlobalDispatcher` to automatically configure proxy based on environment variables. This approach:

1. Is transparent to the user - just set the standard proxy environment variables
2. Works with all `fetch` calls automatically
3. Uses Node.js built-in `undici` (no extra native dependencies)

## Testing

Tested on macOS with Node.js v22.22.0:

```bash
export HTTPS_PROXY=http://127.0.0.1:7897
ft sync
# ✓ 122 new bookmarks synced (122 total)
```

## Related

Fixes #9

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes global HTTP dispatch behavior for all `fetch` calls and introduces a new runtime dependency (`undici`) with Node engine constraints.
> 
> **Overview**
> Adds proxy support for GraphQL bookmark syncing by reading standard `*_PROXY` environment variables and, when present, setting an `undici` `ProxyAgent` via `setGlobalDispatcher` so `fetch` requests route through the proxy.
> 
> Updates npm metadata to include the `undici` dependency (and corresponding lockfile changes).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3db821f43bfe9d0c17fb9730520a425a7502e00c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->