### PR TITLE
fix: Format dates as YYYY-MM-DD in ft md exports instead of using raw string slice

### DIFF
--- a/src/md-export.ts
+++ b/src/md-export.ts
@@ -33,8 +33,20 @@ function bookmarksDir(): string {
   return path.join(mdDir(), 'bookmarks');
 }
 
+function formatSafeDate(dateStr: string): string {
+  const parsed = Date.parse(dateStr);
+  if (Number.isFinite(parsed)) {
+    const d = new Date(parsed);
+    const yyyy = d.getFullYear();
+    const mm = String(d.getMonth() + 1).padStart(2, '0');
+    const dd = String(d.getDate()).padStart(2, '0');
+    return `${yyyy}-${mm}-${dd}`;
+  }
+  return 'undated';
+}
+
 function bookmarkFilename(b: BookmarkTimelineItem): string {
-  const date = (b.postedAt ?? b.bookmarkedAt ?? '').slice(0, 10) || 'undated';
+  const date = formatSafeDate(b.postedAt ?? b.bookmarkedAt ?? '');
   const author = b.authorHandle ? slug(b.authorHandle) : 'unknown';
   const textSlug = slug(b.text.slice(0, 50)) || b.id;
   return `${date}-${author}-${textSlug}.md`;


### PR DESCRIPTION
### Description
In v1.3.2, the new `ft md` command generates markdown files using a simple string slice on the `postedAt` or `bookmarkedAt` database field: `date.slice(0, 10)`.

While this works for standard ISO string timestamps (`2024-11-27`), it fundamentally breaks for any user whose database still contains bookmarks in the legacy Twitter date format (`Fri Apr 01 16:02:20 +0000 2022`). 

For legacy timestamps, slicing the first 10 characters yields `Fri Apr 01`. This results in markdown exports with filenames like `Fri Apr 01-author-slug.md` which:
1. Cannot be sorted chronologically by the filesystem.
2. Are missing the year entirely.
3. Contain spaces, making them harder to script against.

### The Fix
This PR replaces the raw string slice with a robust `Date` parser in `src/md-export.ts`. It parses whatever timestamp format exists in the database and explicitly constructs a uniform, sortable `YYYY-MM-DD` prefix for every exported file.
