### PR TITLE
fix: Expand t.co links in text, expose IDs in search results, and add Codex compatibility

### DIFF
--- a/src/bookmarks-db.ts
+++ b/src/bookmarks-db.ts
@@ -1144,7 +1144,8 @@ export function formatSearchResults(results: SearchResult[]): string {
       const author = r.authorHandle ? `@${r.authorHandle}` : 'unknown';
       const date = r.postedAt ? r.postedAt.slice(0, 10) : '?';
       const text = r.text.length > 140 ? r.text.slice(0, 140) + '...' : r.text;
-      return `${i + 1}. [${date}] ${author}\n   ${text}\n   ${r.url}`;
+      const id = r.id;
+      return `${i + 1}. [${date}] ${author} (ID: ${id})\n   ${text}\n   ${r.url}`;
     })
     .join('\n\n');
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -94,8 +94,13 @@ const FRIENDLY_STOP_REASONS: Record<string, string> = {
   'target additions reached': 'Reached target bookmark count.',
 };
 
-function friendlyStopReason(raw?: string): string {
+function friendlyStopReason(raw?: string, addedCount: number = 0): string {
   if (!raw) return 'Sync complete.';
+  if (raw === 'caught up to newest stored bookmark') {
+    return addedCount > 0
+      ? 'Sync complete \u2014 caught up to previously stored bookmarks.'
+      : 'All caught up \u2014 no new bookmarks since last sync.';
+  }
   return FRIENDLY_STOP_REASONS[raw] ?? `Sync complete \u2014 ${raw}`;
 }
 
@@ -683,7 +688,7 @@ export function buildCli() {
           }));
 
           console.log(`\n  \u2713 ${result.added} new bookmarks synced (${result.totalBookmarks} total)`);
-          console.log(`  ${friendlyStopReason(result.stopReason)}`);
+          console.log(`  ${friendlyStopReason(result.stopReason, result.added)}`);
           if (result.bookmarkedAtRepaired > 0) {
             console.log(`  \u2713 ${result.bookmarkedAtRepaired} invalid bookmark dates cleared`);
           }

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -20,7 +20,7 @@ export interface EngineConfig {
 
 const KNOWN_ENGINES: Record<string, EngineConfig> = {
   claude: { bin: 'claude', args: (p) => ['-p', '--output-format', 'text', p] },
-  codex:  { bin: 'codex',  args: (p) => ['exec', p] },
+  codex:  { bin: 'codex',  args: (p) => ['exec', '--skip-git-repo-check', p] },
 };
 
 /** Order used when auto-detecting. */

--- a/src/graphql-bookmarks.ts
+++ b/src/graphql-bookmarks.ts
@@ -313,8 +313,14 @@ export function convertTweetToRecord(tweetResult: any, now: string): BookmarkRec
 
   // X Articles / long-form note tweets store full text separately
   const noteTweetText = tweet?.note_tweet?.note_tweet_results?.result?.text;
-  const text = noteTweetText ?? legacy.full_text ?? legacy.text ?? '';
+  let text = noteTweetText ?? legacy.full_text ?? legacy.text ?? '';
 
+  // Expand t.co links in the text using display_url
+  for (const u of urlEntities) {
+    if (u.url && u.display_url) {
+      text = text.split(u.url).join(u.display_url);
+    }
+  }
   return {
     id: tweetId,
     tweetId,

--- a/tests/bookmarks-db.test.ts
+++ b/tests/bookmarks-db.test.ts
@@ -170,13 +170,14 @@ test('getStats returns chronological date range for legacy Twitter timestamps', 
   }, fixtures);
 });
 
-test('formatSearchResults: formats results with author, date, text, url', () => {
+test('formatSearchResults: formats results with author, date, ID, text, url', () => {
   const results = [
-    { id: '1', url: 'https://x.com/test/status/1', text: 'Hello world', authorHandle: 'test', authorName: 'Test', postedAt: '2026-01-15T00:00:00Z', score: -1.5 },
+    { id: '2040535589771149379', url: 'https://x.com/test/status/1', text: 'Hello world', authorHandle: 'test', authorName: 'Test', postedAt: '2026-01-15T00:00:00Z', score: -1.5 },
   ];
   const formatted = formatSearchResults(results);
   assert.ok(formatted.includes('@test'));
   assert.ok(formatted.includes('2026-01-15'));
+  assert.ok(formatted.includes('(ID: 2040535589771149379)'));
   assert.ok(formatted.includes('Hello world'));
   assert.ok(formatted.includes('https://x.com/test/status/1'));
 });

--- a/tests/graphql-bookmarks.test.ts
+++ b/tests/graphql-bookmarks.test.ts
@@ -568,6 +568,24 @@ test('sanitizeBookmarkedAt: clears GraphQL bookmark dates even when they look pl
   assert.equal(result.bookmarkedAt, null);
 });
 
+test('convertTweetToRecord: expands t.co links in full_text using display_url', () => {
+  const tr = {
+    rest_id: '1',
+    legacy: {
+      id_str: '1',
+      full_text: 'Check this: https://t.co/abc and this: https://t.co/def',
+      entities: {
+        urls: [
+          { url: 'https://t.co/abc', display_url: 'example.com/foo' },
+          { url: 'https://t.co/def', display_url: 'tools.exec.security' },
+        ],
+      },
+    },
+  };
+  const result = convertTweetToRecord(tr, NOW)!;
+  assert.equal(result.text, 'Check this: example.com/foo and this: tools.exec.security');
+});
+
 test('formatSyncResult: formats all fields', () => {
   const result = formatSyncResult({
     added: 50,


### PR DESCRIPTION
### Description
This PR addresses three minor UX/formatting bugs discovered while using the CLI:

**1. Expand `t.co` links in tweet text**
* **Symptom**: Tweets containing text that looked like domains (e.g., `tools.exec.security`) were being automatically linkified by Twitter into `t.co` shortlinks. The CLI preserved these shortlinks, corrupting the original text in the terminal output.
* **Fix**: Updated `convertTweetToRecord` to expand all `t.co` shortlinks back into their original `display_url` by mapping them through the `entities.urls` metadata. Includes a new test case.

**2. Expose Bookmark ID in Search Results**
* **Symptom**: The `ft search` command returned truncated text but omitted the bookmark ID, making it impossible to easily transition from a search result to the `ft show <id>` command.
* **Fix**: Updated `formatSearchResults` to append `(ID: <id>)` next to the author handle in the output. Includes an updated test case to protect against regressions.

**3. Codex Compatibility**
* **Fix**: Added the `--skip-git-repo-check` flag to the Codex engine invocation in `src/engine.ts` to prevent the CLI from failing when run outside of a trusted git repository. (similar to https://github.com/afar1/fieldtheory-cli/pull/17)

All tests are passing locally.
