### PR TITLE
feat: add Firefox browser support for cookie-based sync

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -235,7 +235,7 @@ export function buildCli() {
     .option('--target-adds <n>', 'Stop after N new bookmarks', (v: string) => Number(v))
     .option('--delay-ms <n>', 'Delay between requests in ms', (v: string) => Number(v), 600)
     .option('--max-minutes <n>', 'Max runtime in minutes', (v: string) => Number(v), 30)
-    .option('--browser <name>', 'Browser to read cookies from: chrome or firefox', 'chrome')
+    .option('--browser <name>', 'Browser to read cookies from (choices: chrome, firefox)', 'chrome')
     .option('--chrome-user-data-dir <path>', 'Chrome user-data directory')
     .option('--chrome-profile-directory <name>', 'Chrome profile name')
     .option('--firefox-profile-dir <path>', 'Firefox profile directory')
@@ -260,7 +260,10 @@ export function buildCli() {
           }
         } else {
           const startTime = Date.now();
-          const browser = String(options.browser ?? 'chrome').toLowerCase() as 'chrome' | 'firefox';
+          const browser = String(options.browser ?? 'chrome').toLowerCase();
+          if (browser !== 'chrome' && browser !== 'firefox') {
+            throw new Error(`Unsupported browser: "${browser}". Supported browsers: chrome, firefox`);
+          }
           const result = await syncBookmarksGraphQL({
             incremental: !Boolean(options.full),
             maxPages: Number(options.maxPages) || 500,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -119,9 +119,11 @@ function timeAgo(dateStr: string): string {
 
 function showSyncWelcome(): void {
   console.log(`
-  Make sure Google Chrome is open and logged into x.com.
-  Your Chrome session is used to authenticate \u2014 no passwords
+  Make sure your browser is open and logged into x.com.
+  Your browser session is used to authenticate \u2014 no passwords
   are stored or transmitted.
+
+  Supports Chrome (default) and Firefox (--browser firefox).
 `);
 }
 
@@ -233,8 +235,10 @@ export function buildCli() {
     .option('--target-adds <n>', 'Stop after N new bookmarks', (v: string) => Number(v))
     .option('--delay-ms <n>', 'Delay between requests in ms', (v: string) => Number(v), 600)
     .option('--max-minutes <n>', 'Max runtime in minutes', (v: string) => Number(v), 30)
+    .option('--browser <name>', 'Browser to read cookies from: chrome or firefox', 'chrome')
     .option('--chrome-user-data-dir <path>', 'Chrome user-data directory')
     .option('--chrome-profile-directory <name>', 'Chrome profile name')
+    .option('--firefox-profile-dir <path>', 'Firefox profile directory')
     .action(async (options) => {
       const firstRun = isFirstRun();
       if (firstRun) showSyncWelcome();
@@ -256,14 +260,17 @@ export function buildCli() {
           }
         } else {
           const startTime = Date.now();
+          const browser = String(options.browser ?? 'chrome').toLowerCase() as 'chrome' | 'firefox';
           const result = await syncBookmarksGraphQL({
             incremental: !Boolean(options.full),
             maxPages: Number(options.maxPages) || 500,
             targetAdds: typeof options.targetAdds === 'number' && !Number.isNaN(options.targetAdds) ? options.targetAdds : undefined,
             delayMs: Number(options.delayMs) || 600,
             maxMinutes: Number(options.maxMinutes) || 30,
+            browser,
             chromeUserDataDir: options.chromeUserDataDir ? String(options.chromeUserDataDir) : undefined,
             chromeProfileDirectory: options.chromeProfileDirectory ? String(options.chromeProfileDirectory) : undefined,
+            firefoxProfileDir: options.firefoxProfileDir ? String(options.firefoxProfileDir) : undefined,
             onProgress: (status: SyncProgress) => {
               renderProgress(status, startTime);
               if (status.done) process.stderr.write('\n');

--- a/src/firefox-cookies.ts
+++ b/src/firefox-cookies.ts
@@ -1,0 +1,166 @@
+import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync, unlinkSync, copyFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir, platform, homedir } from 'node:os';
+import { randomUUID } from 'node:crypto';
+
+import type { ChromeCookieResult } from './chrome-cookies.js';
+
+/**
+ * Detect the default Firefox profile directory.
+ *
+ * Supports macOS and Linux. Reads profiles.ini to find the profile
+ * marked as default-release (the one Firefox actually uses), falling
+ * back to any profile that has a cookies.sqlite.
+ */
+function firefoxBaseDir(): string {
+  const os = platform();
+  if (os === 'darwin') return join(homedir(), 'Library', 'Application Support', 'Firefox');
+  if (os === 'linux') return join(homedir(), '.mozilla', 'firefox');
+  throw new Error(
+    `Firefox cookie extraction is not yet supported on ${os}.\n` +
+    'Supported platforms: macOS, Linux.\n' +
+    'Pass --firefox-profile-dir <path> to specify your profile manually.'
+  );
+}
+
+export function detectFirefoxProfileDir(): string {
+  const base = firefoxBaseDir();
+  const iniPath = join(base, 'profiles.ini');
+
+  if (!existsSync(iniPath)) {
+    throw new Error(
+      'Firefox profiles.ini not found.\n' +
+      'Is Firefox installed? Expected: ' + iniPath
+    );
+  }
+
+  const ini = readFileSync(iniPath, 'utf8');
+  const profiles: { name: string; path: string; isRelative: boolean }[] = [];
+  let current: { name?: string; path?: string; isRelative?: boolean } = {};
+
+  for (const line of ini.split('\n')) {
+    const trimmed = line.trim();
+    if (trimmed.startsWith('[Profile')) {
+      if (current.path) profiles.push(current as any);
+      current = {};
+    } else if (trimmed.startsWith('Name=')) {
+      current.name = trimmed.slice(5);
+    } else if (trimmed.startsWith('Path=')) {
+      current.path = trimmed.slice(5);
+    } else if (trimmed.startsWith('IsRelative=')) {
+      current.isRelative = trimmed.slice(11) === '1';
+    }
+  }
+  if (current.path) profiles.push(current as any);
+
+  // Prefer default-release, then any profile with cookies.sqlite
+  const resolve = (p: { path: string; isRelative: boolean }) =>
+    p.isRelative ? join(base, p.path) : p.path;
+
+  const defaultRelease = profiles.find(p => p.name === 'default-release');
+  if (defaultRelease) {
+    const dir = resolve(defaultRelease);
+    if (existsSync(join(dir, 'cookies.sqlite'))) return dir;
+  }
+
+  for (const p of profiles) {
+    const dir = resolve(p);
+    if (existsSync(join(dir, 'cookies.sqlite'))) return dir;
+  }
+
+  throw new Error(
+    'No Firefox profile with cookies.sqlite found.\n' +
+    'Open Firefox and log into x.com first, then retry.'
+  );
+}
+
+function queryFirefoxCookies(
+  dbPath: string,
+  host: string,
+  names: string[],
+): { name: string; value: string }[] {
+  if (!existsSync(dbPath)) {
+    throw new Error(
+      `Firefox cookies.sqlite not found at: ${dbPath}\n` +
+      'Open Firefox and browse to any site first so the cookie DB is created.'
+    );
+  }
+
+  const nameList = names.map(n => `'${n.replace(/'/g, "''")}'`).join(',');
+  const sql = `SELECT name, value FROM moz_cookies WHERE host LIKE '%${host}' AND name IN (${nameList});`;
+
+  const tryQuery = (path: string): string =>
+    execFileSync('sqlite3', ['-json', path, sql], {
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+      timeout: 10000,
+    }).trim();
+
+  let output: string;
+  try {
+    output = tryQuery(dbPath);
+  } catch {
+    // Firefox may hold a WAL lock — copy and query the copy
+    const tmpDb = join(tmpdir(), `ft-ff-cookies-${randomUUID()}.db`);
+    try {
+      copyFileSync(dbPath, tmpDb);
+      // Also copy WAL/SHM if they exist so the copy is consistent
+      const walPath = dbPath + '-wal';
+      const shmPath = dbPath + '-shm';
+      if (existsSync(walPath)) copyFileSync(walPath, tmpDb + '-wal');
+      if (existsSync(shmPath)) copyFileSync(shmPath, tmpDb + '-shm');
+      output = tryQuery(tmpDb);
+    } catch (e2: any) {
+      throw new Error(
+        `Could not read Firefox cookies database.\n` +
+        `Path: ${dbPath}\n` +
+        `Error: ${e2.message}\n` +
+        'If Firefox is open, this is normal — the DB copy should work.\n' +
+        'Try closing Firefox and retrying if this persists.'
+      );
+    } finally {
+      try { unlinkSync(tmpDb); } catch {}
+      try { unlinkSync(tmpDb + '-wal'); } catch {}
+      try { unlinkSync(tmpDb + '-shm'); } catch {}
+    }
+  }
+
+  if (!output || output === '[]') return [];
+  try {
+    return JSON.parse(output);
+  } catch {
+    return [];
+  }
+}
+
+export function extractFirefoxXCookies(profileDir?: string): ChromeCookieResult {
+  const dir = profileDir ?? detectFirefoxProfileDir();
+  const dbPath = join(dir, 'cookies.sqlite');
+
+  let cookies = queryFirefoxCookies(dbPath, '.x.com', ['ct0', 'auth_token']);
+  if (cookies.length === 0) {
+    cookies = queryFirefoxCookies(dbPath, '.twitter.com', ['ct0', 'auth_token']);
+  }
+
+  const cookieMap = new Map(cookies.map(c => [c.name, c.value]));
+
+  const ct0 = cookieMap.get('ct0');
+  const authToken = cookieMap.get('auth_token');
+
+  if (!ct0) {
+    throw new Error(
+      'No ct0 CSRF cookie found for x.com in Firefox.\n' +
+      'This means you are not logged into X in Firefox.\n\n' +
+      'Fix:\n' +
+      '  1. Open Firefox\n' +
+      '  2. Go to https://x.com and log in\n' +
+      '  3. Re-run this command\n'
+    );
+  }
+
+  const cookieParts = [`ct0=${ct0}`];
+  if (authToken) cookieParts.push(`auth_token=${authToken}`);
+
+  return { csrfToken: ct0, cookieHeader: cookieParts.join('; ') };
+}

--- a/src/graphql-bookmarks.ts
+++ b/src/graphql-bookmarks.ts
@@ -307,7 +307,7 @@ async function fetchPageWithRetry(csrfToken: string, cursor?: string, cookieHead
         `GraphQL Bookmarks API returned ${response.status}.\n` +
           `Response: ${text.slice(0, 300)}\n\n` +
           (response.status === 401 || response.status === 403
-            ? 'Fix: Your X session may have expired. Open Chrome, go to https://x.com, and make sure you are logged in. Then retry.'
+            ? 'Fix: Your X session may have expired. Open your browser, go to https://x.com, and make sure you are logged in. Then retry.'
             : 'This may be a temporary issue. Try again in a few minutes.')
       );
     }

--- a/src/graphql-bookmarks.ts
+++ b/src/graphql-bookmarks.ts
@@ -2,6 +2,7 @@ import { ensureDir, readJsonLines, writeJsonLines, readJson, writeJson, pathExis
 import { ensureDataDir, twitterBookmarksCachePath, twitterBackfillStatePath } from './paths.js';
 import { loadChromeSessionConfig } from './config.js';
 import { extractChromeXCookies } from './chrome-cookies.js';
+import { extractFirefoxXCookies } from './firefox-cookies.js';
 import type { BookmarkBackfillState, BookmarkRecord } from './types.js';
 import { exportBookmarksForSyncSeed } from './bookmarks-db.js';
 
@@ -48,13 +49,17 @@ export interface SyncOptions {
   maxMinutes?: number;
   /** Consecutive pages with 0 new bookmarks before stopping. Default: 3 */
   stalePageLimit?: number;
+  /** Browser to extract cookies from. Default: 'chrome' */
+  browser?: 'chrome' | 'firefox';
   /** Chrome user-data-dir override. */
   chromeUserDataDir?: string;
   /** Chrome profile directory name (e.g. "Default"). */
   chromeProfileDirectory?: string;
-  /** Direct csrf token override; skips Chrome cookie extraction. */
+  /** Firefox profile directory override. */
+  firefoxProfileDir?: string;
+  /** Direct csrf token override; skips cookie extraction. */
   csrfToken?: string;
-  /** Direct cookie header override; skips Chrome cookie extraction. */
+  /** Direct cookie header override; skips cookie extraction. */
   cookieHeader?: string;
   /** Progress callback. */
   onProgress?: (status: SyncProgress) => void;
@@ -391,6 +396,10 @@ export async function syncBookmarksGraphQL(
   if (options.csrfToken) {
     csrfToken = options.csrfToken;
     cookieHeader = options.cookieHeader;
+  } else if (options.browser === 'firefox') {
+    const cookies = extractFirefoxXCookies(options.firefoxProfileDir);
+    csrfToken = cookies.csrfToken;
+    cookieHeader = cookies.cookieHeader;
   } else {
     const chromeConfig = loadChromeSessionConfig();
     const chromeDir = options.chromeUserDataDir ?? chromeConfig.chromeUserDataDir;


### PR DESCRIPTION
## Summary

Adds Firefox as a supported browser for cookie-based bookmark syncing, alongside the existing Chrome support.

```bash
ft sync --browser firefox
```

- **Auto-detects** the active Firefox profile by parsing `profiles.ini` — no manual config needed
- **No decryption required** — unlike Chrome (which encrypts cookies via macOS Keychain), Firefox stores cookies as plaintext in `moz_cookies`, making this simpler and more portable
- **Supports macOS and Linux** (`~/Library/Application Support/Firefox` and `~/.mozilla/firefox/` respectively) — this is the first sync path that works on Linux
- **Handles DB locking** — copies `cookies.sqlite` + WAL/SHM files when Firefox holds a lock
- **Falls back** across `.x.com` and `.twitter.com` cookie domains
- **Manual override** available via `--firefox-profile-dir <path>` for non-standard setups
- **Fully backward compatible** — default browser remains Chrome, no changes to existing behavior

## Changes

- `src/firefox-cookies.ts` — new module: profile detection, cookie querying, extraction
- `src/graphql-bookmarks.ts` — added `browser` and `firefoxProfileDir` to `SyncOptions`, branch on browser type during cookie extraction
- `src/cli.ts` — added `--browser` and `--firefox-profile-dir` flags to the sync command, updated welcome text

## Test plan

- [x] Tested incremental sync with Firefox on macOS — 1274 bookmarks synced successfully
- [x] Verified profile auto-detection via `profiles.ini`
- [x] Verified cookie extraction while Firefox is running (WAL copy path)
- [x] Verified Chrome sync still works as default (no regression)
- [ ] Linux testing (paths are correct per Firefox docs, not yet tested on a Linux box)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new Firefox cookie-extraction path and CLI flags that affect how authentication cookies are sourced for sync; failures or platform/tooling differences (e.g., `sqlite3`, profile detection) could break session-based syncing on some setups.
> 
> **Overview**
> Adds Firefox as an alternative cookie source for session-based bookmark syncing. The `ft sync` command now accepts `--browser chrome|firefox` (default `chrome`) plus `--firefox-profile-dir`, and the onboarding text is updated accordingly.
> 
> Implements `src/firefox-cookies.ts` to auto-detect a Firefox profile via `profiles.ini`, query `cookies.sqlite` for `ct0`/`auth_token` (with `.x.com` → `.twitter.com` fallback), and handle locked DBs by copying the SQLite DB (and WAL/SHM) before querying. `syncBookmarksGraphQL` is extended with `browser`/`firefoxProfileDir` options and branches cookie extraction to Chrome vs Firefox unless `csrfToken`/`cookieHeader` are provided.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 718a71cc7c01e293db7b0f15483a2131c732ff1f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->