### PR TITLE
Fix `ft status` after successful GraphQL sync

### DIFF
--- a/src/bookmarks.ts
+++ b/src/bookmarks.ts
@@ -1,6 +1,6 @@
 import { ensureDir, pathExists, readJson, readJsonLines, writeJson, writeJsonLines } from './fs.js';
-import { ensureDataDir, twitterBookmarksCachePath, twitterBookmarksMetaPath } from './paths.js';
-import type { BookmarkCacheMeta, BookmarkRecord } from './types.js';
+import { ensureDataDir, twitterBackfillStatePath, twitterBookmarksCachePath, twitterBookmarksMetaPath } from './paths.js';
+import type { BookmarkBackfillState, BookmarkCacheMeta, BookmarkRecord } from './types.js';
 import { loadXApiConfig } from './config.js';
 import { loadTwitterOAuthToken } from './xauth.js';
 
@@ -231,9 +231,30 @@ export async function syncTwitterBookmarks(
 export async function getTwitterBookmarksStatus(): Promise<BookmarkCacheMeta & { cachePath: string; metaPath: string }> {
   const cachePath = twitterBookmarksCachePath();
   const metaPath = twitterBookmarksMetaPath();
-  const meta: BookmarkCacheMeta = (await pathExists(metaPath))
+  const statePath = twitterBackfillStatePath();
+  const meta = (await pathExists(metaPath))
     ? await readJson<BookmarkCacheMeta>(metaPath)
-    : { provider: 'twitter', schemaVersion: 1, totalBookmarks: 0 };
+    : undefined;
+  const state = (await pathExists(statePath))
+    ? await readJson<BookmarkBackfillState>(statePath)
+    : undefined;
+  const metaUpdatedAt = meta?.lastIncrementalSyncAt ?? meta?.lastFullSyncAt;
+  const graphQlStatusIsNewer = Boolean(
+    state?.lastRunAt && (!metaUpdatedAt || Date.parse(state.lastRunAt) > Date.parse(metaUpdatedAt))
+  );
+
+  if (!meta || graphQlStatusIsNewer) {
+    const totalBookmarks = (await readJsonLines<BookmarkRecord>(cachePath)).length;
+    return {
+      provider: 'twitter',
+      schemaVersion: meta?.schemaVersion ?? 1,
+      lastFullSyncAt: meta?.lastFullSyncAt,
+      lastIncrementalSyncAt: state?.lastRunAt ?? meta?.lastIncrementalSyncAt,
+      totalBookmarks,
+      cachePath,
+      metaPath,
+    };
+  }
 
   return {
     ...meta,

--- a/src/graphql-bookmarks.ts
+++ b/src/graphql-bookmarks.ts
@@ -1,8 +1,8 @@
 import { ensureDir, readJsonLines, writeJsonLines, readJson, writeJson, pathExists } from './fs.js';
-import { ensureDataDir, twitterBookmarksCachePath, twitterBackfillStatePath } from './paths.js';
+import { ensureDataDir, twitterBookmarksCachePath, twitterBookmarksMetaPath, twitterBackfillStatePath } from './paths.js';
 import { loadChromeSessionConfig } from './config.js';
 import { extractChromeXCookies } from './chrome-cookies.js';
-import type { BookmarkBackfillState, BookmarkRecord } from './types.js';
+import type { BookmarkBackfillState, BookmarkCacheMeta, BookmarkRecord } from './types.js';
 import { exportBookmarksForSyncSeed } from './bookmarks-db.js';
 
 const X_PUBLIC_BEARER =
@@ -402,10 +402,14 @@ export async function syncBookmarksGraphQL(
 
   ensureDataDir();
   const cachePath = twitterBookmarksCachePath();
+  const metaPath = twitterBookmarksMetaPath();
   const statePath = twitterBackfillStatePath();
   let existing = await loadExistingBookmarks();
   const newestKnownId = incremental
     ? existing.slice().sort((a, b) => compareBookmarkChronology(b, a))[0]?.id
+    : undefined;
+  const previousMeta = (await pathExists(metaPath))
+    ? await readJson<BookmarkCacheMeta>(metaPath)
     : undefined;
   const prevState: BookmarkBackfillState = (await pathExists(statePath))
     ? await readJson<BookmarkBackfillState>(statePath)
@@ -474,7 +478,15 @@ export async function syncBookmarksGraphQL(
 
   if (stopReason === 'unknown') stopReason = page >= maxPages ? 'max pages reached' : 'unknown';
 
+  const syncedAt = new Date().toISOString();
   await writeJsonLines(cachePath, existing);
+  await writeJson(metaPath, {
+    provider: 'twitter',
+    schemaVersion: 1,
+    lastFullSyncAt: incremental ? previousMeta?.lastFullSyncAt : syncedAt,
+    lastIncrementalSyncAt: incremental ? syncedAt : previousMeta?.lastIncrementalSyncAt,
+    totalBookmarks: existing.length,
+  } satisfies BookmarkCacheMeta);
   await writeJson(statePath, updateState(prevState, { added: totalAdded, seenIds: allSeenIds.slice(-20), stopReason }));
 
   options.onProgress?.({

--- a/tests/bookmarks-status.test.ts
+++ b/tests/bookmarks-status.test.ts
@@ -1,0 +1,74 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import os from 'node:os';
+import path from 'node:path';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { writeJson, writeJsonLines } from '../src/fs.js';
+import { getTwitterBookmarksStatus } from '../src/bookmarks.js';
+
+test('getTwitterBookmarksStatus falls back to GraphQL cache and state when metadata is missing', async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), 'ft-status-'));
+  process.env.FT_DATA_DIR = tmpDir;
+
+  try {
+    await writeJsonLines(path.join(tmpDir, 'bookmarks.jsonl'), [
+      { id: '1', tweetId: '1', url: 'https://x.com/alice/status/1', text: 'one', syncedAt: '2026-04-05T12:00:00Z', tags: [] },
+      { id: '2', tweetId: '2', url: 'https://x.com/bob/status/2', text: 'two', syncedAt: '2026-04-05T12:00:00Z', tags: [] },
+    ]);
+    await writeJson(path.join(tmpDir, 'bookmarks-backfill-state.json'), {
+      provider: 'twitter',
+      lastRunAt: '2026-04-05T12:34:56Z',
+      totalRuns: 1,
+      totalAdded: 2,
+      lastAdded: 2,
+      lastSeenIds: ['1', '2'],
+      stopReason: 'caught up to newest stored bookmark',
+    });
+
+    const status = await getTwitterBookmarksStatus();
+
+    assert.equal(status.totalBookmarks, 2);
+    assert.equal(status.lastIncrementalSyncAt, '2026-04-05T12:34:56Z');
+    assert.equal(status.cachePath, path.join(tmpDir, 'bookmarks.jsonl'));
+    assert.equal(status.metaPath, path.join(tmpDir, 'bookmarks-meta.json'));
+  } finally {
+    delete process.env.FT_DATA_DIR;
+    await rm(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test('getTwitterBookmarksStatus prefers newer GraphQL state over stale metadata', async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), 'ft-status-'));
+  process.env.FT_DATA_DIR = tmpDir;
+
+  try {
+    await writeJson(path.join(tmpDir, 'bookmarks-meta.json'), {
+      provider: 'twitter',
+      schemaVersion: 1,
+      lastIncrementalSyncAt: '2026-04-05T10:00:00Z',
+      totalBookmarks: 1,
+    });
+    await writeJsonLines(path.join(tmpDir, 'bookmarks.jsonl'), [
+      { id: '1', tweetId: '1', url: 'https://x.com/alice/status/1', text: 'one', syncedAt: '2026-04-05T12:00:00Z', tags: [] },
+      { id: '2', tweetId: '2', url: 'https://x.com/bob/status/2', text: 'two', syncedAt: '2026-04-05T12:00:00Z', tags: [] },
+      { id: '3', tweetId: '3', url: 'https://x.com/carol/status/3', text: 'three', syncedAt: '2026-04-05T12:00:00Z', tags: [] },
+    ]);
+    await writeJson(path.join(tmpDir, 'bookmarks-backfill-state.json'), {
+      provider: 'twitter',
+      lastRunAt: '2026-04-05T12:34:56Z',
+      totalRuns: 2,
+      totalAdded: 3,
+      lastAdded: 2,
+      lastSeenIds: ['1', '2', '3'],
+      stopReason: 'caught up to newest stored bookmark',
+    });
+
+    const status = await getTwitterBookmarksStatus();
+
+    assert.equal(status.totalBookmarks, 3);
+    assert.equal(status.lastIncrementalSyncAt, '2026-04-05T12:34:56Z');
+  } finally {
+    delete process.env.FT_DATA_DIR;
+    await rm(tmpDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
`ft sync` can succeed via the default GraphQL path, write bookmarks to disk, and make `ft search` work, while `ft status` still reports `bookmarks: 0` and `last updated: never`. This PR fixes that mismatch.

## What was broken
The default GraphQL sync path and the status path were using different metadata sources:

- `syncBookmarksGraphQL()` wrote `bookmarks.jsonl` and `bookmarks-backfill-state.json`
- `getTwitterBookmarksStatus()` only read `bookmarks-meta.json`

On a GraphQL-only install, `bookmarks-meta.json` was never created, so `ft status` fell back to the zero-bookmark default even though the cache and index were already populated.

## Why this happened
The repo has two sync implementations:

- the older API sync path, which updates `bookmarks-meta.json`
- the newer GraphQL sync path, which did not

`ft status` was still coupled to the API metadata contract, so a successful GraphQL sync left status in a stale or empty state.

## Fix
This change does two things:

- make the GraphQL sync path write `bookmarks-meta.json` so future syncs keep shared status metadata up to date
- make `getTwitterBookmarksStatus()` recover from existing installs by falling back to the GraphQL cache + backfill state when `bookmarks-meta.json` is missing or older than the most recent GraphQL run

That means existing users get correct status output immediately, and future syncs keep both metadata files aligned.

## Why this approach
- fixes already-synced installs without requiring users to delete data or resync from scratch
- preserves compatibility with the API sync path instead of introducing a new status-only code path
- keeps the data model converging on a single shared status file going forward

## Verification
- added regression coverage for missing GraphQL metadata and stale metadata fallback
- `npx tsx --test tests/bookmarks-status.test.ts tests/bookmarks-service.test.ts`
- `npm run build`
- manually verified `node bin/ft.mjs status` against a successful GraphQL sync now reports the real bookmark count and timestamp

## User-visible before/after
Before:

```
ft sync            # succeeds
ft search ...      # works
ft status          # bookmarks: 0 / last updated: never
```

After:

```
ft sync            # succeeds
ft search ...      # works
ft status          # shows the real bookmark count and last sync time
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: updates bookmark status bookkeeping and adds regression tests; main risk is minor behavior changes in how sync timestamps and counts are derived when metadata/state files disagree.
> 
> **Overview**
> Fixes `ft status` after GraphQL-based bookmark syncs by **writing `bookmarks-meta.json` during GraphQL sync** and by teaching `getTwitterBookmarksStatus()` to **fall back to `bookmarks.jsonl` + `bookmarks-backfill-state.json`** when metadata is missing or older than the latest GraphQL run.
> 
> Adds tests covering the missing-metadata fallback and the “GraphQL state newer than meta” case to prevent regressions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb4332f3186692d911853115d562faf4e2b40fe0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->