### PR TITLE
[codex] Handle cancelled interactive prompts cleanly

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -22,6 +22,7 @@ import { formatClassificationSummary } from './bookmark-classify.js';
 import { classifyWithLlm, classifyDomainsWithLlm } from './bookmark-classify-llm.js';
 import { resolveEngine, detectAvailableEngines } from './engine.js';
 import { loadPreferences, savePreferences } from './preferences.js';
+import { PromptCancelledError, promptText } from './prompt.js';
 import { renderViz } from './bookmarks-viz.js';
 import { listBrowserIds } from './browsers.js';
 import { dataDir, ensureDataDir, isFirstRun, twitterBookmarksIndexPath } from './paths.js';
@@ -325,6 +326,11 @@ function safe(fn: (...args: any[]) => Promise<void>): (...args: any[]) => Promis
     try {
       await fn(...args);
     } catch (err) {
+      if (err instanceof PromptCancelledError) {
+        console.log(`\n  ${err.message}\n`);
+        process.exitCode = err.exitCode;
+        return;
+      }
       const msg = (err as Error).message;
       console.error(`\n  Error: ${msg}\n`);
       process.exitCode = 1;
@@ -478,13 +484,11 @@ export function buildCli() {
 
           // Allow --yes to skip confirmation
           if (!options.yes) {
-            const rl = await import('node:readline');
-            const prompt = rl.createInterface({ input: process.stdin, output: process.stdout });
-            const answer = await new Promise<string>((resolve) => {
-              prompt.question('  Continue? (y/N) ', resolve);
-            });
-            prompt.close();
-            if (answer.trim().toLowerCase() !== 'y') {
+            const answer = await promptText('  Continue? (y/N) ', { output: process.stdout });
+            if (answer.kind === 'interrupt') {
+              throw new PromptCancelledError('Cancelled. Rebuild aborted.', 130);
+            }
+            if (answer.kind !== 'answer' || answer.value.toLowerCase() !== 'y') {
               console.log('  Aborted.');
               return;
             }
@@ -817,17 +821,20 @@ export function buildCli() {
         return;
       }
 
-      const readline = await import('node:readline');
-      const rl = readline.createInterface({ input: process.stdin, output: process.stderr });
-      const answer = await new Promise<string>((resolve) => {
-        rl.question('  Select default: ', (a) => { rl.close(); resolve(a.trim().toLowerCase()); });
-      });
+      const answer = await promptText('  Select default: ');
+      if (answer.kind === 'interrupt') {
+        throw new PromptCancelledError('Cancelled. No default model saved.', 130);
+      }
+      if (answer.kind === 'close' || !answer.value) {
+        console.log('  No default model saved.');
+        return;
+      }
 
-      if (available.includes(answer)) {
-        savePreferences({ ...prefs, defaultEngine: answer });
-        console.log(`  \u2713 Default model set to ${answer}`);
-      } else if (answer) {
-        console.log(`  "${answer}" is not available. Found: ${available.join(', ')}`);
+      if (available.includes(answer.value)) {
+        savePreferences({ ...prefs, defaultEngine: answer.value });
+        console.log(`  \u2713 Default model set to ${answer.value}`);
+      } else {
+        console.log(`  "${answer.value}" is not available. Found: ${available.join(', ')}`);
         process.exitCode = 1;
       }
     }));

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -9,6 +9,7 @@ import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 import { loadPreferences, savePreferences } from './preferences.js';
+import { PromptCancelledError, promptText } from './prompt.js';
 
 // ── Engine registry ────────────────────────────────────────────────────
 
@@ -68,14 +69,14 @@ export function detectAvailableEngines(): string[] {
 // ── Interactive prompt ─────────────────────────────────────────────────
 
 async function askYesNo(question: string): Promise<boolean> {
-  const { createInterface } = await import('node:readline');
-  return new Promise((resolve) => {
-    const rl = createInterface({ input: process.stdin, output: process.stderr });
-    rl.question(question, (answer) => {
-      rl.close();
-      resolve(answer.trim().toLowerCase().startsWith('y'));
-    });
-  });
+  const result = await promptText(question);
+  if (result.kind === 'interrupt') {
+    throw new PromptCancelledError('Cancelled before selecting a model.', 130);
+  }
+  if (result.kind === 'close') {
+    throw new PromptCancelledError('No model selected.', 0);
+  }
+  return result.value.toLowerCase().startsWith('y');
 }
 
 // ── Resolution ─────────────────────────────────────────────────────────

--- a/src/prompt.ts
+++ b/src/prompt.ts
@@ -1,0 +1,69 @@
+export type PromptResult =
+  | { kind: 'answer'; value: string }
+  | { kind: 'close' }
+  | { kind: 'interrupt' };
+
+export class PromptCancelledError extends Error {
+  constructor(
+    message: string,
+    readonly exitCode: number,
+  ) {
+    super(message);
+    this.name = 'PromptCancelledError';
+  }
+}
+
+export interface PromptInterface {
+  question(query: string, callback: (answer: string) => void): void;
+  close(): void;
+  once(event: 'close' | 'SIGINT', listener: () => void): this;
+  removeListener(event: 'close' | 'SIGINT', listener: () => void): this;
+}
+
+export interface PromptOptions {
+  input?: NodeJS.ReadableStream;
+  output?: NodeJS.WritableStream;
+}
+
+export function promptWithInterface(rl: PromptInterface, question: string): Promise<PromptResult> {
+  return new Promise((resolve) => {
+    let settled = false;
+
+    const cleanup = () => {
+      rl.removeListener('close', onClose);
+      rl.removeListener('SIGINT', onSigint);
+    };
+
+    const settle = (result: PromptResult) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      resolve(result);
+    };
+
+    const onClose = () => {
+      settle({ kind: 'close' });
+    };
+
+    const onSigint = () => {
+      settle({ kind: 'interrupt' });
+      rl.close();
+    };
+
+    rl.once('close', onClose);
+    rl.once('SIGINT', onSigint);
+    rl.question(question, (answer) => {
+      settle({ kind: 'answer', value: answer.trim() });
+      rl.close();
+    });
+  });
+}
+
+export async function promptText(question: string, options: PromptOptions = {}): Promise<PromptResult> {
+  const { createInterface } = await import('node:readline');
+  const rl = createInterface({
+    input: options.input ?? process.stdin,
+    output: options.output ?? process.stderr,
+  });
+  return promptWithInterface(rl, question);
+}

--- a/tests/prompt.test.ts
+++ b/tests/prompt.test.ts
@@ -1,0 +1,58 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { EventEmitter } from 'node:events';
+import { promptWithInterface } from '../src/prompt.js';
+
+class FakePrompt extends EventEmitter {
+  private callback: ((answer: string) => void) | null = null;
+  closed = false;
+  prompt = '';
+
+  question(query: string, callback: (answer: string) => void): void {
+    this.prompt = query;
+    this.callback = callback;
+  }
+
+  answer(value: string): void {
+    this.callback?.(value);
+  }
+
+  close(): void {
+    if (this.closed) return;
+    this.closed = true;
+    this.emit('close');
+  }
+}
+
+test('promptWithInterface: resolves trimmed answer and closes interface', async () => {
+  const prompt = new FakePrompt();
+  const pending = promptWithInterface(prompt, 'Pick one: ');
+
+  prompt.answer('  codex  ');
+  const result = await pending;
+
+  assert.deepEqual(result, { kind: 'answer', value: 'codex' });
+  assert.equal(prompt.prompt, 'Pick one: ');
+  assert.equal(prompt.closed, true);
+});
+
+test('promptWithInterface: resolves close when prompt closes without answer', async () => {
+  const prompt = new FakePrompt();
+  const pending = promptWithInterface(prompt, 'Pick one: ');
+
+  prompt.close();
+  const result = await pending;
+
+  assert.deepEqual(result, { kind: 'close' });
+});
+
+test('promptWithInterface: resolves interrupt on SIGINT and closes interface', async () => {
+  const prompt = new FakePrompt();
+  const pending = promptWithInterface(prompt, 'Pick one: ');
+
+  prompt.emit('SIGINT');
+  const result = await pending;
+
+  assert.deepEqual(result, { kind: 'interrupt' });
+  assert.equal(prompt.closed, true);
+});


### PR DESCRIPTION
## Summary
- add a shared prompt helper that always settles on answer, EOF/close, and Ctrl+C
- handle cancelled interactive prompts gracefully in `ft model`, `ft sync --rebuild`, and engine selection during classification
- add prompt regression tests covering answer, close, and interrupt behavior

## Why
Cancelling `ft model` before choosing a default left a pending promise from `readline.question()`, which caused Node 25 to print an unsettled top-level await warning on exit.

## Impact
Interactive prompt cancellation now exits cleanly with a user-facing message instead of a Node runtime warning.

## Root cause
The CLI awaited prompt promises that only resolved in the `question()` callback. On Ctrl+C or prompt close, `readline` closed the interface without invoking that callback, so the awaiting command never settled.

## Validation
- `npm run build`
- `npm test` (`101/101`)
- manual repro: `FT_DATA_DIR=/tmp/... node bin/ft.mjs model`, then Ctrl+C at `Select default:` now exits `130` with `Cancelled. No default model saved.`

## Commit summary
- `91f7831` Handle cancelled interactive prompts cleanly