### PR TITLE
Add bookmark folder sync for classified bookmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ On first run, `ft sync` extracts your X session from Chrome and downloads your b
 | Command | Description |
 |---------|-------------|
 | `ft sync` | Download and sync bookmarks (no API required) |
+| `ft sync --folders` | Sync bookmarks, then push local classifications into X bookmark folders |
 | `ft sync --full` | Full history crawl (not just incremental) |
 | `ft sync --gaps` | Backfill missing quoted tweets and expand truncated articles |
 | `ft sync --classify` | Sync then classify new bookmarks with LLM |
@@ -110,6 +111,27 @@ Then ask your agent:
 
 Works with Claude Code, Codex, or any agent with shell access.
 
+## Folder sync
+
+Use your local classifications to organize bookmarks back into X bookmark folders:
+
+```bash
+# Sync inbound bookmarks, then make bounded folder progress
+ft sync --folders
+
+# Preview the broad folders that would be created
+ft folders sync --dry-run
+
+# Resume the backlog until everything eligible has been assigned
+ft folders sync --until-done
+```
+
+Defaults:
+
+- Organizes by `primary_domain`
+- Only creates broad folders with at least 100 bookmarks
+- Adds missing bookmark-to-folder assignments only; it never removes bookmarks from folders
+
 ## Scheduling
 
 ```bash
@@ -118,6 +140,9 @@ Works with Claude Code, Codex, or any agent with shell access.
 
 # Sync and classify every morning
 0 7 * * * ft sync --classify
+
+# Sync inbound bookmarks and make bounded folder progress every morning
+0 7 * * * ft sync --folders
 ```
 
 ## Data

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "test": "tsx --test tests/**/*.test.ts",
+    "test": "tsx --test --test-concurrency 1 tests/**/*.test.ts",
     "dev": "tsx src/cli.ts",
     "start": "node dist/cli.js",
     "prepublishOnly": "npm run build"

--- a/src/bookmarks-db.ts
+++ b/src/bookmarks-db.ts
@@ -6,7 +6,7 @@ import type { BookmarkRecord, QuotedTweetSnapshot } from './types.js';
 import { classifyCorpus, formatClassificationSummary } from './bookmark-classify.js';
 import type { ClassificationSummary } from './bookmark-classify.js';
 
