### PR TITLE
feat: add explicit LLM engine selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,12 +34,13 @@ On first run, `ft sync` extracts your X session from Chrome and downloads your b
 | Command | Description |
 |---------|-------------|
 | `ft sync` | Download and sync all bookmarks (no API required) |
-| `ft sync --classify` | Sync then classify new bookmarks with LLM |
+| `ft sync --classify [--engine <auto\|claude\|codex>]` | Sync then classify new bookmarks with LLM |
 | `ft sync --full` | Full history crawl (not just incremental) |
 | `ft search <query>` | Full-text search with BM25 ranking |
 | `ft viz` | Terminal dashboard with sparklines, categories, and domains |
-| `ft classify` | Classify by category and domain using LLM |
+| `ft classify [--engine <auto\|claude\|codex>]` | Classify by category and domain using LLM |
 | `ft classify --regex` | Classify by category using simple regex |
+| `ft classify-domains [--engine <auto\|claude\|codex>]` | Classify bookmarks by subject domain using LLM |
 | `ft categories` | Show category distribution |
 | `ft domains` | Subject domain distribution |
 | `ft stats` | Top authors, languages, date range |
@@ -74,6 +75,8 @@ Works with Claude Code, Codex, or any agent with shell access. Just tell your ag
 0 7 * * * ft sync --classify
 ```
 
+LLM classification defaults to `--engine auto`, which preserves the current behavior: prefer Claude when available, otherwise use Codex. If you explicitly pass `--engine claude` or `--engine codex`, Field Theory will fail immediately if that CLI is not installed or not on your `PATH`.
+
 ## Data
 
 All data is stored locally at `~/.ft-bookmarks/`:
@@ -107,6 +110,14 @@ To remove all data: `rm -rf ~/.ft-bookmarks`
 | **commerce** | Products, shopping, physical goods |
 
 Use `ft classify` for LLM-powered classification that catches what regex misses.
+
+Examples:
+
+```bash
+ft classify --engine claude
+ft classify-domains --engine codex
+ft sync --classify --engine auto
+```
 
 ## Platform support
 

--- a/src/bookmark-classify-llm.ts
+++ b/src/bookmark-classify-llm.ts
@@ -27,18 +27,45 @@ interface LlmClassification {
 
 // ── Engine detection ────────────────────────────────────────────────────
 
-type Engine = 'claude' | 'codex';
+export const LLM_ENGINE_CHOICES = ['auto', 'claude', 'codex'] as const;
+export type LlmEngineSelection = typeof LLM_ENGINE_CHOICES[number];
+type Engine = Exclude<LlmEngineSelection, 'auto'>;
 
-function detectEngine(): Engine | null {
+function isEngineAvailable(engine: Engine): boolean {
   try {
-    execFileSync('which', ['claude'], { stdio: 'ignore' });
-    return 'claude';
-  } catch { /* not found */ }
-  try {
-    execFileSync('which', ['codex'], { stdio: 'ignore' });
-    return 'codex';
-  } catch { /* not found */ }
-  return null;
+    execFileSync('which', [engine], { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function getNoSupportedEngineError(): Error {
+  return new Error(
+    'No supported LLM CLI found.\n' +
+    'Install one of the following and log in:\n' +
+    '  - Claude Code: https://docs.anthropic.com/en/docs/claude-code\n' +
+    '  - Codex CLI:   https://github.com/openai/codex'
+  );
+}
+
+export function resolveLlmEngine(
+  selection: LlmEngineSelection = 'auto',
+  isAvailable: (engine: Engine) => boolean = isEngineAvailable,
+): Engine {
+  if (selection === 'auto') {
+    if (isAvailable('claude')) return 'claude';
+    if (isAvailable('codex')) return 'codex';
+    throw getNoSupportedEngineError();
+  }
+
+  if (isAvailable(selection)) return selection;
+
+  const alternatives = LLM_ENGINE_CHOICES.filter((engine) => engine !== selection).join('|');
+  throw new Error(
+    `Requested LLM engine "${selection}" is not available in PATH.\n` +
+    `Install it and log in, or choose a different engine with --engine ${alternatives}.`
+  );
 }
 
 function invokeEngine(engine: Engine, prompt: string): string {
@@ -139,17 +166,9 @@ export interface LlmClassifyResult {
 }
 
 export async function classifyWithLlm(
-  options: { onBatch?: (done: number, total: number) => void } = {},
+  options: { engine?: LlmEngineSelection; onBatch?: (done: number, total: number) => void } = {},
 ): Promise<LlmClassifyResult> {
-  const engine = detectEngine();
-  if (!engine) {
-    throw new Error(
-      'No supported LLM CLI found.\n' +
-      'Install one of the following and log in:\n' +
-      '  - Claude Code: https://docs.anthropic.com/en/docs/claude-code\n' +
-      '  - Codex CLI:   https://github.com/openai/codex'
-    );
-  }
+  const engine = resolveLlmEngine(options.engine);
 
   const dbPath = twitterBookmarksIndexPath();
   const db = await openDb(dbPath);
@@ -260,17 +279,9 @@ ${items}`;
 }
 
 export async function classifyDomainsWithLlm(
-  options: { all?: boolean; onBatch?: (done: number, total: number) => void } = {},
+  options: { engine?: LlmEngineSelection; all?: boolean; onBatch?: (done: number, total: number) => void } = {},
 ): Promise<LlmClassifyResult> {
-  const engine = detectEngine();
-  if (!engine) {
-    throw new Error(
-      'No supported LLM CLI found.\n' +
-      'Install one of the following and log in:\n' +
-      '  - Claude Code: https://docs.anthropic.com/en/docs/claude-code\n' +
-      '  - Codex CLI:   https://github.com/openai/codex'
-    );
-  }
+  const engine = resolveLlmEngine(options.engine);
 
   const dbPath = twitterBookmarksIndexPath();
   const db = await openDb(dbPath);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { Command } from 'commander';
+import { Command, Option } from 'commander';
 import { syncTwitterBookmarks } from './bookmarks.js';
 import { getBookmarkStatusView, formatBookmarkStatus } from './bookmarks-service.js';
 import { runTwitterOAuthFlow } from './xauth.js';
@@ -19,7 +19,13 @@ import {
   getBookmarkById,
 } from './bookmarks-db.js';
 import { formatClassificationSummary } from './bookmark-classify.js';
-import { classifyWithLlm, classifyDomainsWithLlm } from './bookmark-classify-llm.js';
+import {
+  LLM_ENGINE_CHOICES,
+  classifyWithLlm,
+  classifyDomainsWithLlm,
+  resolveLlmEngine,
+} from './bookmark-classify-llm.js';
+import type { LlmEngineSelection } from './bookmark-classify-llm.js';
 import { renderViz } from './bookmarks-viz.js';
 import { dataDir, ensureDataDir, isFirstRun, twitterBookmarksIndexPath } from './paths.js';
 import fs from 'node:fs';
@@ -170,6 +176,18 @@ function safe(fn: (...args: any[]) => Promise<void>): (...args: any[]) => Promis
   };
 }
 
