### PR TITLE
fix: add Linux cookie extraction support (v11 prefix + GNOME keyring)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Sync and store locally all of your X/Twitter bookmarks. Search, classify, and make them available to Claude Code, Codex, or any agent with shell access.
 
-Free and open source. Designed for Mac.
+Free and open source. Works on macOS and Linux.
 
 ## Install
 

--- a/src/chrome-cookies.ts
+++ b/src/chrome-cookies.ts
@@ -56,8 +56,9 @@ function getMacOSChromeKey(): Buffer {
  * determines which key to use — they are not interchangeable.
  */
 interface LinuxChromeKeys {
-  v10Key: Buffer; // "peanuts" key — for cookies with v10 prefix
-  v11Key: Buffer; // keyring key  — for cookies with v11 prefix
+  v10Key: Buffer;        // "peanuts" key — for cookies with v10 prefix
+  v11Key: Buffer | null; // keyring key  — for cookies with v11 prefix;
+                         // null when the keyring password could not be read
 }
 
 function getLinuxChromeKeys(): LinuxChromeKeys {
@@ -65,10 +66,12 @@ function getLinuxChromeKeys(): LinuxChromeKeys {
   const v10Key = pbkdf2Sync('peanuts', 'saltysalt', 1, 16, 'sha1');
 
   // v11 uses the password stored in the GNOME Secret Service.
-  // Fall back to "peanuts" if no keyring entry is found (e.g. headless systems),
-  // which means v11 cookies won't decrypt — but that matches Chrome's own
-  // behavior (it only writes v11 cookies when the keyring is available).
-  let v11Key = v10Key;
+  // Chrome writes v11 cookies only when the keyring is available, but it
+  // accesses the keyring via libsecret directly — not the secret-tool CLI.
+  // If secret-tool is absent or returns nothing we set v11Key to null so
+  // that any attempt to decrypt a v11 cookie produces a clear error rather
+  // than a silent wrong-key AES crash (ERR_OSSL_EVP_BAD_DECRYPT).
+  let v11Key: Buffer | null = null;
   try {
     const pw = execFileSync(
       'secret-tool',
@@ -77,7 +80,7 @@ function getLinuxChromeKeys(): LinuxChromeKeys {
     ).trim();
     if (pw) v11Key = pbkdf2Sync(pw, 'saltysalt', 1, 16, 'sha1');
   } catch {
-    // secret-tool not installed or no keyring entry.
+    // secret-tool not installed or no keyring entry — v11Key stays null.
   }
 
   return { v10Key, v11Key };
@@ -115,22 +118,22 @@ function sanitizeCookieValue(name: string, value: string): string {
  * Decrypt a single Chrome cookie value.
  *
  * @param encryptedValue  Raw bytes from the `encrypted_value` column.
- * @param key             AES key for `v10`-prefixed cookies (macOS) or the
- *                        caller's chosen key.  On Linux, pass the `v10Key`
- *                        here and supply `v11Key` separately.
+ * @param key             AES key for `v10`-prefixed cookies.  On macOS this
+ *                        is the only key needed.  On Linux pass `v10Key` here.
  * @param dbVersion       Chrome cookie DB schema version (from the `meta`
  *                        table); >= 24 means a 32-byte SHA256(host_key) prefix
  *                        is prepended to the plaintext (Chrome ~130+).
- * @param v11Key          Optional separate key for `v11`-prefixed cookies
- *                        (Linux keyring key).  When omitted, `key` is used
- *                        for both prefixes (correct for macOS where only
- *                        `v10` exists).
+ * @param v11Key          Key for `v11`-prefixed cookies (Linux keyring key).
+ *                        Pass `null` when the keyring password could not be
+ *                        read — a clear error is thrown rather than attempting
+ *                        decryption with the wrong key.  Omit on macOS (only
+ *                        `v10` cookies exist there).
  */
 export function decryptCookieValue(
   encryptedValue: Buffer,
   key: Buffer,
   dbVersion = 0,
-  v11Key?: Buffer,
+  v11Key?: Buffer | null,
 ): string {
   if (encryptedValue.length === 0) return '';
 
@@ -138,14 +141,40 @@ export function decryptCookieValue(
   const isV11 = encryptedValue[0] === 0x76 && encryptedValue[1] === 0x31 && encryptedValue[2] === 0x31;
 
   if (isV10 || isV11) {
+    if (isV11 && v11Key === null) {
+      // The cookie was encrypted with the GNOME keyring key, but we couldn't
+      // read the keyring password (secret-tool missing or no entry).
+      // Throwing here avoids a cryptic ERR_OSSL_EVP_BAD_DECRYPT crash.
+      throw new Error(
+        'Chrome stored this cookie with a GNOME keyring key (v11), but the\n' +
+        'keyring password could not be retrieved.\n\n' +
+        'Fix:\n' +
+        '  1. Install libsecret-tools:  sudo apt-get install libsecret-tools\n' +
+        '  2. Confirm the entry exists: secret-tool lookup application chrome\n' +
+        '  3. Or use the API method:    ft auth && ft sync --api'
+      );
+    }
+
     // On Linux v10 and v11 use different keys; on macOS only v10 exists and
-    // both parameters point to the same key.
+    // v11Key is undefined, so key is used for both (unchanged behaviour).
     const decryptKey = isV11 && v11Key ? v11Key : key;
     const iv = Buffer.alloc(16, 0x20); // 16 spaces
     const ciphertext = encryptedValue.subarray(3);
     const decipher = createDecipheriv('aes-128-cbc', decryptKey, iv);
-    let decrypted = decipher.update(ciphertext);
-    decrypted = Buffer.concat([decrypted, decipher.final()]);
+    let decrypted: Buffer;
+    try {
+      decrypted = Buffer.concat([decipher.update(ciphertext), decipher.final()]);
+    } catch (err: any) {
+      throw new Error(
+        `AES decryption failed for a ${isV11 ? 'v11' : 'v10'} cookie.\n` +
+        'This usually means the wrong key was used.\n\n' +
+        'Fix:\n' +
+        '  1. Close Chrome completely and run ft sync again\n' +
+        '  2. Confirm the keyring entry: secret-tool lookup application chrome\n' +
+        '  3. Or use the API method:     ft auth && ft sync --api\n\n' +
+        `OpenSSL detail: ${err.message}`
+      );
+    }
 
     // Chrome DB version >= 24 (Chrome ~130+) prepends SHA256(host_key) to plaintext
     if (dbVersion >= 24 && decrypted.length > 32) {
@@ -253,13 +282,14 @@ export function extractChromeXCookies(
   const dbPath = join(chromeUserDataDir, profileDirectory, 'Cookies');
 
   // On Linux, v10 and v11 cookies use different keys; derive both up front.
-  // On macOS only v10 exists, so a single key suffices (v11Key stays undefined).
+  // On macOS only v10 exists, so v11Key is left undefined (decryptCookieValue
+  // treats undefined as "same as key", which is correct for macOS).
   let key: Buffer;
-  let v11Key: Buffer | undefined;
+  let v11Key: Buffer | null | undefined;
   if (os === 'linux') {
     const linuxKeys = getLinuxChromeKeys();
     key = linuxKeys.v10Key;
-    v11Key = linuxKeys.v11Key;
+    v11Key = linuxKeys.v11Key; // Buffer when keyring found, null when not
   } else {
     key = getMacOSChromeKey();
   }

--- a/src/chrome-cookies.ts
+++ b/src/chrome-cookies.ts
@@ -44,29 +44,43 @@ function getMacOSChromeKey(): Buffer {
 }
 
 /**
- * Derive the AES key Chrome uses on Linux to encrypt cookies.
+ * The two AES keys Chrome may use on Linux, selected per-cookie by prefix:
  *
- * Chrome on Linux stores an encryption password in the GNOME Secret Service
- * (via libsecret / secret-tool) under the key `application=chrome`.  It then
- * derives a 16-byte AES-128 key with PBKDF2-HMAC-SHA1, salt "saltysalt",
- * and **1 iteration** (vs. 1003 on macOS).  When no keyring is available
- * Chrome falls back to the hard-coded password "peanuts".
+ *  - `v10` cookies were encrypted with the hard-coded password "peanuts"
+ *    (used before keyring integration, or when no keyring is available).
+ *  - `v11` cookies were encrypted with a password stored in the GNOME
+ *    Secret Service (via `secret-tool lookup application chrome`).
+ *
+ * Both use PBKDF2-HMAC-SHA1 with salt "saltysalt" and **1 iteration**
+ * (vs. 1003 on macOS).  The prefix in each cookie's encrypted_value
+ * determines which key to use — they are not interchangeable.
  */
-function getLinuxChromeKey(): Buffer {
-  // Try GNOME Secret Service first (works on GNOME / KDE with libsecret).
+interface LinuxChromeKeys {
+  v10Key: Buffer; // "peanuts" key — for cookies with v10 prefix
+  v11Key: Buffer; // keyring key  — for cookies with v11 prefix
+}
+
+function getLinuxChromeKeys(): LinuxChromeKeys {
+  // v10 always uses the hard-coded "peanuts" password.
+  const v10Key = pbkdf2Sync('peanuts', 'saltysalt', 1, 16, 'sha1');
+
+  // v11 uses the password stored in the GNOME Secret Service.
+  // Fall back to "peanuts" if no keyring entry is found (e.g. headless systems),
+  // which means v11 cookies won't decrypt — but that matches Chrome's own
+  // behavior (it only writes v11 cookies when the keyring is available).
+  let v11Key = v10Key;
   try {
     const pw = execFileSync(
       'secret-tool',
       ['lookup', 'application', 'chrome'],
       { encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'], timeout: 5000 }
     ).trim();
-    if (pw) return pbkdf2Sync(pw, 'saltysalt', 1, 16, 'sha1');
+    if (pw) v11Key = pbkdf2Sync(pw, 'saltysalt', 1, 16, 'sha1');
   } catch {
-    // secret-tool not installed or no entry — fall through to hard-coded default.
+    // secret-tool not installed or no keyring entry.
   }
 
-  // Chrome's hard-coded fallback password when no keyring is present.
-  return pbkdf2Sync('peanuts', 'saltysalt', 1, 16, 'sha1');
+  return { v10Key, v11Key };
 }
 
 function sanitizeCookieValue(name: string, value: string): string {
@@ -97,18 +111,39 @@ function sanitizeCookieValue(name: string, value: string): string {
   return cleaned;
 }
 
-export function decryptCookieValue(encryptedValue: Buffer, key: Buffer, dbVersion = 0): string {
+/**
+ * Decrypt a single Chrome cookie value.
+ *
+ * @param encryptedValue  Raw bytes from the `encrypted_value` column.
+ * @param key             AES key for `v10`-prefixed cookies (macOS) or the
+ *                        caller's chosen key.  On Linux, pass the `v10Key`
+ *                        here and supply `v11Key` separately.
+ * @param dbVersion       Chrome cookie DB schema version (from the `meta`
+ *                        table); >= 24 means a 32-byte SHA256(host_key) prefix
+ *                        is prepended to the plaintext (Chrome ~130+).
+ * @param v11Key          Optional separate key for `v11`-prefixed cookies
+ *                        (Linux keyring key).  When omitted, `key` is used
+ *                        for both prefixes (correct for macOS where only
+ *                        `v10` exists).
+ */
+export function decryptCookieValue(
+  encryptedValue: Buffer,
+  key: Buffer,
+  dbVersion = 0,
+  v11Key?: Buffer,
+): string {
   if (encryptedValue.length === 0) return '';
 
-  // Prefix is "v10" (macOS) or "v11" (Linux). Both use the same AES-128-CBC
-  // scheme; only the key-derivation parameters differ between platforms.
   const isV10 = encryptedValue[0] === 0x76 && encryptedValue[1] === 0x31 && encryptedValue[2] === 0x30;
   const isV11 = encryptedValue[0] === 0x76 && encryptedValue[1] === 0x31 && encryptedValue[2] === 0x31;
 
   if (isV10 || isV11) {
+    // On Linux v10 and v11 use different keys; on macOS only v10 exists and
+    // both parameters point to the same key.
+    const decryptKey = isV11 && v11Key ? v11Key : key;
     const iv = Buffer.alloc(16, 0x20); // 16 spaces
     const ciphertext = encryptedValue.subarray(3);
-    const decipher = createDecipheriv('aes-128-cbc', key, iv);
+    const decipher = createDecipheriv('aes-128-cbc', decryptKey, iv);
     let decrypted = decipher.update(ciphertext);
     decrypted = Buffer.concat([decrypted, decipher.final()]);
 
@@ -216,7 +251,18 @@ export function extractChromeXCookies(
   }
 
   const dbPath = join(chromeUserDataDir, profileDirectory, 'Cookies');
-  const key = os === 'linux' ? getLinuxChromeKey() : getMacOSChromeKey();
+
+  // On Linux, v10 and v11 cookies use different keys; derive both up front.
+  // On macOS only v10 exists, so a single key suffices (v11Key stays undefined).
+  let key: Buffer;
+  let v11Key: Buffer | undefined;
+  if (os === 'linux') {
+    const linuxKeys = getLinuxChromeKeys();
+    key = linuxKeys.v10Key;
+    v11Key = linuxKeys.v11Key;
+  } else {
+    key = getMacOSChromeKey();
+  }
 
   let result = queryCookies(dbPath, '.x.com', ['ct0', 'auth_token']);
   if (result.cookies.length === 0) {
@@ -228,7 +274,7 @@ export function extractChromeXCookies(
     const hexVal = cookie.encrypted_value_hex;
     if (hexVal && hexVal.length > 0) {
       const buf = Buffer.from(hexVal, 'hex');
-      decrypted.set(cookie.name, decryptCookieValue(buf, key, result.dbVersion));
+      decrypted.set(cookie.name, decryptCookieValue(buf, key, result.dbVersion, v11Key));
     } else if (cookie.value) {
       decrypted.set(cookie.name, cookie.value);
     }

--- a/src/chrome-cookies.ts
+++ b/src/chrome-cookies.ts
@@ -43,6 +43,32 @@ function getMacOSChromeKey(): Buffer {
   );
 }
 
+/**
+ * Derive the AES key Chrome uses on Linux to encrypt cookies.
+ *
+ * Chrome on Linux stores an encryption password in the GNOME Secret Service
+ * (via libsecret / secret-tool) under the key `application=chrome`.  It then
+ * derives a 16-byte AES-128 key with PBKDF2-HMAC-SHA1, salt "saltysalt",
+ * and **1 iteration** (vs. 1003 on macOS).  When no keyring is available
+ * Chrome falls back to the hard-coded password "peanuts".
+ */
+function getLinuxChromeKey(): Buffer {
+  // Try GNOME Secret Service first (works on GNOME / KDE with libsecret).
+  try {
+    const pw = execFileSync(
+      'secret-tool',
+      ['lookup', 'application', 'chrome'],
+      { encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'], timeout: 5000 }
+    ).trim();
+    if (pw) return pbkdf2Sync(pw, 'saltysalt', 1, 16, 'sha1');
+  } catch {
+    // secret-tool not installed or no entry — fall through to hard-coded default.
+  }
+
+  // Chrome's hard-coded fallback password when no keyring is present.
+  return pbkdf2Sync('peanuts', 'saltysalt', 1, 16, 'sha1');
+}
+
 function sanitizeCookieValue(name: string, value: string): string {
   const cleaned = value.replace(/\0+$/g, '').trim();
   if (!cleaned) {
@@ -74,7 +100,12 @@ function sanitizeCookieValue(name: string, value: string): string {
 export function decryptCookieValue(encryptedValue: Buffer, key: Buffer, dbVersion = 0): string {
   if (encryptedValue.length === 0) return '';
 
-  if (encryptedValue[0] === 0x76 && encryptedValue[1] === 0x31 && encryptedValue[2] === 0x30) {
+  // Prefix is "v10" (macOS) or "v11" (Linux). Both use the same AES-128-CBC
+  // scheme; only the key-derivation parameters differ between platforms.
+  const isV10 = encryptedValue[0] === 0x76 && encryptedValue[1] === 0x31 && encryptedValue[2] === 0x30;
+  const isV11 = encryptedValue[0] === 0x76 && encryptedValue[1] === 0x31 && encryptedValue[2] === 0x31;
+
+  if (isV10 || isV11) {
     const iv = Buffer.alloc(16, 0x20); // 16 spaces
     const ciphertext = encryptedValue.subarray(3);
     const decipher = createDecipheriv('aes-128-cbc', key, iv);
@@ -176,16 +207,16 @@ export function extractChromeXCookies(
   profileDirectory = 'Default'
 ): ChromeCookieResult {
   const os = platform();
-  if (os !== 'darwin') {
+  if (os !== 'darwin' && os !== 'linux') {
     throw new Error(
-      `Direct cookie extraction is currently supported on macOS only.\n` +
+      `Direct cookie extraction is supported on macOS and Linux only.\n` +
       `Detected platform: ${os}\n` +
-      'Fix: Pass --csrf-token and --cookie-header directly, or contribute Linux/Windows support.'
+      'Fix: Pass --csrf-token and --cookie-header directly, or contribute Windows support.'
     );
   }
 
   const dbPath = join(chromeUserDataDir, profileDirectory, 'Cookies');
-  const key = getMacOSChromeKey();
+  const key = os === 'linux' ? getLinuxChromeKey() : getMacOSChromeKey();
 
   let result = queryCookies(dbPath, '.x.com', ['ct0', 'auth_token']);
   if (result.cookies.length === 0) {


### PR DESCRIPTION
## What was broken on Linux

`ft sync` failed on Linux with two distinct bugs:

### Bug 1 — `v11` cookie prefix not handled in `decryptCookieValue`

Chrome on **Linux** stores cookies with a `v11` byte prefix (`76 31 31`), while Chrome on **macOS** uses `v10` (`76 31 30`).  The decryption guard in `decryptCookieValue` only checked for `v10`:

```ts
if (encryptedValue[0] === 0x76 && encryptedValue[1] === 0x31 && encryptedValue[2] === 0x30) {
```

`v11` cookies fell through to `return encryptedValue.toString('utf8')`, returning raw binary ciphertext.  The downstream printable-ASCII sanity check then threw:

```
Error: Could not decrypt the ct0 cookie.
```

Both prefixes use the same AES-128-CBC scheme (same IV, same algorithm) — only key derivation differs by platform.

### Bug 2 — `extractChromeXCookies` hard-blocked on non-macOS

```ts
if (os !== 'darwin') {
  throw new Error('Direct cookie extraction is currently supported on macOS only.');
}
```

This threw before any decryption was attempted, surfacing to the user as:

```
Couldn't connect to your Chrome session.
```

## Fix

- **`decryptCookieValue`**: accept both `v10` and `v11` prefixes.
- **`getLinuxChromeKey()`** (new): reads the encryption password from the GNOME Secret Service via `secret-tool lookup application chrome` (PBKDF2-HMAC-SHA1, salt `"saltysalt"`, **1 iteration** — vs. 1003 on macOS), falling back to Chrome's hard-coded default `"peanuts"` when no keyring is present.
- **`extractChromeXCookies`**: allow `linux` platform and select the right key function.
- **README**: updated to say "macOS and Linux" instead of "Designed for Mac."

## Test environment

- Ubuntu 24.04, Google Chrome 130+ (cookie DB version 24)
- DB version 24 prepends a 32-byte `SHA256(host_key)` to the plaintext — already stripped by the existing `dbVersion >= 24` guard, no change needed there.
- 53 bookmarks successfully synced end-to-end after the fix.

## Notes for reviewers

- `secret-tool` is part of `libsecret-tools` (available in all major distros).  The fallback to `"peanuts"` handles headless / no-keyring environments.
- No changes to the macOS path.
- Windows is still unsupported (unchanged).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes cookie decryption/key derivation and adds Linux-specific subprocess calls (`secret-tool`) that may behave differently across environments.
> 
> **Overview**
> Extends direct Chrome-session cookie extraction to **Linux** by deriving both `v10` ("peanuts") and `v11` (GNOME keyring via `secret-tool`) AES keys and selecting the correct key based on the cookie prefix.
> 
> Updates `decryptCookieValue` to handle `v11`-prefixed cookies (and optionally accept a separate `v11` key), relaxes the OS gate in `extractChromeXCookies` to allow Linux, and tweaks README messaging to state macOS+Linux support.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f977bbd111ac2fdcd2738e9f1ebbecc8a99408bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->