-const SCHEMA_VERSION = 4;
+const SCHEMA_VERSION = 5;
 
 export interface SearchResult {
   id: string;
@@ -213,6 +213,24 @@ function initSchema(db: Database): void {
     tokenize='porter unicode61'
   )`);
 
+  db.run(`CREATE TABLE IF NOT EXISTS x_bookmark_folders (
+    label TEXT PRIMARY KEY,
+    folder_name TEXT NOT NULL,
+    folder_id TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+  )`);
+
+  db.run(`CREATE TABLE IF NOT EXISTS x_bookmark_folder_sync (
+    tweet_id TEXT PRIMARY KEY,
+    label TEXT NOT NULL,
+    folder_id TEXT NOT NULL,
+    status TEXT NOT NULL,
+    attempt_count INTEGER NOT NULL DEFAULT 0,
+    last_error TEXT,
+    last_attempted_at TEXT,
+    completed_at TEXT
+  )`);
+
   db.run(`REPLACE INTO meta VALUES ('schema_version', '${SCHEMA_VERSION}')`);
 }
 
@@ -236,9 +254,34 @@ function ensureMigrations(db: Database): void {
       try { db.run('ALTER TABLE bookmarks ADD COLUMN quoted_tweet_json TEXT'); } catch { /* already exists */ }
     }
   }
+  if (version < 5) {
+    db.run(`CREATE TABLE IF NOT EXISTS x_bookmark_folders (
+      label TEXT PRIMARY KEY,
+      folder_name TEXT NOT NULL,
+      folder_id TEXT NOT NULL,
+      updated_at TEXT NOT NULL
+    )`);
+    db.run(`CREATE TABLE IF NOT EXISTS x_bookmark_folder_sync (
+      tweet_id TEXT PRIMARY KEY,
+      label TEXT NOT NULL,
+      folder_id TEXT NOT NULL,
+      status TEXT NOT NULL,
+      attempt_count INTEGER NOT NULL DEFAULT 0,
+      last_error TEXT,
+      last_attempted_at TEXT,
+      completed_at TEXT
+    )`);
+  }
   if (version < SCHEMA_VERSION) {
     db.run(`REPLACE INTO meta VALUES ('schema_version', '${SCHEMA_VERSION}')`);
   }
+}
+
+export async function openBookmarksIndexDb(): Promise<Database> {
+  const dbPath = twitterBookmarksIndexPath();
+  const db = await openDb(dbPath);
+  ensureMigrations(db);
+  return db;
 }
 
 interface PreservedBookmarkFields {

--- a/src/bookmarks-db.ts
+++ b/src/bookmarks-db.ts
@@ -248,6 +248,7 @@ function ensureMigrations(db: Database): void {
       db.run('CREATE INDEX IF NOT EXISTS idx_bookmarks_domain ON bookmarks(primary_domain)');
     }
   }
+
   if (version < 4) {
     const tableExists = db.exec("SELECT name FROM sqlite_master WHERE type='table' AND name='bookmarks'");
     if (tableExists.length && tableExists[0].values.length > 0) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -31,6 +31,13 @@ import { listBrowserIds } from './browsers.js';
 import { dataDir, ensureDataDir, isFirstRun, twitterBookmarksIndexPath, twitterBackfillStatePath, mdDir } from './paths.js';
 import { PromptCancelledError, promptText } from './prompt.js';
 import { skillWithFrontmatter, installSkill, uninstallSkill } from './skill.js';
+import {
+  syncBookmarkFolders,
+  formatBookmarkFolderSyncResult,
+  type FolderBy,
+  type BookmarkFolderSyncProgress,
+  type BookmarkFolderSyncOptions,
+} from './x-bookmark-folders.js';
 import fs from 'node:fs';
 import path from 'node:path';
 import { createRequire } from 'node:module';
@@ -81,6 +88,23 @@ export async function runWithSpinner<T>(
   } finally {
     spinner.stop();
   }
+}
+
+function renderFolderSyncProgress(status: BookmarkFolderSyncProgress, startTime: number): void {
+  const elapsed = Math.round((Date.now() - startTime) / 1000);
+  const spin = SPINNER[spinnerIdx++ % SPINNER.length];
+  const phaseLabel = {
+    planning: 'Planning folders',
+    folders: 'Preparing folders',
+    reconcile: 'Reconciling existing',
+    assigning: 'Assigning bookmarks',
+  }[status.phase];
+  const total = Math.max(status.total, 0);
+  const completed = Math.max(status.completed, 0);
+  const pct = total > 0 ? `${Math.round((Math.min(completed, total) / total) * 100)}%` : '--';
+  const detail = status.detail ? `  \u2502  ${status.detail}` : '';
+  const line = `  ${spin} ${phaseLabel}...  ${completed}/${total}${total > 0 ? ` (${pct})` : ''}  \u2502  ${elapsed}s${detail}`;
+  process.stderr.write(`\r\x1b[K${line}`);
 }
 
 const FRIENDLY_STOP_REASONS: Record<string, string> = {
@@ -353,9 +377,117 @@ function safe(fn: (...args: any[]) => Promise<void>): (...args: any[]) => Promis
   };
 }
 
+function collectValues(value: string, previous: string[]): string[] {
+  return [...previous, value];
+}
+
+function resolveCookieOverrides(options: any): { csrfToken?: string; cookieHeader?: string } {
+  if (!options.cookies || !Array.isArray(options.cookies) || options.cookies.length === 0) {
+    return {};
+  }
+  const csrfToken = String(options.cookies[0]);
+  const authToken = options.cookies.length > 1 ? String(options.cookies[1]) : undefined;
+  const parts = [`ct0=${csrfToken}`];
+  if (authToken) parts.push(`auth_token=${authToken}`);
+  return { csrfToken, cookieHeader: parts.join('; ') };
+}
+
+function buildFolderSyncOptions(
+  options: any,
+  defaults: {
+    maxActions: number;
+    maxMinutes: number;
+    allowUntilDone: boolean;
+    maxActionsProvided?: boolean;
+    maxMinutesProvided?: boolean;
+  },
+): BookmarkFolderSyncOptions {
+  return {
+    folderBy: (options.folderBy ? String(options.folderBy) : 'domain') as FolderBy,
+    minFolderSize: Number(options.minFolderSize) || 100,
+    includeLabels: Array.isArray(options.includeLabel) ? options.includeLabel.map(String) : [],
+    excludeLabels: Array.isArray(options.excludeLabel) ? options.excludeLabel.map(String) : [],
+    dryRun: Boolean(options.dryRun),
+    maxActions: defaults.maxActionsProvided && typeof options.maxActions === 'number' && !Number.isNaN(options.maxActions)
+      ? options.maxActions
+      : defaults.maxActions,
+    maxMinutes: defaults.maxMinutesProvided && typeof options.maxMinutes === 'number' && !Number.isNaN(options.maxMinutes)
+      ? options.maxMinutes
+      : defaults.maxMinutes,
+    untilDone: defaults.allowUntilDone ? Boolean(options.untilDone) : false,
+    browser: options.browser ? String(options.browser) : undefined,
+    ...resolveCookieOverrides(options),
+    chromeUserDataDir: options.chromeUserDataDir ? String(options.chromeUserDataDir) : undefined,
+    chromeProfileDirectory: options.chromeProfileDirectory ? String(options.chromeProfileDirectory) : undefined,
+    firefoxProfileDir: options.firefoxProfileDir ? String(options.firefoxProfileDir) : undefined,
+  };
+}
+
+function withFolderSyncProgress(
+  folderOptions: BookmarkFolderSyncOptions,
+  enabled: boolean,
+): BookmarkFolderSyncOptions {
+  if (!enabled) return folderOptions;
+  const startTime = Date.now();
+  return {
+    ...folderOptions,
+    onProgress: (status: BookmarkFolderSyncProgress) => {
+      renderFolderSyncProgress(status, startTime);
+    },
+  };
+}
+
+function addSyncFolderFlag(command: Command): Command {
+  return command.option('--folders', 'Push local classifications into X bookmark folders after sync', false);
+}
+
+function addBrowserSessionFlags(command: Command): Command {
+  return command
+    .option('--browser <name>', 'Browser to read session from (chrome, chromium, brave, firefox, ...)')
+    .option('--cookies <values...>', 'Pass ct0 and auth_token directly (skips browser extraction)')
+    .option('--chrome-user-data-dir <path>', 'Chrome-family user-data directory')
+    .option('--chrome-profile-directory <name>', 'Chrome-family profile name')
+    .option('--firefox-profile-dir <path>', 'Firefox profile directory');
+}
+
+function addAdvancedFolderSyncFlags(
+  command: Command,
+  defaults: { allowUntilDone: boolean; includeMaxMinutes?: boolean },
+): Command {
+  command
+    .option('--folder-by <domain|category>', 'Choose whether folders are derived from domains or categories', 'domain')
+    .option('--min-folder-size <n>', 'Only create folders for labels with at least N bookmarks', (v: string) => Number(v), 100)
+    .option('--include-label <slug>', 'Force-include a label', collectValues, [])
+    .option('--exclude-label <slug>', 'Exclude a label', collectValues, [])
+    .option('--dry-run', 'Preview folder changes without mutating X', false)
+    .option('--max-actions <n>', 'Maximum bookmark-folder assignments to attempt', (v: string) => Number(v));
+
+  if (defaults.includeMaxMinutes !== false) {
+    command.option('--max-minutes <n>', 'Maximum runtime for folder sync in minutes', (v: string) => Number(v));
+  }
+
+  if (defaults.allowUntilDone) {
+    command.option('--until-done', 'Keep resuming folder assignment work until the backlog is exhausted', false);
+  }
+
+  return command;
+}
+
+interface CliDeps {
+  syncTwitterBookmarks: typeof syncTwitterBookmarks;
+  syncBookmarksGraphQL: typeof syncBookmarksGraphQL;
+  syncBookmarkFolders: typeof syncBookmarkFolders;
+}
+
 // ── CLI ─────────────────────────────────────────────────────────────────────
 
-export function buildCli() {
+export function buildCli(partialDeps: Partial<CliDeps> = {}) {
+  const deps: CliDeps = {
+    syncTwitterBookmarks,
+    syncBookmarksGraphQL,
+    syncBookmarkFolders,
+    ...partialDeps,
+  };
   const program = new Command();
 
   async function rebuildIndex(): Promise<number> {
@@ -410,7 +542,8 @@ export function buildCli() {
 
   // ── sync ────────────────────────────────────────────────────────────────
 
-  program
+  addSyncFolderFlag(
+    addBrowserSessionFlags(program
     .command('sync')
     .description('Sync bookmarks from X into your local database')
     .option('--api', 'Use OAuth v2 API instead of Chrome session', false)
@@ -422,13 +555,8 @@ export function buildCli() {
     .option('--max-pages <n>', 'Max pages to fetch (default: unlimited)', (v: string) => Number(v))
     .option('--target-adds <n>', 'Stop after N new bookmarks', (v: string) => Number(v))
     .option('--delay-ms <n>', 'Delay between requests in ms', (v: string) => Number(v), 600)
-    .option('--max-minutes <n>', 'Max runtime in minutes', (v: string) => Number(v), 30)
-    .option('--browser <name>', 'Browser to read session from (chrome, chromium, brave, firefox, ...)')
-    .option('--cookies <values...>', 'Pass ct0 and auth_token directly (skips browser extraction)')
-    .option('--chrome-user-data-dir <path>', 'Chrome-family user-data directory')
-    .option('--chrome-profile-directory <name>', 'Chrome-family profile name')
-    .option('--firefox-profile-dir <path>', 'Firefox profile directory')
-    .action(async (options) => {
+    .option('--max-minutes <n>', 'Max runtime in minutes', (v: string) => Number(v), 30))
+  ).action(async (options) => {
       const firstRun = isFirstRun();
       if (firstRun) showSyncWelcome();
       ensureDataDir();
@@ -519,7 +647,7 @@ export function buildCli() {
         const mode = Boolean(options.rebuild) ? 'full' : 'incremental';
 
         if (useApi) {
-          const result = await syncTwitterBookmarks(mode, {
+          const result = await deps.syncTwitterBookmarks(mode, {
             targetAdds: typeof options.targetAdds === 'number' && !Number.isNaN(options.targetAdds) ? options.targetAdds : undefined,
           });
           console.log(`\n  \u2713 ${result.added} new bookmarks synced (${result.totalBookmarks} total)`);
@@ -539,16 +667,7 @@ export function buildCli() {
             }
             return `Syncing bookmarks...  ${lastSync.newAdded} new  \u2502  page ${lastSync.page}  \u2502  ${elapsed}s`;
           });
-          // Parse --cookies <ct0> [auth_token] — variadic, gives us an array
-          let csrfToken: string | undefined;
-          let cookieHeader: string | undefined;
-          if (options.cookies && Array.isArray(options.cookies) && options.cookies.length > 0) {
-            csrfToken = String(options.cookies[0]);
-            const authToken = options.cookies.length > 1 ? String(options.cookies[1]) : undefined;
-            const parts = [`ct0=${csrfToken}`];
-            if (authToken) parts.push(`auth_token=${authToken}`);
-            cookieHeader = parts.join('; ');
-          }
+          const { csrfToken, cookieHeader } = resolveCookieOverrides(options);
 
           // Load saved cursor for --continue mode
           let resumeCursor: string | undefined;
@@ -609,6 +728,26 @@ export function buildCli() {
           }
         }
 
+        if (options.folders) {
+          if (!requireIndex()) return;
+          const folderResult = await deps.syncBookmarkFolders(withFolderSyncProgress(
+            buildFolderSyncOptions({
+              browser: options.browser,
+              cookies: options.cookies,
+              chromeUserDataDir: options.chromeUserDataDir,
+              chromeProfileDirectory: options.chromeProfileDirectory,
+              firefoxProfileDir: options.firefoxProfileDir,
+            }, {
+              maxActions: 500,
+              maxMinutes: 15,
+              allowUntilDone: false,
+            }),
+            true,
+          ));
+          process.stderr.write('\n');
+          console.log(`\n${formatBookmarkFolderSyncResult(folderResult)}\n`);
+        }
+
         if (firstRun) {
           console.log(`\n  Next steps:`);
           console.log(`        ft classify              Classify by category and domain (LLM)`);
@@ -644,6 +783,31 @@ export function buildCli() {
         process.exitCode = 1;
       }
     });
+
+  // ── folders sync ───────────────────────────────────────────────────────
+
+  const foldersCommand = program.command('folders').description('Advanced bookmark folder commands');
+
+  addBrowserSessionFlags(addAdvancedFolderSyncFlags(
+    foldersCommand
+      .command('sync')
+      .description('Resume or preview bookmark-folder organization'),
+    { allowUntilDone: true },
+  )).action(safe(async (options, command) => {
+    if (!requireIndex()) return;
+    const folderResult = await deps.syncBookmarkFolders(withFolderSyncProgress(
+      buildFolderSyncOptions(options, {
+        maxActions: options.untilDone ? Number.POSITIVE_INFINITY : 500,
+        maxMinutes: options.untilDone ? 240 : 15,
+        allowUntilDone: true,
+        maxActionsProvided: command.getOptionValueSource('maxActions') !== 'default',
+        maxMinutesProvided: command.getOptionValueSource('maxMinutes') !== 'default',
+      }),
+      !options.dryRun,
+    ));
+    if (!options.dryRun) process.stderr.write('\n');
+    console.log(formatBookmarkFolderSyncResult(folderResult));
+  }));
 
   // ── search ──────────────────────────────────────────────────────────────
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -690,7 +690,7 @@ export function buildCli(partialDeps: Partial<CliDeps> = {}) {
           // stale limit is fine.
           const continueWithoutCursor = Boolean(options.continue) && !resumeCursor;
 
-          const result = await runWithSpinner(spinner, () => syncBookmarksGraphQL({
+          const result = await runWithSpinner(spinner, () => deps.syncBookmarksGraphQL({
             incremental: !Boolean(options.rebuild) && !Boolean(options.continue),
             resumeCursor,
             stalePageLimit: continueWithoutCursor ? Infinity : undefined,

--- a/src/graphql-bookmarks.ts
+++ b/src/graphql-bookmarks.ts
@@ -2,7 +2,7 @@ import { ensureDir, readJsonLines, writeJsonLines, readJson, writeJson, pathExis
 import { ensureDataDir, twitterBookmarksCachePath, twitterBookmarksMetaPath, twitterBackfillStatePath } from './paths.js';
 import type { BookmarkBackfillState, BookmarkCacheMeta, BookmarkRecord, QuotedTweetSnapshot } from './types.js';
 import { exportBookmarksForSyncSeed, updateQuotedTweets, updateBookmarkText } from './bookmarks-db.js';
-import { createXSessionContext, type XSessionContext } from './x-session.js';
+import { createXSessionContext, DEFAULT_X_USER_AGENT, type XSessionContext } from './x-session.js';
 
 const BOOKMARKS_QUERY_ID = 'Z9GWmP0kP2dajyckAaDUBw';
 const BOOKMARKS_OPERATION = 'Bookmarks';
@@ -716,7 +716,7 @@ async function fetchTweetViaSyndication(tweetId: string): Promise<SyndicationRes
   for (let attempt = 0; attempt < 4; attempt++) {
     const response = await fetch(`${SYNDICATION_URL}?id=${tweetId}&token=x`, {
       headers: {
-        'user-agent': CHROME_UA,
+        'user-agent': DEFAULT_X_USER_AGENT,
       },
     });
 

--- a/src/graphql-bookmarks.ts
+++ b/src/graphql-bookmarks.ts
@@ -1,15 +1,8 @@
 import { ensureDir, readJsonLines, writeJsonLines, readJson, writeJson, pathExists } from './fs.js';
 import { ensureDataDir, twitterBookmarksCachePath, twitterBookmarksMetaPath, twitterBackfillStatePath } from './paths.js';
-import { loadChromeSessionConfig } from './config.js';
-import { extractChromeXCookies } from './chrome-cookies.js';
-import { extractFirefoxXCookies } from './firefox-cookies.js';
 import type { BookmarkBackfillState, BookmarkCacheMeta, BookmarkRecord, QuotedTweetSnapshot } from './types.js';
 import { exportBookmarksForSyncSeed, updateQuotedTweets, updateBookmarkText } from './bookmarks-db.js';
-
-const CHROME_UA = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.0.0 Safari/537.36';
-
-const X_PUBLIC_BEARER =
-  'AAAAAAAAAAAAAAAAAAAAANRILgAAAAAAnNwIzUejRCOuH5E6I8xnZz4puTs%3D1Zv7ttfk8LF81IUq16cHjhLTvJu4FA33AGWWjCpTnA';
+import { createXSessionContext, type XSessionContext } from './x-session.js';
 
 const BOOKMARKS_QUERY_ID = 'Z9GWmP0kP2dajyckAaDUBw';
 const BOOKMARKS_OPERATION = 'Bookmarks';
@@ -186,18 +179,6 @@ function buildUrl(cursor?: string, count = 20): string {
     features: JSON.stringify(GRAPHQL_FEATURES),
   });
   return `https://x.com/i/api/graphql/${BOOKMARKS_QUERY_ID}/${BOOKMARKS_OPERATION}?${params}`;
-}
-
-function buildHeaders(csrfToken: string, cookieHeader?: string): Record<string, string> {
-  return {
-    authorization: `Bearer ${X_PUBLIC_BEARER}`,
-    'x-csrf-token': csrfToken,
-    'x-twitter-auth-type': 'OAuth2Session',
-    'x-twitter-active-user': 'yes',
-    'content-type': 'application/json',
-    'user-agent': CHROME_UA,
-    cookie: cookieHeader ?? `ct0=${csrfToken}`,
-  };
 }
 
 interface PageResult {
@@ -382,11 +363,24 @@ export function parseBookmarksResponse(json: any, now?: string): PageResult {
   return { records, nextCursor };
 }
 
-async function fetchPageWithRetry(csrfToken: string, cursor?: string, cookieHeader?: string, pageSize?: number): Promise<PageResult> {
+async function fetchPageWithRetry(
+  session: XSessionContext,
+  cursor?: string,
+  pageSize?: number,
+): Promise<PageResult> {
   let lastError: Error | undefined;
 
   for (let attempt = 0; attempt < 4; attempt++) {
-    const response = await fetch(buildUrl(cursor, pageSize), { headers: buildHeaders(csrfToken, cookieHeader) });
+    const effectiveUrl = buildUrl(cursor, pageSize);
+    const url = effectiveUrl;
+    const path = new URL(url).pathname;
+    const headers = { ...session.headers };
+    try {
+      headers['x-client-transaction-id'] = await session.transactionIdGenerator.generate('GET', path);
+    } catch {
+      // Best effort: bookmark sync already works in some environments without this header.
+    }
+    const response = await fetch(effectiveUrl, { headers });
 
     if (response.status === 429) {
       const waitSec = Math.min(15 * Math.pow(2, attempt), 120);
@@ -494,27 +488,14 @@ export async function syncBookmarksGraphQL(
   const checkpointEvery = options.checkpointEvery ?? 25;
   const pageSize = Math.max(1, Math.min(options.pageSize ?? 20, 100));
 
-  let csrfToken: string;
-  let cookieHeader: string | undefined;
-
-  if (options.csrfToken) {
-    csrfToken = options.csrfToken;
-    cookieHeader = options.cookieHeader;
-  } else {
-    const config = loadChromeSessionConfig({ browserId: options.browser });
-
-    if (config.browser.cookieBackend === 'firefox') {
-      const cookies = extractFirefoxXCookies(options.firefoxProfileDir);
-      csrfToken = cookies.csrfToken;
-      cookieHeader = cookies.cookieHeader;
-    } else {
-      const chromeDir = options.chromeUserDataDir ?? config.chromeUserDataDir;
-      const chromeProfile = options.chromeProfileDirectory ?? config.chromeProfileDirectory;
-      const cookies = extractChromeXCookies(chromeDir, chromeProfile, config.browser);
-      csrfToken = cookies.csrfToken;
-      cookieHeader = cookies.cookieHeader;
-    }
-  }
+  const session = createXSessionContext({
+    browser: options.browser,
+    csrfToken: options.csrfToken,
+    cookieHeader: options.cookieHeader,
+    chromeUserDataDir: options.chromeUserDataDir,
+    chromeProfileDirectory: options.chromeProfileDirectory,
+    firefoxProfileDir: options.firefoxProfileDir,
+  });
 
   ensureDataDir();
   const cachePath = twitterBookmarksCachePath();
@@ -547,7 +528,7 @@ export async function syncBookmarksGraphQL(
       break;
     }
 
-    const result = await fetchPageWithRetry(csrfToken, cursor, cookieHeader, pageSize);
+    const result = await fetchPageWithRetry(session, cursor, pageSize);
     page += 1;
 
     if (result.records.length === 0 && !result.nextCursor) {
@@ -636,7 +617,7 @@ export async function syncBookmarksGraphQL(
         break;
       }
 
-      const result = await fetchPageWithRetry(csrfToken, cursor, cookieHeader, pageSize);
+      const result = await fetchPageWithRetry(session, cursor, pageSize);
       page += 1;
 
       if (result.records.length === 0 && !result.nextCursor) {

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -36,6 +36,10 @@ export function twitterBackfillStatePath(): string {
   return path.join(dataDir(), 'bookmarks-backfill-state.json');
 }
 
+export function xBookmarkFolderOpsPath(): string {
+  return path.join(dataDir(), 'x-bookmark-folder-ops.json');
+}
+
 export function bookmarkMediaDir(): string {
   return path.join(dataDir(), 'media');
 }

--- a/src/x-bookmark-folders.ts
+++ b/src/x-bookmark-folders.ts
@@ -264,7 +264,7 @@ function throwResponseError(action: string, response: GraphqlResponse): never {
   }
   if (isSessionExpired(response)) {
     throw new GraphqlRequestError(
-      `${action} failed because your X browser session appears to be expired. Open Chrome, visit https://x.com, make sure you're logged in, then retry.`,
+      `${action} failed because your X browser session appears to be expired. Open your browser, visit https://x.com, make sure you're logged in, then retry.`,
       'session',
       response.status,
     );

--- a/src/x-bookmark-folders.ts
+++ b/src/x-bookmark-folders.ts
@@ -1,0 +1,931 @@
+import type { Database } from 'sql.js';
+import { openBookmarksIndexDb } from './bookmarks-db.js';
+import { saveDb } from './db.js';
+import { parseBookmarksResponse } from './graphql-bookmarks.js';
+import { pathExists, readJson } from './fs.js';
+import { twitterBookmarksIndexPath, xBookmarkFolderOpsPath } from './paths.js';
+import { buildXHeaders, createXSessionContext, type XSessionContext, type XSessionOptions } from './x-session.js';
+
+const BOOKMARK_FOLDER_TIMELINE_FEATURES = {
+  rweb_tipjar_consumption_enabled: true,
+  responsive_web_graphql_exclude_directive_enabled: true,
+  verified_phone_label_enabled: false,
+  creator_subscriptions_tweet_preview_api_enabled: true,
+  responsive_web_graphql_timeline_navigation_enabled: true,
+  responsive_web_graphql_skip_user_profile_image_extensions_enabled: false,
+  communities_web_enable_tweet_community_results_fetch: true,
+  c9s_tweet_anatomy_moderator_badge_enabled: true,
+  articles_preview_enabled: false,
+  tweetypie_unmention_optimization_enabled: true,
+  responsive_web_edit_tweet_api_enabled: true,
+  graphql_is_translatable_rweb_tweet_is_translatable_enabled: true,
+  view_counts_everywhere_api_enabled: true,
+  longform_notetweets_consumption_enabled: true,
+  responsive_web_twitter_article_tweet_consumption_enabled: true,
+  tweet_awards_web_tipping_enabled: false,
+  creator_subscriptions_quote_tweet_preview_enabled: false,
+  freedom_of_speech_not_reach_fetch_enabled: true,
+  standardized_nudges_misinfo: true,
+  tweet_with_visibility_results_prefer_gql_limited_actions_policy_enabled: true,
+  tweet_with_visibility_results_prefer_gql_media_interstitial_enabled: true,
+  rweb_video_timestamps_enabled: true,
+  longform_notetweets_rich_text_read_enabled: true,
+  longform_notetweets_inline_media_enabled: true,
+  responsive_web_enhance_cards_enabled: false,
+};
+
+const DEFAULT_FOLDER_OPS = {
+  createFolder: { queryId: '6Xxqpq8TM_CREYiuof_h5w', operationName: 'createBookmarkFolder', method: 'POST' as const },
+  addToFolder: { queryId: '4KHZvvNbHNf07bsgnL9gWA', operationName: 'bookmarkTweetToFolder', method: 'POST' as const },
+  listFolders: { queryId: 'i78YDd0Tza-dV4SYs58kRg', operationName: 'BookmarkFoldersSlice', method: 'GET' as const },
+  folderTimeline: { queryId: '8HoabOvl7jl9IC1Aixj-vg', operationName: 'BookmarkFolderTimeline', method: 'GET' as const },
+};
+
+const MANUAL_RECOVERY_MESSAGE =
+  `X's internal bookmark-folder query ids may have rotated.\n\n` +
+  `Recovery:\n` +
+  `  1. Open x.com in your browser and open DevTools\n` +
+  `  2. Filter Network requests by /i/api/graphql and bookmark\n` +
+  `  3. Create a probe folder and add one bookmark to it\n` +
+  `  4. Save the observed query ids into ${xBookmarkFolderOpsPath()}\n`;
+
+export type FolderBy = 'domain' | 'category';
+
+export interface FolderLabelPlan {
+  label: string;
+  folderName: string;
+  count: number;
+}
+
+export interface BookmarkFolderSyncOptions extends XSessionOptions {
+  folderBy?: FolderBy;
+  minFolderSize?: number;
+  includeLabels?: string[];
+  excludeLabels?: string[];
+  dryRun?: boolean;
+  maxActions?: number;
+  maxMinutes?: number;
+  untilDone?: boolean;
+  onProgress?: (status: BookmarkFolderSyncProgress) => void;
+  fetchImpl?: typeof fetch;
+  randomInt?: (min: number, max: number) => number;
+  sleep?: (ms: number) => Promise<void>;
+  session?: XSessionContext;
+}
+
+export interface BookmarkFolderSyncProgress {
+  phase: 'planning' | 'folders' | 'reconcile' | 'assigning';
+  completed: number;
+  total: number;
+  detail?: string;
+}
+
+export interface BookmarkFolderSyncResult {
+  folderBy: FolderBy;
+  dryRun: boolean;
+  eligibleLabels: FolderLabelPlan[];
+  foldersCreated: number;
+  foldersMatched: number;
+  assignmentsPlanned: number;
+  assignmentsCompleted: number;
+  assignmentsAlreadyPresent: number;
+  assignmentsPending: number;
+  stopReason: string;
+  overridePath: string;
+}
+
+export interface XBookmarkFolder {
+  id: string;
+  name: string;
+  media?: unknown;
+}
+
+interface BookmarkFolderOps {
+  createFolder: GraphqlOperationDescriptor;
+  addToFolder: GraphqlOperationDescriptor;
+  listFolders: GraphqlOperationDescriptor;
+  folderTimeline: GraphqlOperationDescriptor;
+}
+
+interface GraphqlOperationDescriptor {
+  queryId: string;
+  operationName: string;
+  method: 'GET' | 'POST';
+}
+
+interface FolderSyncCandidate {
+  tweetId: string;
+  label: string;
+}
+
+interface GraphqlResponse<T = any> {
+  status: number;
+  ok: boolean;
+  json: T | null;
+  text: string;
+}
+
+class GraphqlRequestError extends Error {
+  constructor(
+    message: string,
+    readonly kind: 'stale-operation' | 'session' | 'premium' | 'rate-limit' | 'generic',
+    readonly status: number,
+  ) {
+    super(message);
+  }
+}
+
+interface PendingAssignment {
+  tweetId: string;
+  label: string;
+  folderId: string;
+  status: string;
+  attemptCount: number;
+}
+
+export function formatFolderName(label: string): string {
+  const map: Record<string, string> = {
+    ai: 'AI',
+    'web-dev': 'Web Dev',
+    devops: 'DevOps',
+    crypto: 'Crypto',
+  };
+  if (map[label]) return map[label];
+  return label
+    .split('-')
+    .map((part) => (part ? part[0].toUpperCase() + part.slice(1) : part))
+    .join(' ');
+}
+
+function normalizeName(value: string): string {
+  return value.trim().toLowerCase().replace(/\s+/g, ' ');
+}
+
+export function selectFolderLabels(
+  counts: Record<string, number>,
+  options: { minFolderSize?: number; includeLabels?: string[]; excludeLabels?: string[] } = {},
+): FolderLabelPlan[] {
+  const minFolderSize = options.minFolderSize ?? 100;
+  const includes = new Set((options.includeLabels ?? []).map((label) => label.trim()).filter(Boolean));
+  const excludes = new Set((options.excludeLabels ?? []).map((label) => label.trim()).filter(Boolean));
+
+  return Object.entries(counts)
+    .filter(([label, count]) => count > 0 && (count >= minFolderSize || includes.has(label)) && !excludes.has(label))
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+    .map(([label, count]) => ({ label, count, folderName: formatFolderName(label) }));
+}
+
+export function buildGraphqlGetUrl(
+  operation: GraphqlOperationDescriptor,
+  variables: Record<string, unknown> = {},
+  features?: Record<string, unknown>,
+): string {
+  const params = new URLSearchParams();
+  params.set('variables', JSON.stringify(variables));
+  if (features && Object.keys(features).length > 0) {
+    params.set('features', JSON.stringify(features));
+  }
+  return `https://x.com/i/api/graphql/${operation.queryId}/${operation.operationName}?${params.toString()}`;
+}
+
+export function buildGraphqlPostBody(
+  operation: GraphqlOperationDescriptor,
+  variables: Record<string, unknown>,
+  features?: Record<string, unknown>,
+): Record<string, unknown> {
+  const body: Record<string, unknown> = {
+    queryId: operation.queryId,
+    variables,
+  };
+  if (features && Object.keys(features).length > 0) body.features = features;
+  return body;
+}
+
+export async function loadBookmarkFolderOperations(): Promise<BookmarkFolderOps> {
+  const overridePath = xBookmarkFolderOpsPath();
+  if (!(await pathExists(overridePath))) return DEFAULT_FOLDER_OPS;
+  const override = await readJson<Partial<BookmarkFolderOps>>(overridePath);
+  return {
+    createFolder: { ...DEFAULT_FOLDER_OPS.createFolder, ...override.createFolder },
+    addToFolder: { ...DEFAULT_FOLDER_OPS.addToFolder, ...override.addToFolder },
+    listFolders: { ...DEFAULT_FOLDER_OPS.listFolders, ...override.listFolders },
+    folderTimeline: { ...DEFAULT_FOLDER_OPS.folderTimeline, ...override.folderTimeline },
+  };
+}
+
+function safeJsonParse(text: string): any | null {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return null;
+  }
+}
+
+function extractErrorMessage(response: GraphqlResponse): string {
+  const jsonError = response.json?.errors?.[0]?.message;
+  if (typeof jsonError === 'string' && jsonError.trim()) return jsonError;
+  return response.text.slice(0, 300) || `HTTP ${response.status}`;
+}
+
+function isRateLimit(status: number, text: string): boolean {
+  return status === 429 || /rate limit/i.test(text);
+}
+
+function isOperationNotFound(response: GraphqlResponse): boolean {
+  const text = `${response.text} ${extractErrorMessage(response)}`;
+  return /PersistedQueryNotFound|Query.+not found|No operation named/i.test(text);
+}
+
+function isSessionExpired(response: GraphqlResponse): boolean {
+  return response.status === 401 || response.status === 403;
+}
+
+function isPremiumIssue(response: GraphqlResponse): boolean {
+  return /premium|bookmark folders/i.test(`${response.text} ${extractErrorMessage(response)}`);
+}
+
+function isAlreadyAssigned(response: GraphqlResponse): boolean {
+  return /already.+bookmark|already.+folder|duplicate/i.test(`${response.text} ${extractErrorMessage(response)}`);
+}
+
+function isFolderAlreadyExists(response: GraphqlResponse): boolean {
+  return /collection with that name already exists|folder with that name already exists|already exists/i.test(
+    `${response.text} ${extractErrorMessage(response)}`,
+  );
+}
+
+function throwResponseError(action: string, response: GraphqlResponse): never {
+  if (isOperationNotFound(response)) {
+    throw new GraphqlRequestError(
+      `${action} failed because X rejected the current bookmark-folder query id.\n\n${MANUAL_RECOVERY_MESSAGE}`,
+      'stale-operation',
+      response.status,
+    );
+  }
+  if (isSessionExpired(response)) {
+    throw new GraphqlRequestError(
+      `${action} failed because your X browser session appears to be expired. Open Chrome, visit https://x.com, make sure you're logged in, then retry.`,
+      'session',
+      response.status,
+    );
+  }
+  if (isPremiumIssue(response)) {
+    throw new GraphqlRequestError(
+      `${action} failed because bookmark folders appear unavailable on this account. X bookmark folders are a Premium feature.`,
+      'premium',
+      response.status,
+    );
+  }
+  if (isRateLimit(response.status, response.text)) {
+    throw new GraphqlRequestError(
+      `${action} hit an X rate limit (${response.status}): ${extractErrorMessage(response)}`,
+      'rate-limit',
+      response.status,
+    );
+  }
+  throw new GraphqlRequestError(
+    `${action} failed (${response.status}): ${extractErrorMessage(response)}`,
+    'generic',
+    response.status,
+  );
+}
+
+function walk(node: any, visitor: (value: any) => void): void {
+  if (!node || typeof node !== 'object') return;
+  visitor(node);
+  if (Array.isArray(node)) {
+    for (const value of node) walk(value, visitor);
+    return;
+  }
+  for (const value of Object.values(node)) walk(value, visitor);
+}
+
+export function parseBookmarkFoldersSliceResponse(json: any): { folders: XBookmarkFolder[]; nextCursor?: string } {
+  const byId = new Map<string, XBookmarkFolder>();
+  let nextCursor: string | undefined;
+
+  walk(json, (value) => {
+    if (
+      value &&
+      typeof value === 'object' &&
+      typeof (value.bookmark_collection_id ?? value.id) === 'string' &&
+      typeof value.name === 'string'
+    ) {
+      const id = String(value.bookmark_collection_id ?? value.id);
+      byId.set(id, {
+        id,
+        name: value.name,
+        media: value.media,
+      });
+    }
+
+    if (
+      value &&
+      typeof value === 'object' &&
+      typeof value.cursor === 'string' &&
+      /bottom|next/i.test(String(value.cursor_type ?? value.type ?? ''))
+    ) {
+      nextCursor = value.cursor;
+    }
+  });
+
+  return { folders: Array.from(byId.values()), nextCursor };
+}
+
+export function parseCreateBookmarkFolderResponse(json: any): XBookmarkFolder | null {
+  const parsed = parseBookmarkFoldersSliceResponse(json).folders[0];
+  return parsed ?? null;
+}
+
+export function parseBookmarkFolderTimelineResponse(json: any): { tweetIds: string[]; nextCursor?: string } {
+  const page = parseBookmarksResponse(json);
+  return {
+    tweetIds: page.records.map((record) => record.tweetId),
+    nextCursor: page.nextCursor,
+  };
+}
+
+class XBookmarkFoldersClient {
+  constructor(
+    private readonly session: XSessionContext,
+    private readonly operations: BookmarkFolderOps,
+    private readonly fetchImpl: typeof fetch = fetch,
+  ) {}
+
+  private async requestJson(
+    method: 'GET' | 'POST',
+    url: string,
+    body?: Record<string, unknown>,
+  ): Promise<GraphqlResponse> {
+    const headers = buildXHeaders(
+      { csrfToken: this.session.csrfToken, cookieHeader: this.session.cookieHeader },
+      { userAgent: this.session.userAgent, contentType: body ? 'application/json' : undefined },
+    );
+    try {
+      headers['x-client-transaction-id'] = await this.session.transactionIdGenerator.generate(method, new URL(url).pathname);
+    } catch {
+      // Best effort header. If this drifts, the user can still repair query ids through the override file.
+    }
+    const response = await this.fetchImpl(url, {
+      method,
+      headers,
+      body: body ? JSON.stringify(body) : undefined,
+    });
+    const text = await response.text();
+    return {
+      status: response.status,
+      ok: response.ok,
+      text,
+      json: safeJsonParse(text),
+    };
+  }
+
+  async listFolders(cursor?: string): Promise<{ folders: XBookmarkFolder[]; nextCursor?: string }> {
+    const url = buildGraphqlGetUrl(this.operations.listFolders, cursor ? { cursor } : {});
+    const response = await this.requestJson('GET', url);
+    if (!response.ok) throwResponseError('Listing bookmark folders', response);
+    return parseBookmarkFoldersSliceResponse(response.json);
+  }
+
+  async createFolder(name: string): Promise<XBookmarkFolder> {
+    const url = `https://x.com/i/api/graphql/${this.operations.createFolder.queryId}/${this.operations.createFolder.operationName}`;
+    const response = await this.requestJson('POST', url, buildGraphqlPostBody(this.operations.createFolder, { name }));
+    if (!response.ok) {
+      if (isFolderAlreadyExists(response)) {
+        const folders = await listAllFolders(this);
+        const existing = folders.find((folder) => normalizeName(folder.name) === normalizeName(name));
+        if (existing) return existing;
+      }
+      throwResponseError(`Creating bookmark folder "${name}"`, response);
+    }
+    const folder = parseCreateBookmarkFolderResponse(response.json);
+    if (folder) return folder;
+
+    const folders = await listAllFolders(this);
+    const existing = folders.find((entry) => normalizeName(entry.name) === normalizeName(name));
+    if (existing) return existing;
+
+    throw new Error(`Creating bookmark folder "${name}" succeeded but the response did not include a folder id.`);
+  }
+
+  async folderTimeline(folderId: string, cursor?: string): Promise<{ tweetIds: string[]; nextCursor?: string }> {
+    const url = buildGraphqlGetUrl(
+      this.operations.folderTimeline,
+      { count: 100, includePromotedContent: true, bookmark_collection_id: folderId, ...(cursor ? { cursor } : {}) },
+      BOOKMARK_FOLDER_TIMELINE_FEATURES,
+    );
+    const response = await this.requestJson('GET', url);
+    if (!response.ok) throwResponseError(`Reading bookmark folder timeline for ${folderId}`, response);
+    return parseBookmarkFolderTimelineResponse(response.json);
+  }
+
+  async addTweetToFolder(tweetId: string, folderId: string): Promise<void> {
+    const url = `https://x.com/i/api/graphql/${this.operations.addToFolder.queryId}/${this.operations.addToFolder.operationName}`;
+    const response = await this.requestJson(
+      'POST',
+      url,
+      buildGraphqlPostBody(this.operations.addToFolder, { tweet_id: tweetId, bookmark_collection_id: folderId }),
+    );
+    if (response.ok || isAlreadyAssigned(response)) return;
+    throwResponseError(`Adding tweet ${tweetId} to bookmark folder ${folderId}`, response);
+  }
+}
+
+async function getLabelCounts(db: Database, folderBy: FolderBy): Promise<Record<string, number>> {
+  const column = folderBy === 'domain' ? 'primary_domain' : 'primary_category';
+  const rows = db.exec(
+    `SELECT ${column} AS label, COUNT(*) AS count
+     FROM bookmarks
+     WHERE ${column} IS NOT NULL AND TRIM(${column}) <> ''
+     GROUP BY ${column}`,
+  );
+  return Object.fromEntries((rows[0]?.values ?? []).map((row) => [String(row[0]), Number(row[1])]));
+}
+
+async function listFolderSyncCandidates(db: Database, folderBy: FolderBy, labels: string[]): Promise<FolderSyncCandidate[]> {
+  if (labels.length === 0) return [];
+  const column = folderBy === 'domain' ? 'primary_domain' : 'primary_category';
+  const placeholders = labels.map(() => '?').join(', ');
+  const rows = db.exec(
+    `SELECT tweet_id, ${column} AS label
+     FROM bookmarks
+     WHERE ${column} IN (${placeholders})
+     ORDER BY
+       CASE
+         WHEN bookmarked_at GLOB '____-__-__*' THEN bookmarked_at
+         WHEN posted_at GLOB '____-__-__*' THEN posted_at
+         ELSE ''
+       END DESC,
+       CAST(tweet_id AS INTEGER) DESC`,
+    labels,
+  );
+  return (rows[0]?.values ?? []).map((row) => ({
+    tweetId: String(row[0]),
+    label: String(row[1]),
+  }));
+}
+
+function upsertManagedFolder(db: Database, label: string, folderName: string, folderId: string, nowIso: string): void {
+  db.run(
+    `INSERT INTO x_bookmark_folders (label, folder_name, folder_id, updated_at)
+     VALUES (?, ?, ?, ?)
+     ON CONFLICT(label) DO UPDATE SET
+       folder_name = excluded.folder_name,
+       folder_id = excluded.folder_id,
+       updated_at = excluded.updated_at`,
+    [label, folderName, folderId, nowIso],
+  );
+}
+
+function upsertCandidates(db: Database, rows: FolderSyncCandidate[], folderIdsByLabel: Map<string, string>): void {
+  db.run('BEGIN TRANSACTION');
+  try {
+    for (const row of rows) {
+      const folderId = folderIdsByLabel.get(row.label);
+      if (!folderId) continue;
+      db.run(
+        `INSERT INTO x_bookmark_folder_sync
+          (tweet_id, label, folder_id, status, attempt_count, last_error, last_attempted_at, completed_at)
+         VALUES (?, ?, ?, 'pending', 0, NULL, NULL, NULL)
+         ON CONFLICT(tweet_id) DO UPDATE SET
+           label = excluded.label,
+           folder_id = excluded.folder_id,
+           status = CASE
+             WHEN x_bookmark_folder_sync.status = 'done'
+               AND x_bookmark_folder_sync.label = excluded.label
+               AND x_bookmark_folder_sync.folder_id = excluded.folder_id
+             THEN 'done'
+             ELSE 'pending'
+           END,
+           last_error = NULL,
+           completed_at = CASE
+             WHEN x_bookmark_folder_sync.status = 'done'
+               AND x_bookmark_folder_sync.label = excluded.label
+               AND x_bookmark_folder_sync.folder_id = excluded.folder_id
+             THEN x_bookmark_folder_sync.completed_at
+             ELSE NULL
+           END`,
+        [row.tweetId, row.label, folderId],
+      );
+    }
+    db.run('COMMIT');
+  } catch (error) {
+    db.run('ROLLBACK');
+    throw error;
+  }
+}
+
+function markAssignmentsDone(db: Database, folderId: string, tweetIds: string[], nowIso: string): number {
+  if (tweetIds.length === 0) return 0;
+  let updated = 0;
+  db.run('BEGIN TRANSACTION');
+  try {
+    for (const tweetId of tweetIds) {
+      db.run(
+        `UPDATE x_bookmark_folder_sync
+         SET status = 'done',
+             last_error = NULL,
+             completed_at = ?,
+             folder_id = ?
+         WHERE tweet_id = ? AND folder_id = ?`,
+        [nowIso, folderId, tweetId, folderId],
+      );
+      updated += 1;
+    }
+    db.run('COMMIT');
+  } catch (error) {
+    db.run('ROLLBACK');
+    throw error;
+  }
+  return updated;
+}
+
+function listPendingAssignments(db: Database, limit: number): PendingAssignment[] {
+  const rows = db.exec(
+    `SELECT s.tweet_id, s.label, s.folder_id, s.status, s.attempt_count
+     FROM x_bookmark_folder_sync s
+     JOIN bookmarks b ON b.tweet_id = s.tweet_id
+     WHERE s.status <> 'done'
+     ORDER BY
+       CASE
+         WHEN b.bookmarked_at GLOB '____-__-__*' THEN b.bookmarked_at
+         WHEN b.posted_at GLOB '____-__-__*' THEN b.posted_at
+         ELSE ''
+       END DESC,
+       CAST(b.tweet_id AS INTEGER) DESC
+     LIMIT ?`,
+    [limit],
+  );
+  return (rows[0]?.values ?? []).map((row) => ({
+    tweetId: String(row[0]),
+    label: String(row[1]),
+    folderId: String(row[2]),
+    status: String(row[3]),
+    attemptCount: Number(row[4] ?? 0),
+  }));
+}
+
+function countPendingAssignments(db: Database): number {
+  const rows = db.exec(`SELECT COUNT(*) FROM x_bookmark_folder_sync WHERE status <> 'done'`);
+  return Number(rows[0]?.values?.[0]?.[0] ?? 0);
+}
+
+function setAssignmentState(
+  db: Database,
+  tweetId: string,
+  patch: { status: string; lastError?: string | null; lastAttemptedAt?: string | null; completedAt?: string | null; incrementAttempt?: boolean },
+): void {
+  db.run(
+    `UPDATE x_bookmark_folder_sync
+     SET status = ?,
+         attempt_count = attempt_count + ?,
+         last_error = ?,
+         last_attempted_at = ?,
+         completed_at = ?
+     WHERE tweet_id = ?`,
+    [
+      patch.status,
+      patch.incrementAttempt ? 1 : 0,
+      patch.lastError ?? null,
+      patch.lastAttemptedAt ?? null,
+      patch.completedAt ?? null,
+      tweetId,
+    ],
+  );
+}
+
+async function listAllFolders(client: XBookmarkFoldersClient): Promise<XBookmarkFolder[]> {
+  const folders: XBookmarkFolder[] = [];
+  const seen = new Set<string>();
+  let cursor: string | undefined;
+  for (let page = 0; page < 10; page++) {
+    const result = await client.listFolders(cursor);
+    for (const folder of result.folders) {
+      if (!seen.has(folder.id)) {
+        seen.add(folder.id);
+        folders.push(folder);
+      }
+    }
+    if (!result.nextCursor || result.nextCursor === cursor) break;
+    cursor = result.nextCursor;
+  }
+  return folders;
+}
+
+async function reconcileExistingFolder(
+  db: Database,
+  client: XBookmarkFoldersClient,
+  label: FolderLabelPlan,
+  folderId: string,
+  targetTweetIds: Set<string>,
+  onProgress?: (status: BookmarkFolderSyncProgress) => void,
+): Promise<number> {
+  let cursor: string | undefined;
+  let marked = 0;
+
+  for (let page = 0; page < 1000; page++) {
+    const result = await client.folderTimeline(folderId, cursor);
+    const alreadyPresent = result.tweetIds.filter((tweetId) => targetTweetIds.has(tweetId));
+    if (alreadyPresent.length > 0) {
+      marked += markAssignmentsDone(db, folderId, alreadyPresent, new Date().toISOString());
+    }
+    onProgress?.({
+      phase: 'reconcile',
+      completed: marked,
+      total: targetTweetIds.size,
+      detail: `${label.folderName} page ${page + 1}`,
+    });
+    if (!result.nextCursor || result.nextCursor === cursor || result.tweetIds.length === 0) break;
+    cursor = result.nextCursor;
+  }
+
+  return marked;
+}
+
+function createSleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function stopReasonForOptions(options: BookmarkFolderSyncOptions): { maxActions: number; maxMinutes: number } {
+  return {
+    maxActions: typeof options.maxActions === 'number'
+      ? options.maxActions
+      : options.untilDone ? Number.POSITIVE_INFINITY : 500,
+    maxMinutes: typeof options.maxMinutes === 'number'
+      ? options.maxMinutes
+      : options.untilDone ? 240 : 15,
+  };
+}
+
+function finalizeStopReason(
+  current: string,
+  assignmentsPending: number,
+  maxActions: number,
+  assignmentsCompleted: number,
+): string {
+  if (current !== 'done' || assignmentsPending <= 0) return current;
+  if (Number.isFinite(maxActions) && assignmentsCompleted >= maxActions) {
+    return 'batch complete (more pending)';
+  }
+  return 'paused with pending assignments';
+}
+
+export async function syncBookmarkFolders(options: BookmarkFolderSyncOptions = {}): Promise<BookmarkFolderSyncResult> {
+  const folderBy = options.folderBy ?? 'domain';
+  const dryRun = Boolean(options.dryRun);
+  const { maxActions, maxMinutes } = stopReasonForOptions(options);
+  const sleep = options.sleep ?? createSleep;
+  const jitter = options.randomInt ?? ((min: number, max: number) => Math.floor(Math.random() * (max - min + 1)) + min);
+  const startedAt = Date.now();
+  const db = await openBookmarksIndexDb();
+
+  try {
+    const counts = await getLabelCounts(db, folderBy);
+    const eligibleLabels = selectFolderLabels(counts, {
+      minFolderSize: options.minFolderSize ?? 100,
+      includeLabels: options.includeLabels,
+      excludeLabels: options.excludeLabels,
+    });
+
+    if (eligibleLabels.length === 0) {
+      return {
+        folderBy,
+        dryRun,
+        eligibleLabels: [],
+        foldersCreated: 0,
+        foldersMatched: 0,
+        assignmentsPlanned: 0,
+        assignmentsCompleted: 0,
+        assignmentsAlreadyPresent: 0,
+        assignmentsPending: 0,
+        stopReason: 'no eligible labels',
+        overridePath: xBookmarkFolderOpsPath(),
+      };
+    }
+
+    const candidates = await listFolderSyncCandidates(db, folderBy, eligibleLabels.map((item) => item.label));
+    options.onProgress?.({ phase: 'planning', completed: candidates.length, total: candidates.length, detail: 'Candidates loaded' });
+
+    const operations = await loadBookmarkFolderOperations();
+    const session = options.session ?? createXSessionContext(options);
+    const client = new XBookmarkFoldersClient(session, operations, options.fetchImpl);
+    const existingFolders = await listAllFolders(client);
+    const existingByName = new Map(existingFolders.map((folder) => [normalizeName(folder.name), folder]));
+    const matchedFolderLabels = new Set<string>();
+    const folderIdsByLabel = new Map<string, string>();
+    let foldersCreated = 0;
+    let foldersMatched = 0;
+
+    for (let index = 0; index < eligibleLabels.length; index++) {
+      const label = eligibleLabels[index];
+      const match = existingByName.get(normalizeName(label.folderName));
+      if (match) {
+        folderIdsByLabel.set(label.label, match.id);
+        matchedFolderLabels.add(label.label);
+        foldersMatched += 1;
+      } else if (!dryRun) {
+        const created = await client.createFolder(label.folderName);
+        folderIdsByLabel.set(label.label, created.id);
+        existingByName.set(normalizeName(created.name), created);
+        foldersCreated += 1;
+      }
+      options.onProgress?.({
+        phase: 'folders',
+        completed: index + 1,
+        total: eligibleLabels.length,
+        detail: label.folderName,
+      });
+    }
+
+    if (dryRun) {
+      const pending = candidates.length;
+      return {
+        folderBy,
+        dryRun,
+        eligibleLabels,
+        foldersCreated: eligibleLabels.length - foldersMatched,
+        foldersMatched,
+        assignmentsPlanned: candidates.length,
+        assignmentsCompleted: 0,
+        assignmentsAlreadyPresent: 0,
+        assignmentsPending: pending,
+        stopReason: 'dry run',
+        overridePath: xBookmarkFolderOpsPath(),
+      };
+    }
+
+    const nowIso = new Date().toISOString();
+    for (const label of eligibleLabels) {
+      const folderId = folderIdsByLabel.get(label.label);
+      if (!folderId) continue;
+      upsertManagedFolder(db, label.label, label.folderName, folderId, nowIso);
+    }
+    upsertCandidates(db, candidates, folderIdsByLabel);
+
+    const tweetIdsByLabel = new Map<string, Set<string>>();
+    for (const row of candidates) {
+      const set = tweetIdsByLabel.get(row.label) ?? new Set<string>();
+      set.add(row.tweetId);
+      tweetIdsByLabel.set(row.label, set);
+    }
+
+    let assignmentsAlreadyPresent = 0;
+    for (const label of eligibleLabels) {
+      const folderId = folderIdsByLabel.get(label.label);
+      const targetTweetIds = tweetIdsByLabel.get(label.label);
+      if (!folderId || !targetTweetIds || targetTweetIds.size === 0) continue;
+      if (Date.now() - startedAt > maxMinutes * 60_000) break;
+      if (matchedFolderLabels.has(label.label)) {
+        assignmentsAlreadyPresent += await reconcileExistingFolder(
+          db,
+          client,
+          label,
+          folderId,
+          targetTweetIds,
+          options.onProgress,
+        );
+      }
+    }
+
+    const pendingRows = listPendingAssignments(db, Number.isFinite(maxActions) ? maxActions : Number.MAX_SAFE_INTEGER);
+    let assignmentsCompleted = 0;
+    let stopReason = 'done';
+
+    for (let index = 0; index < pendingRows.length; index++) {
+      const row = pendingRows[index];
+      if (Date.now() - startedAt > maxMinutes * 60_000) {
+        stopReason = 'max runtime reached';
+        break;
+      }
+      if (assignmentsCompleted >= maxActions) {
+        stopReason = 'max actions reached';
+        break;
+      }
+
+      options.onProgress?.({
+        phase: 'assigning',
+        completed: index,
+        total: pendingRows.length,
+        detail: `${formatFolderName(row.label)} \u2190 ${row.tweetId}`,
+      });
+
+      let attempt = 0;
+      while (attempt < 3) {
+        const attemptIso = new Date().toISOString();
+        setAssignmentState(db, row.tweetId, {
+          status: 'running',
+          lastAttemptedAt: attemptIso,
+          lastError: null,
+          incrementAttempt: attempt === 0,
+        });
+
+        try {
+          await client.addTweetToFolder(row.tweetId, row.folderId);
+          setAssignmentState(db, row.tweetId, {
+            status: 'done',
+            completedAt: new Date().toISOString(),
+            lastAttemptedAt: attemptIso,
+            lastError: null,
+          });
+          assignmentsCompleted += 1;
+          options.onProgress?.({
+            phase: 'assigning',
+            completed: assignmentsCompleted,
+            total: pendingRows.length,
+            detail: `${formatFolderName(row.label)} \u2190 ${row.tweetId}`,
+          });
+          await sleep(2000 + jitter(250, 750));
+          break;
+        } catch (error) {
+          const message = (error as Error).message;
+          if (error instanceof GraphqlRequestError && error.kind === 'stale-operation') {
+            setAssignmentState(db, row.tweetId, {
+              status: 'pending',
+              lastError: message,
+              lastAttemptedAt: attemptIso,
+            });
+            throw error;
+          }
+          if (error instanceof GraphqlRequestError && error.kind === 'session') {
+            setAssignmentState(db, row.tweetId, {
+              status: 'pending',
+              lastError: message,
+              lastAttemptedAt: attemptIso,
+            });
+            throw error;
+          }
+          if (error instanceof GraphqlRequestError && error.kind === 'premium') {
+            setAssignmentState(db, row.tweetId, {
+              status: 'pending',
+              lastError: message,
+              lastAttemptedAt: attemptIso,
+            });
+            throw error;
+          }
+
+          attempt += 1;
+          setAssignmentState(db, row.tweetId, {
+            status: 'pending',
+            lastError: message,
+            lastAttemptedAt: attemptIso,
+          });
+          if (
+            (error instanceof GraphqlRequestError && error.kind === 'rate-limit') ||
+            /server error/i.test(message)
+          ) {
+            await sleep(Math.min(15_000 * Math.pow(2, attempt - 1), 120_000));
+            continue;
+          }
+          break;
+        }
+      }
+    }
+
+    const assignmentsPending = countPendingAssignments(db);
+    stopReason = finalizeStopReason(stopReason, assignmentsPending, maxActions, assignmentsCompleted);
+    return {
+      folderBy,
+      dryRun: false,
+      eligibleLabels,
+      foldersCreated,
+      foldersMatched,
+      assignmentsPlanned: candidates.length,
+      assignmentsCompleted,
+      assignmentsAlreadyPresent,
+      assignmentsPending,
+      stopReason,
+      overridePath: xBookmarkFolderOpsPath(),
+    };
+  } finally {
+    try {
+      saveDb(db, twitterBookmarksIndexPath());
+    } finally {
+      db.close();
+    }
+  }
+}
+
+export function formatBookmarkFolderSyncResult(result: BookmarkFolderSyncResult): string {
+  const stopReason = ({
+    'dry run': 'dry run',
+    'no eligible labels': 'no eligible labels',
+    'batch complete (more pending)': 'batch complete; run again to continue',
+    'max runtime reached': 'paused after max runtime; run again to continue',
+    'max actions reached': 'reached requested action limit',
+    'paused with pending assignments': 'paused with assignments still pending',
+    done: 'done',
+  } as Record<string, string>)[result.stopReason] ?? result.stopReason;
+  const labels = result.eligibleLabels.map((label) => `${label.folderName} (${label.count})`).join(' · ');
+  return [
+    `Folder sync: ${result.dryRun ? 'dry run' : 'applied'}`,
+    `  folder basis: ${result.folderBy}`,
+    `  labels: ${result.eligibleLabels.length}${labels ? `  (${labels})` : ''}`,
+    `  folders matched: ${result.foldersMatched}`,
+    `  folders created: ${result.foldersCreated}`,
+    `  planned assignments: ${result.assignmentsPlanned}`,
+    `  already present: ${result.assignmentsAlreadyPresent}`,
+    `  assignments completed: ${result.assignmentsCompleted}`,
+    `  assignments pending: ${result.assignmentsPending}`,
+    `  stop reason: ${stopReason}`,
+  ].join('\n');
+}

--- a/src/x-client-transaction.ts
+++ b/src/x-client-transaction.ts
@@ -1,0 +1,183 @@
+import { createHash, randomInt } from 'node:crypto';
+
+const DEFAULT_KEYWORD = 'obfiowerehiring';
+const ADDITIONAL_RANDOM_NUMBER = 3;
+const HOME_URL = 'https://x.com/';
+const ON_DEMAND_FILE_REGEX = /['"]ondemand\.s['"]\s*:\s*['"]([\w]+)['"]/;
+const META_VERIFICATION_REGEX =
+  /<meta[^>]+name=["']twitter-site-verification["'][^>]+content=["']([^"']+)["']/i;
+const LOADING_ANIM_REGEX = /<svg[^>]+id=["']loading-x-anim-\d+["'][\s\S]*?<\/svg>/gi;
+const PATH_REGEX = /<path[^>]+d=["']([^"']+)["']/gi;
+const INDICES_REGEX = /\(\w\[(\d{1,2})\],\s*16\)/g;
+
+interface TransactionState {
+  keyBytes: number[];
+  animationKey: string;
+}
+
+function floatToHex(x: number): string {
+  const result: string[] = [];
+  let quotient = Math.trunc(x);
+  let fraction = x - quotient;
+
+  while (quotient > 0) {
+    const next = Math.trunc(x / 16);
+    const remainder = Math.trunc(x - next * 16);
+    result.unshift(remainder > 9 ? String.fromCharCode(remainder + 55) : String(remainder));
+    x = next;
+    quotient = Math.trunc(x);
+  }
+
+  if (result.length === 0) result.push('0');
+  if (fraction === 0) return result.join('');
+
+  result.push('.');
+  let safety = 0;
+  while (fraction > 0 && safety < 16) {
+    fraction *= 16;
+    const integer = Math.trunc(fraction);
+    fraction -= integer;
+    result.push(integer > 9 ? String.fromCharCode(integer + 55) : String(integer));
+    safety += 1;
+  }
+  return result.join('');
+}
+
+function isOdd(num: number): number {
+  return num % 2 ? -1 : 0;
+}
+
+function interpolate(from: number[], to: number[], value: number): number[] {
+  return from.map((item, index) => item + (to[index] - item) * value);
+}
+
+function cubicBezierValue(curves: number[], t: number): number {
+  const [p1x, p1y, p2x, p2y] = curves;
+  const u = 1 - t;
+  const tt = t * t;
+  const uu = u * u;
+  const y = 3 * uu * t * p1y + 3 * u * tt * p2y + tt * t;
+  const x = 3 * uu * t * p1x + 3 * u * tt * p2x + tt * t;
+  if (x === 0) return y;
+  return y;
+}
+
+function rotationMatrix(degrees: number): number[] {
+  const radians = (degrees * Math.PI) / 180;
+  const cos = Math.cos(radians);
+  const sin = Math.sin(radians);
+  return [cos, sin, -sin, cos];
+}
+
+function extractVerificationKey(html: string): string {
+  const match = META_VERIFICATION_REGEX.exec(html);
+  if (!match?.[1]) throw new Error("Couldn't extract the twitter-site-verification key from x.com.");
+  return match[1];
+}
+
+function extractOnDemandPath(html: string): string {
+  const match = ON_DEMAND_FILE_REGEX.exec(html);
+  if (!match?.[1]) throw new Error("Couldn't locate X's ondemand transaction script.");
+  return `https://abs.twimg.com/responsive-web/client-web/ondemand.s.${match[1]}a.js`;
+}
+
+function extractIndices(script: string): { rowIndex: number; keyByteIndices: number[] } {
+  const matches = Array.from(script.matchAll(INDICES_REGEX)).map((match) => Number(match[1]));
+  if (matches.length < 2) throw new Error("Couldn't derive X transaction key indices.");
+  return { rowIndex: matches[0], keyByteIndices: matches.slice(1) };
+}
+
+function extractFrames(html: string): string[] {
+  const frames = Array.from(html.matchAll(LOADING_ANIM_REGEX)).map((match) => match[0]);
+  if (frames.length === 0) throw new Error("Couldn't locate X loading animation frames for transaction ids.");
+  return frames;
+}
+
+function parseFrameRows(frameHtml: string): number[][] {
+  const pathMatches = Array.from(frameHtml.matchAll(PATH_REGEX)).map((match) => match[1]);
+  const targetPath = pathMatches[1] ?? pathMatches[0];
+  if (!targetPath) throw new Error("Couldn't parse an SVG path from the X loading animation.");
+  return targetPath
+    .slice(9)
+    .split('C')
+    .map((segment) => segment.replace(/[^\d]+/g, ' ').trim())
+    .filter(Boolean)
+    .map((segment) => segment.split(/\s+/).map((value) => Number(value)));
+}
+
+function solve(value: number, min: number, max: number, rounding: boolean): number {
+  const result = (value * (max - min)) / 255 + min;
+  return rounding ? Math.floor(result) : Math.round(result * 100) / 100;
+}
+
+function animate(frame: number[], targetTime: number): string {
+  const fromColor = [...frame.slice(0, 3), 1].map(Number);
+  const toColor = [...frame.slice(3, 6), 1].map(Number);
+  const toRotation = [solve(frame[6], 60, 360, true)];
+  const curves = frame.slice(7).map((value, index) => solve(value, isOdd(index), 1, false));
+  const tween = cubicBezierValue(curves, targetTime);
+  const color = interpolate(fromColor, toColor, tween).map((value) => (value > 0 ? value : 0));
+  const matrix = rotationMatrix(interpolate([0], toRotation, tween)[0]);
+
+  const parts = color.slice(0, -1).map((value) => Math.round(value).toString(16));
+  for (const value of matrix) {
+    const rounded = Math.abs(Math.round(value * 100) / 100);
+    const hex = floatToHex(rounded).toLowerCase();
+    parts.push(hex.startsWith('.') ? `0${hex}` : hex || '0');
+  }
+  parts.push('0', '0');
+  return parts.join('').replace(/[.-]/g, '');
+}
+
+async function buildTransactionState(userAgent: string): Promise<TransactionState> {
+  const homeResponse = await fetch(HOME_URL, {
+    headers: {
+      'user-agent': userAgent,
+      'cache-control': 'no-cache',
+      referer: HOME_URL,
+    },
+  });
+  const homeHtml = await homeResponse.text();
+  const key = extractVerificationKey(homeHtml);
+  const keyBytes = Array.from(Buffer.from(key, 'base64'));
+  const frames = extractFrames(homeHtml);
+  const onDemandUrl = extractOnDemandPath(homeHtml);
+  const script = await fetch(onDemandUrl, { headers: { 'user-agent': userAgent, referer: HOME_URL } }).then((r) => r.text());
+  const { rowIndex, keyByteIndices } = extractIndices(script);
+
+  const rows = parseFrameRows(frames[keyBytes[5] % frames.length]);
+  const targetRow = rows[keyBytes[rowIndex] % 16];
+  const frameTime = keyByteIndices
+    .map((index) => keyBytes[index] % 16)
+    .reduce((product, value) => product * value, 1);
+  const animationKey = animate(targetRow, frameTime / 4096);
+  return { keyBytes, animationKey };
+}
+
+export interface XClientTransactionIdGenerator {
+  generate(method: string, path: string): Promise<string>;
+}
+
+export class XClientTransaction implements XClientTransactionIdGenerator {
+  private statePromise?: Promise<TransactionState>;
+
+  constructor(private readonly userAgent: string) {}
+
+  private state(): Promise<TransactionState> {
+    if (!this.statePromise) this.statePromise = buildTransactionState(this.userAgent);
+    return this.statePromise;
+  }
+
+  async generate(method: string, path: string): Promise<string> {
+    const state = await this.state();
+    const timeNow = Math.floor((Date.now() - 1682924400 * 1000) / 1000);
+    const timeBytes = [0, 1, 2, 3].map((index) => (timeNow >> (index * 8)) & 0xff);
+    const hash = createHash('sha256')
+      .update(`${method.toUpperCase()}!${path}!${timeNow}${DEFAULT_KEYWORD}${state.animationKey}`)
+      .digest();
+    const payload = [...state.keyBytes, ...timeBytes, ...Array.from(hash.subarray(0, 16)), ADDITIONAL_RANDOM_NUMBER];
+    const mask = randomInt(0, 256);
+    const out = Buffer.from([mask, ...payload.map((value) => value ^ mask)]);
+    return out.toString('base64').replace(/=+$/g, '');
+  }
+}

--- a/src/x-session.ts
+++ b/src/x-session.ts
@@ -1,0 +1,89 @@
+import { loadChromeSessionConfig } from './config.js';
+import { extractChromeXCookies } from './chrome-cookies.js';
+import { extractFirefoxXCookies } from './firefox-cookies.js';
+import { XClientTransaction, type XClientTransactionIdGenerator } from './x-client-transaction.js';
+
+export const X_PUBLIC_BEARER =
+  'AAAAAAAAAAAAAAAAAAAAANRILgAAAAAAnNwIzUejRCOuH5E6I8xnZz4puTs%3D1Zv7ttfk8LF81IUq16cHjhLTvJu4FA33AGWWjCpTnA';
+
+export const DEFAULT_X_USER_AGENT =
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.0.0 Safari/537.36';
+
+export interface XSessionOptions {
+  browser?: string;
+  chromeUserDataDir?: string;
+  chromeProfileDirectory?: string;
+  firefoxProfileDir?: string;
+  csrfToken?: string;
+  cookieHeader?: string;
+  userAgent?: string;
+  transactionIdGenerator?: XClientTransactionIdGenerator;
+}
+
+export interface XSessionAuth {
+  csrfToken: string;
+  cookieHeader: string;
+}
+
+export interface XSessionContext extends XSessionAuth {
+  userAgent: string;
+  headers: Record<string, string>;
+  transactionIdGenerator: XClientTransactionIdGenerator;
+}
+
+export function buildXHeaders(
+  auth: XSessionAuth,
+  options: { userAgent?: string; contentType?: string } = {},
+): Record<string, string> {
+  const userAgent = options.userAgent ?? DEFAULT_X_USER_AGENT;
+  const headers: Record<string, string> = {
+    authorization: `Bearer ${X_PUBLIC_BEARER}`,
+    'x-csrf-token': auth.csrfToken,
+    'x-twitter-auth-type': 'OAuth2Session',
+    'x-twitter-active-user': 'yes',
+    referer: 'https://x.com/',
+    'user-agent': userAgent,
+    cookie: auth.cookieHeader,
+  };
+  if (options.contentType) headers['content-type'] = options.contentType;
+  return headers;
+}
+
+export function resolveXSessionAuth(options: XSessionOptions = {}): XSessionAuth {
+  if (options.csrfToken) {
+    return {
+      csrfToken: options.csrfToken,
+      cookieHeader: options.cookieHeader ?? `ct0=${options.csrfToken}`,
+    };
+  }
+
+  const config = loadChromeSessionConfig({ browserId: options.browser });
+
+  if (config.browser.cookieBackend === 'firefox') {
+    const cookies = extractFirefoxXCookies(options.firefoxProfileDir);
+    return {
+      csrfToken: cookies.csrfToken,
+      cookieHeader: cookies.cookieHeader,
+    };
+  }
+
+  const chromeDir = options.chromeUserDataDir ?? config.chromeUserDataDir;
+  const chromeProfile = options.chromeProfileDirectory ?? config.chromeProfileDirectory;
+  const cookies = extractChromeXCookies(chromeDir, chromeProfile, config.browser);
+  return {
+    csrfToken: cookies.csrfToken,
+    cookieHeader: cookies.cookieHeader,
+  };
+}
+
+export function createXSessionContext(options: XSessionOptions = {}): XSessionContext {
+  const auth = resolveXSessionAuth(options);
+  const userAgent = options.userAgent ?? DEFAULT_X_USER_AGENT;
+  const transactionIdGenerator = options.transactionIdGenerator ?? new XClientTransaction(userAgent);
+  return {
+    ...auth,
+    userAgent,
+    headers: buildXHeaders(auth, { userAgent, contentType: 'application/json' }),
+    transactionIdGenerator,
+  };
+}

--- a/tests/bookmarks-db.test.ts
+++ b/tests/bookmarks-db.test.ts
@@ -3,7 +3,14 @@ import assert from 'node:assert/strict';
 import { mkdtemp, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
-import { buildIndex, searchBookmarks, getStats, formatSearchResults, getBookmarkById } from '../src/bookmarks-db.js';
+import {
+  buildIndex,
+  searchBookmarks,
+  getStats,
+  formatSearchResults,
+  getBookmarkById,
+  openBookmarksIndexDb,
+} from '../src/bookmarks-db.js';
 import { openDb, saveDb } from '../src/db.js';
 import { twitterBookmarksIndexPath } from '../src/paths.js';
 
@@ -47,7 +54,7 @@ test('buildIndex refreshes existing rows without dropping classifications', asyn
         `UPDATE bookmarks
          SET categories = ?, primary_category = ?, domains = ?, primary_domain = ?, github_urls = ?
          WHERE id = ?`,
-        ['ai,ml', 'research', 'example.com', 'example.com', '["https://github.com/openai/test"]', '1']
+        ['ai,ml', 'research', 'example.com', 'example.com', '["https://github.com/openai/test"]', '1'],
       );
       saveDb(db, dbPath);
     } finally {
@@ -61,7 +68,7 @@ test('buildIndex refreshes existing rows without dropping classifications', asyn
             text: 'Machine learning note updated',
             bookmarkedAt: '2026-04-02T00:00:00Z',
           }
-        : fixture
+        : fixture,
     );
     const jsonl = updatedFixtures.map((r) => JSON.stringify(r)).join('\n') + '\n';
     await writeFile(path.join(process.env.FT_DATA_DIR!, 'bookmarks.jsonl'), jsonl);
@@ -79,6 +86,66 @@ test('buildIndex refreshes existing rows without dropping classifications', asyn
     assert.deepEqual(bookmark.domains, ['example.com']);
     assert.equal(bookmark.primaryDomain, 'example.com');
     assert.deepEqual(bookmark.githubUrls, ['https://github.com/openai/test']);
+  });
+});
+
+test('openBookmarksIndexDb upgrades schema version 4 databases with folder sync tables', async () => {
+  await withIsolatedDataDir(async () => {
+    const dbPath = twitterBookmarksIndexPath();
+    const db = await openDb(dbPath);
+    try {
+      db.run(`CREATE TABLE meta (key TEXT PRIMARY KEY, value TEXT)`);
+      db.run(`INSERT INTO meta VALUES ('schema_version', '4')`);
+      db.run(`CREATE TABLE bookmarks (
+        id TEXT PRIMARY KEY,
+        tweet_id TEXT NOT NULL,
+        url TEXT NOT NULL,
+        text TEXT NOT NULL,
+        author_handle TEXT,
+        author_name TEXT,
+        author_profile_image_url TEXT,
+        posted_at TEXT,
+        bookmarked_at TEXT,
+        synced_at TEXT NOT NULL,
+        conversation_id TEXT,
+        in_reply_to_status_id TEXT,
+        quoted_status_id TEXT,
+        language TEXT,
+        like_count INTEGER,
+        repost_count INTEGER,
+        reply_count INTEGER,
+        quote_count INTEGER,
+        bookmark_count INTEGER,
+        view_count INTEGER,
+        media_count INTEGER DEFAULT 0,
+        link_count INTEGER DEFAULT 0,
+        links_json TEXT,
+        tags_json TEXT,
+        ingested_via TEXT,
+        categories TEXT,
+        primary_category TEXT,
+        github_urls TEXT,
+        domains TEXT,
+        primary_domain TEXT,
+        quoted_tweet_json TEXT
+      )`);
+      saveDb(db, dbPath);
+    } finally {
+      db.close();
+    }
+
+    const migrated = await openBookmarksIndexDb();
+    try {
+      const tables = migrated.exec(
+        `SELECT name FROM sqlite_master WHERE type='table' AND name IN ('x_bookmark_folders', 'x_bookmark_folder_sync') ORDER BY name`,
+      );
+      assert.deepEqual(tables[0].values.map((row) => row[0]), ['x_bookmark_folder_sync', 'x_bookmark_folders']);
+
+      const version = migrated.exec(`SELECT value FROM meta WHERE key = 'schema_version'`);
+      assert.equal(version[0].values[0][0], '5');
+    } finally {
+      migrated.close();
+    }
   });
 });
 

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1,6 +1,32 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { compareVersions, runWithSpinner } from '../src/cli.js';
+import { mkdtemp, mkdir, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { buildCli, compareVersions, runWithSpinner } from '../src/cli.js';
+import { twitterBookmarksCachePath, twitterBookmarksIndexPath } from '../src/paths.js';
+
+const originalDataDir = process.env.FT_DATA_DIR;
+const originalLog = console.log;
+const originalError = console.error;
+const originalStderrWrite = process.stderr.write.bind(process.stderr);
+
+test.after(() => {
+  console.log = originalLog;
+  console.error = originalError;
+  process.stderr.write = originalStderrWrite as typeof process.stderr.write;
+  if (originalDataDir) process.env.FT_DATA_DIR = originalDataDir;
+  else delete process.env.FT_DATA_DIR;
+});
+
+async function setupCliFixture(): Promise<string> {
+  const cwd = await mkdtemp(path.join(tmpdir(), 'ft-cli-'));
+  process.env.FT_DATA_DIR = cwd;
+  await mkdir(cwd, { recursive: true });
+  await writeFile(twitterBookmarksCachePath(), '\n');
+  await writeFile(twitterBookmarksIndexPath(), '');
+  return cwd;
+}
 
 test('compareVersions: equal versions return 0', () => {
   assert.equal(compareVersions('1.2.3', '1.2.3'), 0);
@@ -52,4 +78,217 @@ test('runWithSpinner: stops spinner after error', async () => {
   );
 
   assert.equal(stopped, 1);
+});
+
+test('ft sync --folders delegates bounded folder sync defaults', async () => {
+  await setupCliFixture();
+  let captured: any;
+  console.log = () => {};
+  console.error = () => {};
+
+  const cli = buildCli({
+    syncBookmarksGraphQL: async () => ({
+      added: 0,
+      bookmarkedAtRepaired: 0,
+      totalBookmarks: 0,
+      bookmarkedAtMissing: 0,
+      pages: 0,
+      stopReason: 'end of bookmarks',
+      cachePath: twitterBookmarksCachePath(),
+      statePath: '/tmp/state.json',
+    }),
+    syncBookmarkFolders: async (options) => {
+      captured = options;
+      return {
+        folderBy: 'domain',
+        dryRun: false,
+        eligibleLabels: [],
+        foldersCreated: 0,
+        foldersMatched: 0,
+        assignmentsPlanned: 0,
+        assignmentsCompleted: 0,
+        assignmentsAlreadyPresent: 0,
+        assignmentsPending: 0,
+        stopReason: 'done',
+        overridePath: '/tmp/ops.json',
+      };
+    },
+  });
+
+  await cli.parseAsync(['sync', '--folders'], { from: 'user' });
+  assert.equal(captured.dryRun, false);
+  assert.equal(captured.maxActions, 500);
+  assert.equal(captured.maxMinutes, 15);
+  assert.equal(captured.folderBy, 'domain');
+});
+
+test('ft sync --folders forwards current browser session flags into folder sync', async () => {
+  await setupCliFixture();
+  let captured: any;
+  console.log = () => {};
+  console.error = () => {};
+
+  const cli = buildCli({
+    syncBookmarksGraphQL: async () => ({
+      added: 0,
+      bookmarkedAtRepaired: 0,
+      totalBookmarks: 0,
+      bookmarkedAtMissing: 0,
+      pages: 0,
+      stopReason: 'end of bookmarks',
+      cachePath: twitterBookmarksCachePath(),
+      statePath: '/tmp/state.json',
+    }),
+    syncBookmarkFolders: async (options) => {
+      captured = options;
+      return {
+        folderBy: 'domain',
+        dryRun: false,
+        eligibleLabels: [],
+        foldersCreated: 0,
+        foldersMatched: 0,
+        assignmentsPlanned: 0,
+        assignmentsCompleted: 0,
+        assignmentsAlreadyPresent: 0,
+        assignmentsPending: 0,
+        stopReason: 'done',
+        overridePath: '/tmp/ops.json',
+      };
+    },
+  });
+
+  await cli.parseAsync([
+    'sync',
+    '--folders',
+    '--browser', 'firefox',
+    '--cookies', 'csrf-123', 'token-456',
+    '--chrome-user-data-dir', '/tmp/chrome-data',
+    '--chrome-profile-directory', 'Profile 7',
+    '--firefox-profile-dir', '/tmp/firefox-profile',
+  ], { from: 'user' });
+
+  assert.equal(captured.browser, 'firefox');
+  assert.equal(captured.csrfToken, 'csrf-123');
+  assert.equal(captured.cookieHeader, 'ct0=csrf-123; auth_token=token-456');
+  assert.equal(captured.chromeUserDataDir, '/tmp/chrome-data');
+  assert.equal(captured.chromeProfileDirectory, 'Profile 7');
+  assert.equal(captured.firefoxProfileDir, '/tmp/firefox-profile');
+});
+
+test('ft sync keeps advanced folder options off the main command surface', () => {
+  const cli = buildCli();
+  const syncCommand = cli.commands.find((command) => command.name() === 'sync');
+  assert.ok(syncCommand);
+  const flags = syncCommand.options.map((option) => option.long);
+  assert.ok(flags.includes('--folders'));
+  assert.ok(!flags.includes('--folder-by'));
+  assert.ok(!flags.includes('--min-folder-size'));
+  assert.ok(!flags.includes('--include-label'));
+  assert.ok(!flags.includes('--exclude-label'));
+  assert.ok(!flags.includes('--until-done'));
+});
+
+test('ft folders sync --until-done forwards resumable defaults', async () => {
+  await setupCliFixture();
+  let captured: any;
+  console.log = () => {};
+  console.error = () => {};
+
+  const cli = buildCli({
+    syncBookmarkFolders: async (options) => {
+      captured = options;
+      return {
+        folderBy: 'domain',
+        dryRun: false,
+        eligibleLabels: [],
+        foldersCreated: 0,
+        foldersMatched: 0,
+        assignmentsPlanned: 0,
+        assignmentsCompleted: 0,
+        assignmentsAlreadyPresent: 0,
+        assignmentsPending: 0,
+        stopReason: 'done',
+        overridePath: '/tmp/ops.json',
+      };
+    },
+  });
+
+  await cli.parseAsync(['folders', 'sync', '--until-done'], { from: 'user' });
+  assert.equal(captured.untilDone, true);
+  assert.equal(captured.maxMinutes, 240);
+  assert.equal(captured.maxActions, Number.POSITIVE_INFINITY);
+});
+
+test('ft folders sync forwards browser and cookie flags', async () => {
+  await setupCliFixture();
+  let captured: any;
+  console.log = () => {};
+  console.error = () => {};
+
+  const cli = buildCli({
+    syncBookmarkFolders: async (options) => {
+      captured = options;
+      return {
+        folderBy: 'domain',
+        dryRun: false,
+        eligibleLabels: [],
+        foldersCreated: 0,
+        foldersMatched: 0,
+        assignmentsPlanned: 0,
+        assignmentsCompleted: 0,
+        assignmentsAlreadyPresent: 0,
+        assignmentsPending: 0,
+        stopReason: 'done',
+        overridePath: '/tmp/ops.json',
+      };
+    },
+  });
+
+  await cli.parseAsync([
+    'folders', 'sync',
+    '--browser', 'firefox',
+    '--cookies', 'csrf-abc',
+    '--firefox-profile-dir', '/tmp/firefox',
+  ], { from: 'user' });
+
+  assert.equal(captured.browser, 'firefox');
+  assert.equal(captured.csrfToken, 'csrf-abc');
+  assert.equal(captured.cookieHeader, 'ct0=csrf-abc');
+  assert.equal(captured.firefoxProfileDir, '/tmp/firefox');
+});
+
+test('ft folders sync attaches live progress reporting for non-dry runs', async () => {
+  await setupCliFixture();
+  let captured: any;
+  console.log = () => {};
+  console.error = () => {};
+  process.stderr.write = (() => true) as typeof process.stderr.write;
+
+  const cli = buildCli({
+    syncBookmarkFolders: async (options) => {
+      captured = options;
+      options.onProgress?.({
+        phase: 'assigning',
+        completed: 1,
+        total: 10,
+        detail: 'AI ← 123',
+      });
+      return {
+        folderBy: 'domain',
+        dryRun: false,
+        eligibleLabels: [],
+        foldersCreated: 0,
+        foldersMatched: 0,
+        assignmentsPlanned: 10,
+        assignmentsCompleted: 1,
+        assignmentsAlreadyPresent: 0,
+        assignmentsPending: 9,
+        stopReason: 'done',
+        overridePath: '/tmp/ops.json',
+      };
+    },
+  });
+
+  await cli.parseAsync(['folders', 'sync', '--max-actions', '10'], { from: 'user' });
+  assert.equal(typeof captured.onProgress, 'function');
 });

--- a/tests/x-bookmark-folders.test.ts
+++ b/tests/x-bookmark-folders.test.ts
@@ -1,0 +1,317 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, mkdir, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import {
+  buildGraphqlGetUrl,
+  buildGraphqlPostBody,
+  formatFolderName,
+  parseBookmarkFolderTimelineResponse,
+  parseBookmarkFoldersSliceResponse,
+  selectFolderLabels,
+  syncBookmarkFolders,
+} from '../src/x-bookmark-folders.js';
+import { twitterBookmarksCachePath, twitterBookmarksIndexPath } from '../src/paths.js';
+import { buildIndex, openBookmarksIndexDb } from '../src/bookmarks-db.js';
+import { saveDb } from '../src/db.js';
+
+const originalDataDir = process.env.FT_DATA_DIR;
+
+test.after(() => {
+  if (originalDataDir) process.env.FT_DATA_DIR = originalDataDir;
+  else delete process.env.FT_DATA_DIR;
+});
+
+function makeTimelineResponse(tweetIds: string[], cursor?: string) {
+  return {
+    data: {
+      bookmark_timeline_v2: {
+        timeline: {
+          instructions: [
+            {
+              type: 'TimelineAddEntries',
+              entries: [
+                ...tweetIds.map((tweetId, index) => ({
+                  entryId: `tweet-${index}`,
+                  content: {
+                    itemContent: {
+                      tweet_results: {
+                        result: {
+                          rest_id: tweetId,
+                          legacy: {
+                            id_str: tweetId,
+                            full_text: `Tweet ${tweetId}`,
+                            entities: { urls: [] },
+                          },
+                        },
+                      },
+                    },
+                  },
+                })),
+                ...(cursor ? [{ entryId: 'cursor-bottom-1', content: { value: cursor } }] : []),
+              ],
+            },
+          ],
+        },
+      },
+    },
+  };
+}
+
+async function setupFolderFixture(): Promise<string> {
+  const cwd = await mkdtemp(path.join(tmpdir(), 'ft-folders-'));
+  process.env.FT_DATA_DIR = cwd;
+  await mkdir(cwd, { recursive: true });
+  const records = [
+    {
+      id: '1',
+      tweetId: '1',
+      url: 'https://x.com/alice/status/1',
+      text: 'AI systems',
+      authorHandle: 'alice',
+      authorName: 'Alice',
+      syncedAt: '2026-01-01T00:00:00Z',
+      postedAt: '2026-01-01T00:00:00Z',
+      bookmarkedAt: '2026-01-01T01:00:00Z',
+      language: 'en',
+      links: [],
+      tags: [],
+      ingestedVia: 'graphql',
+      categories: 'opinion',
+      primaryCategory: 'opinion',
+      domains: 'ai',
+      primaryDomain: 'ai',
+    },
+    {
+      id: '2',
+      tweetId: '2',
+      url: 'https://x.com/bob/status/2',
+      text: 'Another AI bookmark',
+      authorHandle: 'bob',
+      authorName: 'Bob',
+      syncedAt: '2026-01-02T00:00:00Z',
+      postedAt: '2026-01-02T00:00:00Z',
+      bookmarkedAt: '2026-01-02T01:00:00Z',
+      language: 'en',
+      links: [],
+      tags: [],
+      ingestedVia: 'graphql',
+      categories: 'tool',
+      primaryCategory: 'tool',
+      domains: 'ai',
+      primaryDomain: 'ai',
+    },
+    {
+      id: '3',
+      tweetId: '3',
+      url: 'https://x.com/cara/status/3',
+      text: 'Religion bookmark',
+      authorHandle: 'cara',
+      authorName: 'Cara',
+      syncedAt: '2026-01-03T00:00:00Z',
+      postedAt: '2026-01-03T00:00:00Z',
+      bookmarkedAt: '2026-01-03T01:00:00Z',
+      language: 'en',
+      links: [],
+      tags: [],
+      ingestedVia: 'graphql',
+      categories: 'research',
+      primaryCategory: 'research',
+      domains: 'religion',
+      primaryDomain: 'religion',
+    },
+  ];
+  const jsonl = records.map((row) => JSON.stringify(row)).join('\n') + '\n';
+  await writeFile(twitterBookmarksCachePath(), jsonl);
+  await buildIndex({ force: true });
+  const db = await openBookmarksIndexDb();
+  try {
+    db.run(`UPDATE bookmarks SET categories = 'opinion', primary_category = 'opinion', domains = 'ai', primary_domain = 'ai' WHERE tweet_id = '1'`);
+    db.run(`UPDATE bookmarks SET categories = 'tool', primary_category = 'tool', domains = 'ai', primary_domain = 'ai' WHERE tweet_id = '2'`);
+    db.run(`UPDATE bookmarks SET categories = 'research', primary_category = 'research', domains = 'religion', primary_domain = 'religion' WHERE tweet_id = '3'`);
+    saveDb(db, twitterBookmarksIndexPath());
+  } finally {
+    db.close();
+  }
+  return cwd;
+}
+
+test('formatFolderName maps special slugs and title-cases the rest', () => {
+  assert.equal(formatFolderName('ai'), 'AI');
+  assert.equal(formatFolderName('web-dev'), 'Web Dev');
+  assert.equal(formatFolderName('religion'), 'Religion');
+});
+
+test('selectFolderLabels applies thresholds and include/exclude overrides', () => {
+  const labels = selectFolderLabels(
+    { ai: 10, religion: 4, politics: 2, health: 1 },
+    { minFolderSize: 3, includeLabels: ['health'], excludeLabels: ['politics'] },
+  );
+
+  assert.deepEqual(
+    labels.map((item) => item.label),
+    ['ai', 'religion', 'health'],
+  );
+});
+
+test('GraphQL builders encode variables correctly', () => {
+  const operation = { queryId: 'qid123', operationName: 'BookmarkFoldersSlice', method: 'GET' as const };
+  const url = buildGraphqlGetUrl(operation, { cursor: 'abc' }, { featureA: true });
+  const parsed = new URL(url);
+  assert.equal(parsed.pathname, '/i/api/graphql/qid123/BookmarkFoldersSlice');
+  assert.equal(parsed.searchParams.get('variables'), JSON.stringify({ cursor: 'abc' }));
+  assert.equal(parsed.searchParams.get('features'), JSON.stringify({ featureA: true }));
+
+  const body = buildGraphqlPostBody(
+    { queryId: 'qid456', operationName: 'createBookmarkFolder', method: 'POST' },
+    { name: 'AI' },
+  );
+  assert.deepEqual(body, { queryId: 'qid456', variables: { name: 'AI' } });
+});
+
+test('parseBookmarkFoldersSliceResponse extracts folders recursively', () => {
+  const parsed = parseBookmarkFoldersSliceResponse({
+    data: {
+      viewer: {
+        folders: [
+          { bookmark_collection_id: 'folder-1', name: 'AI', media: { icon: 'star' } },
+          { bookmark_collection_id: 'folder-2', name: 'Religion' },
+        ],
+      },
+    },
+  });
+
+  assert.deepEqual(parsed.folders.map((folder) => folder.id), ['folder-1', 'folder-2']);
+  assert.equal(parsed.folders[0].name, 'AI');
+});
+
+test('parseBookmarkFoldersSliceResponse accepts current id-based X folder items', () => {
+  const parsed = parseBookmarkFoldersSliceResponse({
+    data: {
+      viewer: {
+        user_results: {
+          result: {
+            bookmark_collections_slice: {
+              items: [
+                { id: '2041087987396583655', name: 'AI', media: { media_key: '3_1' } },
+              ],
+            },
+          },
+        },
+      },
+    },
+  });
+
+  assert.deepEqual(parsed.folders, [{ id: '2041087987396583655', name: 'AI', media: { media_key: '3_1' } }]);
+});
+
+test('parseBookmarkFolderTimelineResponse extracts tweet ids and cursor', () => {
+  const parsed = parseBookmarkFolderTimelineResponse(makeTimelineResponse(['123', '456'], 'next-cursor'));
+  assert.deepEqual(parsed.tweetIds, ['123', '456']);
+  assert.equal(parsed.nextCursor, 'next-cursor');
+});
+
+test('syncBookmarkFolders dry-run plans assignments and sends transaction headers', async () => {
+  await setupFolderFixture();
+  const requests: Array<{ url: string; headers: Record<string, string> }> = [];
+  const result = await syncBookmarkFolders({
+    dryRun: true,
+    minFolderSize: 2,
+    session: {
+      csrfToken: 'csrf',
+      cookieHeader: 'ct0=csrf; auth_token=token',
+      userAgent: 'TestAgent/1.0',
+      headers: {},
+      transactionIdGenerator: { generate: async () => 'txid-123' },
+    },
+    fetchImpl: async (input: string | URL, init?: RequestInit) => {
+      requests.push({
+        url: String(input),
+        headers: (init?.headers ?? {}) as Record<string, string>,
+      });
+      return new Response(JSON.stringify({
+        data: {
+          viewer: {
+            folders: [{ bookmark_collection_id: 'folder-1', name: 'AI' }],
+          },
+        },
+      }), { status: 200 });
+    },
+  });
+
+  assert.equal(result.dryRun, true);
+  assert.equal(result.eligibleLabels.length, 1);
+  assert.equal(result.eligibleLabels[0].label, 'ai');
+  assert.equal(result.assignmentsPlanned, 2);
+  assert.equal(requests.length > 0, true);
+  assert.equal(requests[0].headers['x-client-transaction-id'], 'txid-123');
+});
+
+test('syncBookmarkFolders recovers folder id by re-listing folders after create response omits it', async () => {
+  await setupFolderFixture();
+  const requests: string[] = [];
+  let listCount = 0;
+
+  const result = await syncBookmarkFolders({
+    minFolderSize: 2,
+    maxActions: 0,
+    sleep: async () => {},
+    session: {
+      csrfToken: 'csrf',
+      cookieHeader: 'ct0=csrf; auth_token=token',
+      userAgent: 'TestAgent/1.0',
+      headers: {},
+      transactionIdGenerator: { generate: async () => 'txid-456' },
+    },
+    fetchImpl: async (input: string | URL) => {
+      const url = String(input);
+      requests.push(url);
+
+      if (url.includes('/BookmarkFoldersSlice')) {
+        listCount += 1;
+        const folders = listCount === 1
+          ? []
+          : [{ id: 'folder-1', name: 'AI', media: { media_key: '3_1' } }];
+        return new Response(JSON.stringify({
+          data: {
+            viewer: {
+              user_results: {
+                result: {
+                  bookmark_collections_slice: {
+                    items: folders,
+                  },
+                },
+              },
+            },
+          },
+        }), { status: 200 });
+      }
+
+      if (url.includes('/createBookmarkFolder')) {
+        return new Response(JSON.stringify({ data: {} }), { status: 200 });
+      }
+
+      throw new Error(`Unexpected request: ${url}`);
+    },
+  });
+
+  assert.equal(result.foldersCreated, 1);
+  assert.equal(result.foldersMatched, 0);
+  assert.equal(result.assignmentsPending, 2);
+  assert.equal(result.stopReason, 'batch complete (more pending)');
+  assert.equal(requests.some((url) => url.includes('/createBookmarkFolder')), true);
+});
+
+test('openBookmarksIndexDb exposes folder sync tables after migration', async () => {
+  await setupFolderFixture();
+  const db = await openBookmarksIndexDb();
+  try {
+    const rows = db.exec(
+      `SELECT name FROM sqlite_master WHERE type='table' AND name IN ('x_bookmark_folders', 'x_bookmark_folder_sync') ORDER BY name`,
+    );
+    assert.deepEqual(rows[0].values.map((row) => row[0]), ['x_bookmark_folder_sync', 'x_bookmark_folders']);
+  } finally {
+    db.close();
+  }
+});

--- a/tests/x-bookmark-folders.test.ts
+++ b/tests/x-bookmark-folders.test.ts
@@ -303,6 +303,59 @@ test('syncBookmarkFolders recovers folder id by re-listing folders after create 
   assert.equal(requests.some((url) => url.includes('/createBookmarkFolder')), true);
 });
 
+test('syncBookmarkFolders persists resumable state to disk', async () => {
+  await setupFolderFixture();
+
+  await syncBookmarkFolders({
+    minFolderSize: 2,
+    maxActions: 0,
+    sleep: async () => {},
+    session: {
+      csrfToken: 'csrf',
+      cookieHeader: 'ct0=csrf; auth_token=token',
+      userAgent: 'TestAgent/1.0',
+      headers: {},
+      transactionIdGenerator: { generate: async () => 'txid-789' },
+    },
+    fetchImpl: async (input: string | URL) => {
+      const url = String(input);
+
+      if (url.includes('/BookmarkFoldersSlice')) {
+        return new Response(JSON.stringify({
+          data: {
+            viewer: {
+              user_results: {
+                result: {
+                  bookmark_collections_slice: {
+                    items: [{ id: 'folder-1', name: 'AI', media: { media_key: '3_1' } }],
+                  },
+                },
+              },
+            },
+          },
+        }), { status: 200 });
+      }
+
+      if (url.includes('/BookmarkFolderTimeline')) {
+        return new Response(JSON.stringify(makeTimelineResponse([])), { status: 200 });
+      }
+
+      throw new Error(`Unexpected request: ${url}`);
+    },
+  });
+
+  const db = await openBookmarksIndexDb();
+  try {
+    const folders = db.exec(`SELECT label, folder_id FROM x_bookmark_folders ORDER BY label`);
+    assert.deepEqual(folders[0].values, [['ai', 'folder-1']]);
+
+    const syncRows = db.exec(`SELECT tweet_id, status FROM x_bookmark_folder_sync ORDER BY tweet_id`);
+    assert.deepEqual(syncRows[0].values, [['1', 'pending'], ['2', 'pending']]);
+  } finally {
+    db.close();
+  }
+});
+
 test('openBookmarksIndexDb exposes folder sync tables after migration', async () => {
   await setupFolderFixture();
   const db = await openBookmarksIndexDb();

--- a/tests/x-session.test.ts
+++ b/tests/x-session.test.ts
@@ -1,0 +1,30 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { buildXHeaders, createXSessionContext, DEFAULT_X_USER_AGENT } from '../src/x-session.js';
+
+test('buildXHeaders includes cookie auth and csrf headers', () => {
+  const headers = buildXHeaders(
+    { csrfToken: 'csrf-123', cookieHeader: 'ct0=csrf-123; auth_token=token-456' },
+    { userAgent: 'TestAgent/1.0', contentType: 'application/json' },
+  );
+
+  assert.equal(headers.authorization.includes('Bearer '), true);
+  assert.equal(headers['x-csrf-token'], 'csrf-123');
+  assert.equal(headers.cookie, 'ct0=csrf-123; auth_token=token-456');
+  assert.equal(headers['user-agent'], 'TestAgent/1.0');
+  assert.equal(headers['content-type'], 'application/json');
+});
+
+test('createXSessionContext honors direct token overrides and custom transaction generator', () => {
+  const generator = { generate: async () => 'txid-123' };
+  const context = createXSessionContext({
+    csrfToken: 'csrf-abc',
+    cookieHeader: 'ct0=csrf-abc; auth_token=token-def',
+    transactionIdGenerator: generator,
+  });
+
+  assert.equal(context.csrfToken, 'csrf-abc');
+  assert.equal(context.cookieHeader, 'ct0=csrf-abc; auth_token=token-def');
+  assert.equal(context.transactionIdGenerator, generator);
+  assert.equal(context.userAgent, DEFAULT_X_USER_AGENT);
+});


### PR DESCRIPTION
## What changed

This adds bookmark folder sync as a lean extension of the existing `ft sync` flow.

- `ft sync --folders` now back-syncs locally classified bookmarks into matching X bookmark folders
- `ft folders sync` remains available as the advanced/resumable path for dry runs, retries, and long backfills
- folder sync reuses the existing browser-session auth approach, tracks resumable state in SQLite, and runs conservatively with visible terminal progress

## Why

`ft` already syncs bookmarks locally and classifies them by category/domain, but there was no way to push that organization back into X's native bookmark folders. This closes that loop without making the main CLI surface feel much heavier.

## Impact

Users can keep their existing local classification workflow and opt into a bounded folder sync with `ft sync --folders`, or run a full resumable backfill with `ft folders sync --until-done`.

## Validation

- `npm test`
- `npm run build`
- `node /private/tmp/fieldtheory-cli-pr/bin/ft.mjs folders sync --dry-run`
- `node /private/tmp/fieldtheory-cli-pr/bin/ft.mjs folders sync --max-actions 1`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new networked folder-creation/assignment flows against X’s internal GraphQL APIs and introduces new SQLite migration/state tables, which could impact sync behavior if X endpoints or auth headers change.
> 
> **Overview**
> Adds **folder back-sync** so locally classified bookmarks can be organized into X bookmark folders via `ft sync --folders` (bounded defaults) and a new advanced `ft folders sync` command (dry-run, include/exclude labels, resumable `--until-done`, progress output).
> 
> Implements new X session utilities (`x-session.ts` + `x-client-transaction.ts`) to centralize cookie/CSRF auth and (best-effort) generate `x-client-transaction-id` headers, and updates bookmark GraphQL sync to use this session context.
> 
> Extends the SQLite schema to track managed folders and resumable assignment state (`x_bookmark_folders`, `x_bookmark_folder_sync`, schema v4) and adds docs/tests; test runner is serialized to avoid concurrency issues.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5010080f8afcc419ce0171472dd216d46d75150. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->