+export function addLlmEngineOption<T extends Command>(
+  command: T,
+  description = 'LLM engine to use (auto prefers claude, then codex)'
+): T {
+  command.addOption(
+    new Option('--engine <engine>', description)
+      .choices([...LLM_ENGINE_CHOICES])
+      .default('auto')
+  );
+  return command;
+}
+
 // ── CLI ─────────────────────────────────────────────────────────────────────
 
 export function buildCli() {
@@ -183,10 +201,11 @@ export function buildCli() {
     return idx.newRecords;
   }
 
-  async function classifyNew(): Promise<void> {
+  async function classifyNew(engine: LlmEngineSelection = 'auto'): Promise<void> {
     const start = Date.now();
     process.stderr.write('  Classifying new bookmarks (categories)...\n');
     const catResult = await classifyWithLlm({
+      engine,
       onBatch: (done: number, total: number) => {
         const pct = total > 0 ? Math.round((done / total) * 100) : 0;
         const elapsed = Math.round((Date.now() - start) / 1000);
@@ -200,6 +219,7 @@ export function buildCli() {
     const domStart = Date.now();
     process.stderr.write('  Classifying new bookmarks (domains)...\n');
     const domResult = await classifyDomainsWithLlm({
+      engine,
       all: false,
       onBatch: (done: number, total: number) => {
         const pct = total > 0 ? Math.round((done / total) * 100) : 0;
@@ -223,8 +243,9 @@ export function buildCli() {
 
   // ── sync ────────────────────────────────────────────────────────────────
 
-  program
-    .command('sync')
+  addLlmEngineOption(
+    program
+      .command('sync')
     .description('Sync bookmarks from X into your local database')
     .option('--api', 'Use OAuth v2 API instead of Chrome session', false)
     .option('--full', 'Full crawl instead of incremental sync', false)
@@ -234,7 +255,9 @@ export function buildCli() {
     .option('--delay-ms <n>', 'Delay between requests in ms', (v: string) => Number(v), 600)
     .option('--max-minutes <n>', 'Max runtime in minutes', (v: string) => Number(v), 30)
     .option('--chrome-user-data-dir <path>', 'Chrome user-data directory')
-    .option('--chrome-profile-directory <name>', 'Chrome profile name')
+    .option('--chrome-profile-directory <name>', 'Chrome profile name'),
+    'LLM engine to use with --classify (auto prefers claude, then codex)'
+  )
     .action(async (options) => {
       const firstRun = isFirstRun();
       if (firstRun) showSyncWelcome();
@@ -243,6 +266,8 @@ export function buildCli() {
       try {
         const useApi = Boolean(options.api);
         const mode = Boolean(options.full) ? 'full' : 'incremental';
+        const llmEngine = (options.engine ?? 'auto') as LlmEngineSelection;
+        if (options.classify) resolveLlmEngine(llmEngine);
 
         if (useApi) {
           const result = await syncTwitterBookmarks(mode, {
@@ -252,7 +277,7 @@ export function buildCli() {
           console.log(`  \u2713 Data: ${dataDir()}\n`);
           const newCount = await rebuildIndex(result.added);
           if (options.classify && newCount > 0) {
-            await classifyNew();
+            await classifyNew(llmEngine);
           }
         } else {
           const startTime = Date.now();
@@ -276,7 +301,7 @@ export function buildCli() {
 
           const newCount = await rebuildIndex(result.added);
           if (options.classify && newCount > 0) {
-            await classifyNew();
+            await classifyNew(llmEngine);
           }
         }
 
@@ -431,10 +456,13 @@ export function buildCli() {
 
   // ── classify ────────────────────────────────────────────────────────────
 
-  program
-    .command('classify')
+  addLlmEngineOption(
+    program
+      .command('classify')
     .description('Classify bookmarks by category and domain using LLM (requires claude or codex CLI)')
-    .option('--regex', 'Use simple regex classification instead of LLM')
+    .option('--regex', 'Use simple regex classification instead of LLM'),
+    'LLM engine to use (auto prefers claude, then codex)'
+  )
     .action(safe(async (options) => {
       if (!requireData()) return;
       if (options.regex) {
@@ -446,6 +474,7 @@ export function buildCli() {
         let catStart = Date.now();
         process.stderr.write('Classifying categories with LLM (batches of 50, ~2 min per batch)...\n');
         const catResult = await classifyWithLlm({
+          engine: (options.engine ?? 'auto') as LlmEngineSelection,
           onBatch: (done: number, total: number) => {
             const pct = total > 0 ? Math.round((done / total) * 100) : 0;
             const elapsed = Math.round((Date.now() - catStart) / 1000);
@@ -458,6 +487,7 @@ export function buildCli() {
         let domStart = Date.now();
         process.stderr.write('\nClassifying domains with LLM (batches of 50, ~2 min per batch)...\n');
         const domResult = await classifyDomainsWithLlm({
+          engine: (options.engine ?? 'auto') as LlmEngineSelection,
           all: false,
           onBatch: (done: number, total: number) => {
             const pct = total > 0 ? Math.round((done / total) * 100) : 0;
@@ -471,15 +501,19 @@ export function buildCli() {
 
   // ── classify-domains ────────────────────────────────────────────────────
 
-  program
-    .command('classify-domains')
+  addLlmEngineOption(
+    program
+      .command('classify-domains')
     .description('Classify bookmarks by subject domain using LLM (ai, finance, etc.)')
-    .option('--all', 'Re-classify all bookmarks, not just missing')
+    .option('--all', 'Re-classify all bookmarks, not just missing'),
+    'LLM engine to use (auto prefers claude, then codex)'
+  )
     .action(safe(async (options) => {
       if (!requireData()) return;
       const start = Date.now();
       process.stderr.write('Classifying bookmark domains with LLM (batches of 50, ~2 min per batch)...\n');
       const result = await classifyDomainsWithLlm({
+        engine: (options.engine ?? 'auto') as LlmEngineSelection,
         all: options.all ?? false,
         onBatch: (done: number, total: number) => {
           const pct = total > 0 ? Math.round((done / total) * 100) : 0;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -267,7 +267,7 @@ export function buildCli() {
         const useApi = Boolean(options.api);
         const mode = Boolean(options.full) ? 'full' : 'incremental';
         const llmEngine = (options.engine ?? 'auto') as LlmEngineSelection;
-        if (options.classify) resolveLlmEngine(llmEngine);
+        if (options.classify && llmEngine !== 'auto') resolveLlmEngine(llmEngine);
 
         if (useApi) {
           const result = await syncTwitterBookmarks(mode, {

--- a/tests/bookmark-classify-llm.test.ts
+++ b/tests/bookmark-classify-llm.test.ts
@@ -1,0 +1,34 @@
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+import { resolveLlmEngine } from '../src/bookmark-classify-llm.js';
+
+describe('resolveLlmEngine', () => {
+  test('prefers Claude when auto mode finds both engines', () => {
+    const engine = resolveLlmEngine('auto', () => true);
+    assert.equal(engine, 'claude');
+  });
+
+  test('falls back to Codex when Claude is unavailable in auto mode', () => {
+    const engine = resolveLlmEngine('auto', (bin) => bin === 'codex');
+    assert.equal(engine, 'codex');
+  });
+
+  test('throws when no supported engine is available in auto mode', () => {
+    assert.throws(
+      () => resolveLlmEngine('auto', () => false),
+      /No supported LLM CLI found/,
+    );
+  });
+
+  test('fails fast when Claude is explicitly requested but unavailable', () => {
+    assert.throws(
+      () => resolveLlmEngine('claude', (bin) => bin === 'codex'),
+      /Requested LLM engine "claude" is not available/,
+    );
+  });
+
+  test('returns an explicitly requested engine when available', () => {
+    const engine = resolveLlmEngine('codex', (bin) => bin === 'codex');
+    assert.equal(engine, 'codex');
+  });
+});

--- a/tests/cli-engine.test.ts
+++ b/tests/cli-engine.test.ts
@@ -1,0 +1,49 @@
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+import { Command } from 'commander';
+import { addLlmEngineOption, buildCli } from '../src/cli.js';
+
+describe('addLlmEngineOption', () => {
+  test('parses explicit engine values and defaults to auto', () => {
+    const explicit = addLlmEngineOption(new Command('classify'));
+    explicit.parse(['--engine', 'codex'], { from: 'user' });
+    assert.equal(explicit.opts().engine, 'codex');
+
+    const defaults = addLlmEngineOption(new Command('classify'));
+    defaults.parse([], { from: 'user' });
+    assert.equal(defaults.opts().engine, 'auto');
+  });
+
+  test('rejects unsupported engine values', () => {
+    const cmd = addLlmEngineOption(new Command('classify')).exitOverride();
+    assert.throws(
+      () => cmd.parse(['--engine', 'bogus'], { from: 'user' }),
+      /Allowed choices are auto, claude, codex/,
+    );
+  });
+});
+
+describe('buildCli', () => {
+  test('adds engine option help to sync, classify, and classify-domains', () => {
+    const program = buildCli();
+    const sync = program.commands.find((command) => command.name() === 'sync');
+    const classify = program.commands.find((command) => command.name() === 'classify');
+    const classifyDomains = program.commands.find((command) => command.name() === 'classify-domains');
+    const viz = program.commands.find((command) => command.name() === 'viz');
+
+    assert.ok(sync);
+    assert.ok(classify);
+    assert.ok(classifyDomains);
+    assert.ok(viz);
+
+    for (const command of [sync, classify, classifyDomains]) {
+      const engineOption = command.options.find((option) => option.long === '--engine');
+      assert.ok(engineOption);
+      assert.deepEqual(engineOption.argChoices, ['auto', 'claude', 'codex']);
+      assert.match(command.helpInformation(), /--engine <engine>/);
+      assert.match(command.helpInformation(), /choices:[\s\S]*\"auto\", \"claude\", \"codex\"/);
+    }
+
+    assert.doesNotMatch(viz.helpInformation(), /--engine <engine>/);
+  });
+});

--- a/tests/cli-engine.test.ts
+++ b/tests/cli-engine.test.ts
@@ -1,7 +1,32 @@
 import { describe, test } from 'node:test';
 import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
 import { Command } from 'commander';
 import { addLlmEngineOption, buildCli } from '../src/cli.js';
+
+function runCli(args: string[], ftDataDir: string) {
+  const result = spawnSync(
+    process.execPath,
+    ['node_modules/tsx/dist/cli.mjs', 'src/cli.ts', ...args],
+    {
+      cwd: process.cwd(),
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        FT_DATA_DIR: ftDataDir,
+        PATH: '/usr/bin:/bin',
+      },
+    },
+  );
+
+  return {
+    ...result,
+    output: `${result.stdout ?? ''}${result.stderr ?? ''}`,
+  };
+}
 
 describe('addLlmEngineOption', () => {
   test('parses explicit engine values and defaults to auto', () => {
@@ -45,5 +70,31 @@ describe('buildCli', () => {
     }
 
     assert.doesNotMatch(viz.helpInformation(), /--engine <engine>/);
+  });
+
+  test('sync --classify with default auto engine does not fail fast before sync starts', () => {
+    const ftDataDir = mkdtempSync(path.join(tmpdir(), 'ft-cli-'));
+
+    try {
+      const result = runCli(['sync', '--api', '--classify'], ftDataDir);
+      assert.notEqual(result.status, 0);
+      assert.doesNotMatch(result.output, /No supported LLM CLI found/);
+      assert.match(result.output, /Missing user-context OAuth token\. Run: ft auth/);
+    } finally {
+      rmSync(ftDataDir, { recursive: true, force: true });
+    }
+  });
+
+  test('sync --classify with an explicit engine still fails fast when unavailable', () => {
+    const ftDataDir = mkdtempSync(path.join(tmpdir(), 'ft-cli-'));
+
+    try {
+      const result = runCli(['sync', '--api', '--classify', '--engine', 'claude'], ftDataDir);
+      assert.notEqual(result.status, 0);
+      assert.match(result.output, /Requested LLM engine "claude" is not available/);
+      assert.doesNotMatch(result.output, /Missing user-context OAuth token\. Run: ft auth/);
+    } finally {
+      rmSync(ftDataDir, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
## Summary
- add `--engine <auto|claude|codex>` to `ft sync --classify`
- add `--engine <auto|claude|codex>` to `ft classify` and `ft classify-domains`
- preserve existing default behavior with `auto` preferring Claude, then Codex
- fail fast when an explicitly requested engine is unavailable instead of silently falling back
- document the new flag and add focused tests for engine resolution and CLI parsing

## Test Plan
- [x] `npm run build`
- [x] `npx tsx --test tests/bookmark-classify.test.ts tests/bookmark-classify-llm.test.ts tests/cli-engine.test.ts`
- [x] `npm test` still reproduces pre-existing failures in `tests/bookmarks-db.test.ts`
- [x] verified those same `tests/bookmarks-db.test.ts` failures also occur on clean `HEAD`

## Notes
- `ft viz` is unchanged; this PR only adds explicit LLM engine selection.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: primarily CLI option plumbing and engine-selection logic, with a small behavior change to error early when a requested engine binary is missing.
> 
> **Overview**
> Adds `--engine <auto|claude|codex>` to LLM-backed flows (`ft sync --classify`, `ft classify`, `ft classify-domains`) and documents the flag/behavior in the README.
> 
> Centralizes engine detection in `resolveLlmEngine` (auto prefers Claude then Codex) and changes explicit engine requests to **fail fast** if the chosen CLI isn’t on `PATH`, with new unit tests covering engine resolution and Commander option parsing/help.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab068756989d3b358732fbd336c4438e463595e6. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->