### PR TITLE
Add Comet browser support (Chromium fork by Perplexity)

### DIFF
--- a/src/chrome-cookies.ts
+++ b/src/chrome-cookies.ts
@@ -11,6 +11,7 @@ export interface ChromeCookieResult {
 
 function getMacOSChromeKey(): Buffer {
   const candidates = [
+    { service: 'Comet Safe Storage', account: 'Comet' },
     { service: 'Chrome Safe Storage', account: 'Chrome' },
     { service: 'Chrome Safe Storage', account: 'Google Chrome' },
     { service: 'Google Chrome Safe Storage', account: 'Chrome' },


### PR DESCRIPTION
## Summary
Adds [Comet](https://comet.perplexity.ai/) — Perplexity's Chromium-based browser — to the list of supported Safe Storage sources for cookie decryption in \`ft sync\`.

Comet stores its cookie encryption key in the macOS Keychain under:
- **service:** \`Comet Safe Storage\`
- **account:** \`Comet\`

Adding it as the **first** candidate in \`getMacOSChromeKey\` so that on systems with both Chrome and Comet installed, Comet cookies decrypt correctly. (If Chrome Safe Storage is tried first, it succeeds for the keychain lookup but produces \`bad decrypt\` when used against Comet's cookies.)

## Change
One line in \`src/chrome-cookies.ts\`:
\`\`\`ts
{ service: 'Comet Safe Storage', account: 'Comet' },
\`\`\`

## Test plan
- [x] Ran \`ft sync --chrome-user-data-dir "~/Library/Application Support/Comet" --chrome-profile-directory "Default"\` on a Comet Default profile logged into x.com
- [x] Successfully synced **9,996 bookmarks** end-to-end
- [x] Verified \`Comet Safe Storage\` keychain entry exists via \`security find-generic-password -s "Comet Safe Storage"\`
- [x] Confirmed ordering matters — with Chrome Safe Storage first in the list, Comet cookies fail with \`Error: error:1C800064:Provider routines::bad decrypt\`

## Notes
- No new dependencies
- No behavior change for existing Chrome/Chromium/Brave users
- Comet is a Chromium fork so the cookie database layout and user-data-dir structure match Chrome exactly

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds an additional macOS Keychain candidate for deriving the Chrome-family cookie decryption key, with no changes to decryption logic or data handling beyond key lookup order.
> 
> **Overview**
> Adds support for Perplexity’s Chromium-based Comet browser by checking the macOS Keychain entry `Comet Safe Storage` (account `Comet`) first when deriving the Safe Storage key in `getMacOSChromeKey`, improving cookie decryption when both Comet and Chrome are installed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7423f3051bcfce0a2ca3333101909e52e5cf5d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->