### PR TITLE
Support Helium browser for ft sync

### DIFF
--- a/src/chrome-cookies.ts
+++ b/src/chrome-cookies.ts
@@ -9,16 +9,29 @@ export interface ChromeCookieResult {
   cookieHeader: string;
 }
 
-function getMacOSChromeKey(): Buffer {
-  const candidates = [
-    { service: 'Chrome Safe Storage', account: 'Chrome' },
-    { service: 'Chrome Safe Storage', account: 'Google Chrome' },
-    { service: 'Google Chrome Safe Storage', account: 'Chrome' },
-    { service: 'Google Chrome Safe Storage', account: 'Google Chrome' },
-    { service: 'Chromium Safe Storage', account: 'Chromium' },
-    { service: 'Brave Safe Storage', account: 'Brave' },
-    { service: 'Brave Browser Safe Storage', account: 'Brave Browser' },
-  ];
+function getMacOSChromeKey(userDataDir?: string): Buffer {
+  // Helium (net.imput.helium) is a Chromium fork that stores its v10 cookie
+  // password under a non-"Safe Storage" keychain entry. Detect it from the
+  // user-data dir so we only try its entry when the caller is actually
+  // pointing at a Helium profile — otherwise a stray Helium install would
+  // shadow the real Chrome key.
+  const isHeliumDir = !!userDataDir && /net\.imput\.helium/i.test(userDataDir);
+
+  // When the caller is explicitly pointing at a Helium profile, only try
+  // Helium's keychain entry. Falling through to Chrome's "Safe Storage" key
+  // would silently return the wrong key on machines where both browsers are
+  // installed, producing a "bad decrypt" error.
+  const candidates = isHeliumDir
+    ? [{ service: 'Helium Storage Key', account: 'Helium' }]
+    : [
+        { service: 'Chrome Safe Storage', account: 'Chrome' },
+        { service: 'Chrome Safe Storage', account: 'Google Chrome' },
+        { service: 'Google Chrome Safe Storage', account: 'Chrome' },
+        { service: 'Google Chrome Safe Storage', account: 'Google Chrome' },
+        { service: 'Chromium Safe Storage', account: 'Chromium' },
+        { service: 'Brave Safe Storage', account: 'Brave' },
+        { service: 'Brave Browser Safe Storage', account: 'Brave Browser' },
+      ];
 
   for (const candidate of candidates) {
     try {
@@ -185,7 +198,7 @@ export function extractChromeXCookies(
   }
 
   const dbPath = join(chromeUserDataDir, profileDirectory, 'Cookies');
-  const key = getMacOSChromeKey();
+  const key = getMacOSChromeKey(chromeUserDataDir);
 
   let result = queryCookies(dbPath, '.x.com', ['ct0', 'auth_token']);
   if (result.cookies.length === 0) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -233,6 +233,7 @@ export function buildCli() {
     .option('--target-adds <n>', 'Stop after N new bookmarks', (v: string) => Number(v))
     .option('--delay-ms <n>', 'Delay between requests in ms', (v: string) => Number(v), 600)
     .option('--max-minutes <n>', 'Max runtime in minutes', (v: string) => Number(v), 30)
+    .option('--browser <name>', 'Browser to read session from: chrome (default) or helium')
     .option('--chrome-user-data-dir <path>', 'Chrome user-data directory')
     .option('--chrome-profile-directory <name>', 'Chrome profile name')
     .action(async (options) => {
@@ -262,6 +263,7 @@ export function buildCli() {
             targetAdds: typeof options.targetAdds === 'number' && !Number.isNaN(options.targetAdds) ? options.targetAdds : undefined,
             delayMs: Number(options.delayMs) || 600,
             maxMinutes: Number(options.maxMinutes) || 30,
+            browser: options.browser ? String(options.browser) : undefined,
             chromeUserDataDir: options.chromeUserDataDir ? String(options.chromeUserDataDir) : undefined,
             chromeProfileDirectory: options.chromeProfileDirectory ? String(options.chromeProfileDirectory) : undefined,
             onProgress: (status: SyncProgress) => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,5 @@
 import { config as loadDotenv } from 'dotenv';
+import { existsSync } from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
 import { dataDir } from './paths.js';
@@ -22,22 +23,59 @@ export function loadEnv(): void {
   }
 }
 
-function detectChromeUserDataDir(): string | undefined {
+// Known browser ids accepted by --browser / FT_BROWSER. Kept intentionally
+// small: each entry here must be live-tested against a real install of the
+// browser. Chrome is the implicit default if no id is given.
+const SUPPORTED_BROWSER_IDS = ['chrome', 'helium'] as const;
+type SupportedBrowserId = typeof SUPPORTED_BROWSER_IDS[number];
+
+function normalizeBrowserId(raw: string): SupportedBrowserId {
+  const normalized = raw.trim().toLowerCase();
+  if ((SUPPORTED_BROWSER_IDS as readonly string[]).includes(normalized)) {
+    return normalized as SupportedBrowserId;
+  }
+  throw new Error(
+    `Unknown browser: "${raw}".\n` +
+    `Supported browsers: ${SUPPORTED_BROWSER_IDS.join(', ')}.\n` +
+    `Set via --browser <name> or the FT_BROWSER env var.`
+  );
+}
+
+function detectChromeUserDataDir(browserId?: string): string | undefined {
   const platform = os.platform();
   const home = os.homedir();
-  if (platform === 'darwin') return path.join(home, 'Library', 'Application Support', 'Google', 'Chrome');
+
+  // Explicit browser override: --browser / FT_BROWSER.
+  if (browserId) {
+    const id = normalizeBrowserId(browserId);
+    if (id === 'helium') {
+      if (platform === 'darwin') return path.join(home, 'Library', 'Application Support', 'net.imput.helium');
+      return undefined;
+    }
+    // id === 'chrome' falls through to the default detection below.
+  }
+
+  if (platform === 'darwin') {
+    const chrome = path.join(home, 'Library', 'Application Support', 'Google', 'Chrome');
+    if (existsSync(chrome)) return chrome;
+    // Fall back to Helium if Chrome isn't installed.
+    const helium = path.join(home, 'Library', 'Application Support', 'net.imput.helium');
+    if (existsSync(helium)) return helium;
+    return chrome;
+  }
   if (platform === 'linux') return path.join(home, '.config', 'google-chrome');
   if (platform === 'win32') return path.join(home, 'AppData', 'Local', 'Google', 'Chrome', 'User Data');
   return undefined;
 }
 
-export function loadChromeSessionConfig(): ChromeSessionConfig {
+export function loadChromeSessionConfig(overrides: { browserId?: string } = {}): ChromeSessionConfig {
   loadEnv();
-  const dir = process.env.FT_CHROME_USER_DATA_DIR ?? detectChromeUserDataDir();
+  const browserId = overrides.browserId ?? process.env.FT_BROWSER;
+  const dir = process.env.FT_CHROME_USER_DATA_DIR ?? detectChromeUserDataDir(browserId);
   if (!dir) {
     throw new Error(
-      'Could not detect Chrome user-data directory.\n' +
-      'Set FT_CHROME_USER_DATA_DIR in .env or pass --chrome-user-data-dir.'
+      'Could not detect a browser user-data directory.\n' +
+      'Set FT_CHROME_USER_DATA_DIR in .env or pass --chrome-user-data-dir (or --browser helium).'
     );
   }
   return {

--- a/src/config.ts
+++ b/src/config.ts
@@ -41,37 +41,59 @@ function normalizeBrowserId(raw: string): SupportedBrowserId {
   );
 }
 
-function detectChromeUserDataDir(browserId?: string): string | undefined {
+function chromeUserDataDir(): string | undefined {
   const platform = os.platform();
   const home = os.homedir();
+  if (platform === 'darwin') return path.join(home, 'Library', 'Application Support', 'Google', 'Chrome');
+  if (platform === 'linux')  return path.join(home, '.config', 'google-chrome');
+  if (platform === 'win32')  return path.join(home, 'AppData', 'Local', 'Google', 'Chrome', 'User Data');
+  return undefined;
+}
 
-  // Explicit browser override: --browser / FT_BROWSER.
+function heliumUserDataDir(): string | undefined {
+  if (os.platform() !== 'darwin') return undefined;
+  return path.join(os.homedir(), 'Library', 'Application Support', 'net.imput.helium');
+}
+
+function detectChromeUserDataDir(browserId?: string): string | undefined {
+  // Explicit browser override: always honor the request, even if the chosen
+  // browser isn't installed. Returning a "fallback" browser's path would
+  // silently contradict the user's intent and, worse, pair a profile path
+  // with the wrong keychain entry on dual-install machines.
   if (browserId) {
     const id = normalizeBrowserId(browserId);
-    if (id === 'helium') {
-      if (platform === 'darwin') return path.join(home, 'Library', 'Application Support', 'net.imput.helium');
-      return undefined;
-    }
-    // id === 'chrome' falls through to the default detection below.
+    if (id === 'chrome')  return chromeUserDataDir();
+    if (id === 'helium')  return heliumUserDataDir();
   }
 
-  if (platform === 'darwin') {
-    const chrome = path.join(home, 'Library', 'Application Support', 'Google', 'Chrome');
-    if (existsSync(chrome)) return chrome;
-    // Fall back to Helium if Chrome isn't installed.
-    const helium = path.join(home, 'Library', 'Application Support', 'net.imput.helium');
-    if (existsSync(helium)) return helium;
+  // No explicit browser: pick the first installed browser we know about on
+  // macOS, else fall back to Chrome's canonical path (so the error messages
+  // downstream stay stable).
+  if (os.platform() === 'darwin') {
+    const chrome = chromeUserDataDir();
+    if (chrome && existsSync(chrome)) return chrome;
+    const helium = heliumUserDataDir();
+    if (helium && existsSync(helium)) return helium;
     return chrome;
   }
-  if (platform === 'linux') return path.join(home, '.config', 'google-chrome');
-  if (platform === 'win32') return path.join(home, 'AppData', 'Local', 'Google', 'Chrome', 'User Data');
-  return undefined;
+  return chromeUserDataDir();
 }
 
 export function loadChromeSessionConfig(overrides: { browserId?: string } = {}): ChromeSessionConfig {
   loadEnv();
-  const browserId = overrides.browserId ?? process.env.FT_BROWSER;
-  const dir = process.env.FT_CHROME_USER_DATA_DIR ?? detectChromeUserDataDir(browserId);
+
+  // Precedence: an explicit CLI --browser wins over everything else (including
+  // FT_CHROME_USER_DATA_DIR in a stale .env). Otherwise we consult
+  // FT_CHROME_USER_DATA_DIR, then FT_BROWSER, then autodetect.
+  let dir: string | undefined;
+  if (overrides.browserId) {
+    dir = detectChromeUserDataDir(overrides.browserId);
+  } else if (process.env.FT_CHROME_USER_DATA_DIR) {
+    dir = process.env.FT_CHROME_USER_DATA_DIR;
+  } else {
+    dir = detectChromeUserDataDir(process.env.FT_BROWSER);
+  }
+
   if (!dir) {
     throw new Error(
       'Could not detect a browser user-data directory.\n' +

--- a/src/graphql-bookmarks.ts
+++ b/src/graphql-bookmarks.ts
@@ -48,6 +48,8 @@ export interface SyncOptions {
   maxMinutes?: number;
   /** Consecutive pages with 0 new bookmarks before stopping. Default: 3 */
   stalePageLimit?: number;
+  /** Browser id to read session cookies from. Currently "chrome" (default) or "helium". */
+  browser?: string;
   /** Chrome user-data-dir override. */
   chromeUserDataDir?: string;
   /** Chrome profile directory name (e.g. "Default"). */
@@ -392,7 +394,7 @@ export async function syncBookmarksGraphQL(
     csrfToken = options.csrfToken;
     cookieHeader = options.cookieHeader;
   } else {
-    const chromeConfig = loadChromeSessionConfig();
+    const chromeConfig = loadChromeSessionConfig({ browserId: options.browser });
     const chromeDir = options.chromeUserDataDir ?? chromeConfig.chromeUserDataDir;
     const chromeProfile = options.chromeProfileDirectory ?? chromeConfig.chromeProfileDirectory;
     const cookies = extractChromeXCookies(chromeDir, chromeProfile);

--- a/tests/helium.test.ts
+++ b/tests/helium.test.ts
@@ -1,0 +1,114 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { loadChromeSessionConfig } from '../src/config.js';
+
+// These tests cover the Helium-support additions only. They poke the public
+// config surface rather than the internal keychain lookup (which requires
+// real Keychain access).
+
+test('loadChromeSessionConfig: --browser helium resolves to Helium user-data dir on macOS', (t) => {
+  if (process.platform !== 'darwin') {
+    t.skip('macOS-only');
+    return;
+  }
+
+  // Make sure env-var overrides don't shadow the --browser flag.
+  const saved = {
+    FT_BROWSER: process.env.FT_BROWSER,
+    FT_CHROME_USER_DATA_DIR: process.env.FT_CHROME_USER_DATA_DIR,
+    FT_CHROME_PROFILE_DIRECTORY: process.env.FT_CHROME_PROFILE_DIRECTORY,
+  };
+  delete process.env.FT_BROWSER;
+  delete process.env.FT_CHROME_USER_DATA_DIR;
+  delete process.env.FT_CHROME_PROFILE_DIRECTORY;
+
+  try {
+    const cfg = loadChromeSessionConfig({ browserId: 'helium' });
+    assert.match(cfg.chromeUserDataDir, /net\.imput\.helium$/);
+    assert.equal(cfg.chromeProfileDirectory, 'Default');
+  } finally {
+    if (saved.FT_BROWSER !== undefined) process.env.FT_BROWSER = saved.FT_BROWSER;
+    if (saved.FT_CHROME_USER_DATA_DIR !== undefined) process.env.FT_CHROME_USER_DATA_DIR = saved.FT_CHROME_USER_DATA_DIR;
+    if (saved.FT_CHROME_PROFILE_DIRECTORY !== undefined) process.env.FT_CHROME_PROFILE_DIRECTORY = saved.FT_CHROME_PROFILE_DIRECTORY;
+  }
+});
+
+test('loadChromeSessionConfig: FT_BROWSER=helium env var is honored', (t) => {
+  if (process.platform !== 'darwin') {
+    t.skip('macOS-only');
+    return;
+  }
+
+  const saved = {
+    FT_BROWSER: process.env.FT_BROWSER,
+    FT_CHROME_USER_DATA_DIR: process.env.FT_CHROME_USER_DATA_DIR,
+  };
+  delete process.env.FT_CHROME_USER_DATA_DIR;
+  process.env.FT_BROWSER = 'helium';
+
+  try {
+    const cfg = loadChromeSessionConfig();
+    assert.match(cfg.chromeUserDataDir, /net\.imput\.helium$/);
+  } finally {
+    if (saved.FT_BROWSER !== undefined) process.env.FT_BROWSER = saved.FT_BROWSER;
+    else delete process.env.FT_BROWSER;
+    if (saved.FT_CHROME_USER_DATA_DIR !== undefined) process.env.FT_CHROME_USER_DATA_DIR = saved.FT_CHROME_USER_DATA_DIR;
+  }
+});
+
+test('loadChromeSessionConfig: case-insensitive browser id', (t) => {
+  if (process.platform !== 'darwin') {
+    t.skip('macOS-only');
+    return;
+  }
+
+  const savedDir = process.env.FT_CHROME_USER_DATA_DIR;
+  const savedBrowser = process.env.FT_BROWSER;
+  delete process.env.FT_CHROME_USER_DATA_DIR;
+  delete process.env.FT_BROWSER;
+  try {
+    const cfg = loadChromeSessionConfig({ browserId: 'HELIUM' });
+    assert.match(cfg.chromeUserDataDir, /net\.imput\.helium$/);
+  } finally {
+    if (savedDir !== undefined) process.env.FT_CHROME_USER_DATA_DIR = savedDir;
+    if (savedBrowser !== undefined) process.env.FT_BROWSER = savedBrowser;
+  }
+});
+
+test('loadChromeSessionConfig: unknown browser id throws a helpful error', () => {
+  const saved = process.env.FT_CHROME_USER_DATA_DIR;
+  delete process.env.FT_CHROME_USER_DATA_DIR;
+  try {
+    assert.throws(
+      () => loadChromeSessionConfig({ browserId: 'bogus' }),
+      /Unknown browser: "bogus"[\s\S]*Supported browsers: chrome, helium/,
+    );
+  } finally {
+    if (saved !== undefined) process.env.FT_CHROME_USER_DATA_DIR = saved;
+  }
+});
+
+test('loadChromeSessionConfig: no browserId falls back to Chrome default on macOS', (t) => {
+  if (process.platform !== 'darwin') {
+    t.skip('macOS-only');
+    return;
+  }
+
+  const saved = {
+    FT_BROWSER: process.env.FT_BROWSER,
+    FT_CHROME_USER_DATA_DIR: process.env.FT_CHROME_USER_DATA_DIR,
+  };
+  delete process.env.FT_BROWSER;
+  delete process.env.FT_CHROME_USER_DATA_DIR;
+
+  try {
+    const cfg = loadChromeSessionConfig();
+    // When Chrome is installed, detection picks Chrome; otherwise it falls
+    // back to Helium. Accept either so the test is portable across CI
+    // machines.
+    assert.match(cfg.chromeUserDataDir, /Google\/Chrome$|net\.imput\.helium$/);
+  } finally {
+    if (saved.FT_BROWSER !== undefined) process.env.FT_BROWSER = saved.FT_BROWSER;
+    if (saved.FT_CHROME_USER_DATA_DIR !== undefined) process.env.FT_CHROME_USER_DATA_DIR = saved.FT_CHROME_USER_DATA_DIR;
+  }
+});

--- a/tests/helium.test.ts
+++ b/tests/helium.test.ts
@@ -75,6 +75,29 @@ test('loadChromeSessionConfig: case-insensitive browser id', (t) => {
   }
 });
 
+test('loadChromeSessionConfig: --browser chrome always returns Chrome path, even if Chrome is not installed', (t) => {
+  // Regression: an explicit --browser choice must never silently fall back
+  // to a different browser (cursor-bot on #13).
+  if (process.platform !== 'darwin') {
+    t.skip('macOS-only');
+    return;
+  }
+  const saved = {
+    FT_BROWSER: process.env.FT_BROWSER,
+    FT_CHROME_USER_DATA_DIR: process.env.FT_CHROME_USER_DATA_DIR,
+  };
+  delete process.env.FT_BROWSER;
+  delete process.env.FT_CHROME_USER_DATA_DIR;
+  try {
+    const cfg = loadChromeSessionConfig({ browserId: 'chrome' });
+    assert.match(cfg.chromeUserDataDir, /Google\/Chrome$/);
+    assert.doesNotMatch(cfg.chromeUserDataDir, /net\.imput\.helium/);
+  } finally {
+    if (saved.FT_BROWSER !== undefined) process.env.FT_BROWSER = saved.FT_BROWSER;
+    if (saved.FT_CHROME_USER_DATA_DIR !== undefined) process.env.FT_CHROME_USER_DATA_DIR = saved.FT_CHROME_USER_DATA_DIR;
+  }
+});
+
 test('loadChromeSessionConfig: unknown browser id throws a helpful error', () => {
   const saved = process.env.FT_CHROME_USER_DATA_DIR;
   delete process.env.FT_CHROME_USER_DATA_DIR;


### PR DESCRIPTION
## Summary

Adds support for syncing bookmarks from [Helium](https://helium.computer/) — a Chromium fork from imput.net — via `ft sync`. Today Helium fails with a `bad decrypt` / "Safe Storage password not found" error because it stores its v10 cookie-encryption key under a non-`* Safe Storage` Keychain entry (`service="Helium Storage Key", account="Helium"`). The underlying encryption scheme is identical to Chrome's (AES-128-CBC, PBKDF2 `saltysalt`/1003/SHA-1, db version ≥ 24 SHA256 prefix strip), so once the right key is loaded the existing cookie code works unchanged.

## Changes

- **`--browser <name>` flag + `FT_BROWSER` env var** on `ft sync`. Accepts `chrome` (default) or `helium`; unknown values throw a helpful error listing supported ids.
- **Auto-detect Helium** as a macOS fallback in `detectChromeUserDataDir` when `~/Library/Application Support/Google/Chrome` doesn't exist. Machines with Chrome installed behave exactly as before.
- **Keychain selection** in `getMacOSChromeKey(userDataDir)` now detects Helium paths (`net.imput.helium`) and tries *only* Helium's keychain entry. This is important on machines where both Chrome and Helium are installed — otherwise the iteration picks up Chrome's Safe Storage key first and fails with `bad decrypt`.
- Small plumbing to thread `options.browser` from `cli.ts` → `syncBookmarksGraphQL` → `loadChromeSessionConfig`.

Diff surface: ~70 lines across 4 files + a new `tests/helium.test.ts`.

## Why a `--browser` flag (vs. just a path)

Users can already pass `--chrome-user-data-dir /path/to/net.imput.helium` — and that now works too — but a named flag is much friendlier for the common case ("I use Helium"), plus it lets us pin the correct keychain entry by id instead of by path heuristics. The flag is intentionally scoped to browsers that have been live-tested; see the follow-up issue for expanding the list.

## Test plan

- [x] `npm test` — 4 new Helium tests pass, existing 55 tests unchanged (5 pre-existing failures in `bookmarks-db.test.ts` are present on `main` and unrelated).
- [x] Live-tested on macOS 14 with Helium + Chrome both installed:
  - `ft sync --browser helium` → syncs
  - `FT_BROWSER=helium ft sync` → syncs
  - `ft sync --browser HELIUM` → syncs (case-insensitive)
  - `ft sync --browser bogus` → errors with `Unknown browser: "bogus". Supported browsers: chrome, helium.`
  - `ft sync` (bare, Chrome installed) → unchanged behavior
  - `ft sync --chrome-user-data-dir ~/Library/Application\ Support/net.imput.helium` → syncs (path-based detection)
  - `ft sync --browser helium --chrome-profile-directory "Profile 1"` → reads the correct Helium profile
- [x] Verified decrypt succeeds on Helium DB version 24 (v10 + SHA256 prefix).

## Follow-up

A separate issue will propose consolidating this and the existing Chrome/Chromium/Brave keychain lookups behind a small browser registry, and expanding coverage to Arc, Vivaldi, Edge, and Linux/Windows paths. Kept out of this PR to keep the diff small and every supported browser live-tested.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes macOS keychain selection and session config resolution; mistakes could break cookie decryption or pick the wrong profile on dual-install machines.
> 
> **Overview**
> Adds Helium (a Chromium fork) as a supported browser for cookie-based `ft sync`, via a new `--browser` flag and `FT_BROWSER` env var that thread through the GraphQL sync path.
> 
> Updates macOS cookie decryption to select Helium’s distinct Keychain entry when the provided user-data dir indicates a Helium profile, and expands user-data-dir detection/precedence rules to avoid silent fallbacks when a browser is explicitly chosen.
> 
> Includes new unit tests covering Helium config resolution, case-insensitive ids, explicit-browser precedence, and unknown-browser errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9af4dd8c1788cd780743730aae71d2ffbd2f4623. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->