### PR TITLE
fix: prevent --rebuild from instantly terminating on stale page limits

### DIFF
--- a/src/graphql-bookmarks.ts
+++ b/src/graphql-bookmarks.ts
@@ -513,7 +513,10 @@ export async function syncBookmarksGraphQL(
     result.records.forEach((r) => allSeenIds.push(r.id));
     const reachedLatestStored = Boolean(newestKnownId) && result.records.some((record) => record.id === newestKnownId);
 
-    stalePages = added === 0 ? stalePages + 1 : 0;
+    // In incremental mode, a stale page is one that didn't add any *new* bookmarks.
+    // In rebuild mode, we expect added to be 0 (just merging), so a stale page is
+    // one that returned no records at all from the API.
+    stalePages = (incremental ? added === 0 : result.records.length === 0) ? stalePages + 1 : 0;
 
     options.onProgress?.({
       page,


### PR DESCRIPTION
### Description
In v1.3.0, the `incremental &&` guard was removed from the stale page checker in `src/graphql-bookmarks.ts` (Commit `de79bbb`). The intention was to apply stale page limits universally.

However, this completely broke the new `--rebuild` mode for existing users.

Because a full rebuild iterates over thousands of bookmarks the user *already has* in their `bookmarks.jsonl` file, the `added` count for those pages is naturally `0` (the records are just being merged, not newly added to the database count).

Consequently, `--rebuild` instantly hits the `stalePageLimit` on Page 3 and silently terminates the sync with "Sync complete — reached the end of new bookmarks.", preventing users from actually rebuilding their history.

### The Fix
This PR modifies the `stalePages` increment logic:
* In `incremental` mode: A page is stale if it didn't add any *new* bookmarks to the database (`added === 0`).
* In `--rebuild` mode: We fully expect `added` to be 0 for thousands of pages. A page is only considered "stale" (or a dead end) if the GraphQL API returned literally zero records (`result.records.length === 0`).

Tested locally and confirmed that `--rebuild` now successfully pages through the entire existing timeline without terminating prematurely.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the termination logic for bookmark syncing, which could affect how long sync runs and when it stops; mistakes here can lead to incomplete rebuilds or longer-than-expected fetches.
> 
> **Overview**
> Fixes `syncBookmarksGraphQL` stale-page detection so `--rebuild` runs don’t terminate early when pages contain only already-known bookmarks.
> 
> `stalePages` is now incremented based on `added === 0` only in incremental mode, while rebuild mode treats a page as stale only when the API returns zero records, preserving the `stalePageLimit` safeguard without breaking full history rebuilds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7c402cb713a07db3e93a760eda9f6dee58cbd0b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->