### PR TITLE
Fix --full sync fetching hundreds of empty pages

### DIFF
--- a/src/graphql-bookmarks.ts
+++ b/src/graphql-bookmarks.ts
@@ -457,7 +457,7 @@ export async function syncBookmarksGraphQL(
       stopReason = 'caught up to newest stored bookmark';
       break;
     }
-    if (incremental && stalePages >= stalePageLimit) {
+    if (stalePages >= stalePageLimit) {
       stopReason = 'no new bookmarks (stale)';
       break;
     }


### PR DESCRIPTION
## Summary
- The stale page check (`stalePageLimit`) was gated behind `if (incremental && ...)` in `syncBookmarksGraphQL()`, so `ft sync --full` never triggered it
- This caused full syncs to fetch up to 500 pages (or hit the 30-min timeout) even after all bookmarks were already retrieved — e.g., 863 bookmarks found by page 43, but sync continued to page 500
- Removed the `incremental` guard so the stale page limit (default: 3 consecutive empty pages) applies to both incremental and full syncs

## Test plan
- [ ] Run `ft sync --full` and verify it stops shortly after the last page with new bookmarks
- [ ] Run `ft sync` (incremental) and verify it still stops correctly
- [ ] Verify existing tests pass (`npm test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small control-flow change to the GraphQL bookmark sync stop conditions to avoid unnecessary paging; limited to sync termination behavior.
> 
> **Overview**
> Fixes `syncBookmarksGraphQL()` so the `stalePageLimit` early-exit triggers for *full* syncs as well as incremental syncs, preventing `--full` runs from fetching hundreds of consecutive pages with 0 new bookmarks once the dataset is already fully retrieved.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 346775d0ffc8d9be799176d433b9930ea85043a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->