### PR TITLE
feat(firefox): support Firefox cookie extraction on Windows

### DIFF
--- a/src/browsers.ts
+++ b/src/browsers.ts
@@ -88,6 +88,7 @@ const BROWSERS: BrowserDef[] = [
     keychainEntries: [],
     macPath: 'Library/Application Support/Firefox',
     linuxPath: '.mozilla/firefox',
+    winPath: 'AppData/Roaming/Mozilla/Firefox',
   },
 ];
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -239,7 +239,7 @@ export function showWelcome(): void {
     1. Open your browser and log into x.com
     2. Run: ft sync
 
-  Works with Chrome, Brave, Chromium, and Firefox on macOS/Linux.
+  Works with Chrome, Brave, Chromium, and Firefox on macOS, Linux, and Windows.
   Data will be stored at: ${dataDir()}
 `);
 }
@@ -299,7 +299,6 @@ function showSyncWelcome(): void {
   Browser ids: ${browsers}
   Use --browser <name> to choose.
   Default auto-detect prefers installed Chrome-family browsers.
-  Firefox cookie extraction currently works on macOS and Linux.
 `);
 }
 

--- a/src/firefox-cookies.ts
+++ b/src/firefox-cookies.ts
@@ -1,19 +1,35 @@
-import { execFileSync } from 'node:child_process';
 import { existsSync, readFileSync, unlinkSync, copyFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir, homedir, platform } from 'node:os';
 import { randomUUID } from 'node:crypto';
+import { createRequire } from 'node:module';
+import type { SqlJsStatic } from 'sql.js';
 import type { ChromeCookieResult } from './chrome-cookies.js';
+import { getBrowser, browserUserDataDir } from './browsers.js';
+
+const require = createRequire(import.meta.url);
+
+// ── sql.js lazy init (shared pattern with src/db.ts) ─────────────────────────
+
+let sqlPromise: Promise<SqlJsStatic> | undefined;
+
+function getSql(): Promise<SqlJsStatic> {
+  if (!sqlPromise) {
+    const initSqlJs = require('sql.js-fts5') as (opts: any) => Promise<SqlJsStatic>;
+    const wasmPath = require.resolve('sql.js-fts5/dist/sql-wasm.wasm');
+    const wasmBinary = readFileSync(wasmPath);
+    sqlPromise = initSqlJs({ wasmBinary });
+  }
+  return sqlPromise!;
+}
 
 // ── Profile detection ────────────────────────────────────────────────────────
 
 function firefoxBaseDir(): string {
-  const os = platform();
-  const home = homedir();
-  if (os === 'darwin') return join(home, 'Library', 'Application Support', 'Firefox');
-  if (os === 'linux') return join(home, '.mozilla', 'firefox');
+  const dir = browserUserDataDir(getBrowser('firefox'));
+  if (dir) return dir;
   throw new Error(
-    `Firefox cookie extraction is currently supported on macOS and Linux only (detected: ${os}).\n` +
+    `Firefox cookie extraction is not supported on this platform (detected: ${platform()}).\n` +
     'Pass cookies manually:  ft sync --cookies <ct0> <auth_token>'
   );
 }
@@ -71,11 +87,19 @@ export function detectFirefoxProfileDir(): string {
 
 // ── Cookie query ─────────────────────────────────────────────────────────────
 
-function queryFirefoxCookies(
+/**
+ * Read ct0/auth_token from a Firefox cookies.sqlite using the bundled sql.js
+ * WebAssembly build. No external `sqlite3` binary is required, which matters
+ * on Windows where sqlite3 isn't in PATH by default.
+ *
+ * Firefox may hold a WAL lock on the live DB, so we always copy the file
+ * (plus any -wal and -shm siblings) to a tmpdir before opening it.
+ */
+async function queryFirefoxCookies(
   dbPath: string,
   host: string,
   names: string[],
-): { name: string; value: string }[] {
+): Promise<{ name: string; value: string }[]> {
   if (!existsSync(dbPath)) {
     throw new Error(
       `Firefox cookies.sqlite not found at: ${dbPath}\n` +
@@ -83,63 +107,61 @@ function queryFirefoxCookies(
     );
   }
 
-  // Build parameterized-safe SQL. host and names are hardcoded by callers,
-  // but we escape anyway to prevent injection if the API is ever widened.
-  const safeHost = host.replace(/'/g, "''");
-  const nameList = names.map(n => `'${n.replace(/'/g, "''")}'`).join(',');
-  const sql = `SELECT name, value FROM moz_cookies WHERE host LIKE '%${safeHost}' AND name IN (${nameList});`;
+  const tmpDb = join(tmpdir(), `ft-ff-cookies-${randomUUID()}.db`);
+  const walPath = dbPath + '-wal';
+  const shmPath = dbPath + '-shm';
 
-  const tryQuery = (path: string): string =>
-    execFileSync('sqlite3', ['-json', path, sql], {
-      encoding: 'utf8',
-      stdio: ['pipe', 'pipe', 'pipe'],
-      timeout: 10000,
-    }).trim();
-
-  let output: string;
   try {
-    output = tryQuery(dbPath);
-  } catch {
-    // Firefox may hold a WAL lock — copy the DB and query the copy
-    const tmpDb = join(tmpdir(), `ft-ff-cookies-${randomUUID()}.db`);
-    try {
-      copyFileSync(dbPath, tmpDb);
-      const walPath = dbPath + '-wal';
-      const shmPath = dbPath + '-shm';
-      if (existsSync(walPath)) copyFileSync(walPath, tmpDb + '-wal');
-      if (existsSync(shmPath)) copyFileSync(shmPath, tmpDb + '-shm');
-      output = tryQuery(tmpDb);
-    } catch (e2: any) {
-      throw new Error(
-        `Could not read Firefox cookies database.\n` +
-        `Path: ${dbPath}\n` +
-        `Error: ${e2.message}\n` +
-        'If Firefox is open, try closing it and retrying.'
-      );
-    } finally {
-      try { unlinkSync(tmpDb); } catch {}
-      try { unlinkSync(tmpDb + '-wal'); } catch {}
-      try { unlinkSync(tmpDb + '-shm'); } catch {}
-    }
+    copyFileSync(dbPath, tmpDb);
+    if (existsSync(walPath)) copyFileSync(walPath, tmpDb + '-wal');
+    if (existsSync(shmPath)) copyFileSync(shmPath, tmpDb + '-shm');
+  } catch (e: any) {
+    throw new Error(
+      `Could not read Firefox cookies database.\n` +
+      `Path: ${dbPath}\n` +
+      `Error: ${e.message}\n` +
+      'If Firefox is open, try closing it and retrying.'
+    );
   }
 
-  if (!output || output === '[]') return [];
   try {
-    return JSON.parse(output);
-  } catch {
-    return [];
+    const SQL = await getSql();
+    const bytes = readFileSync(tmpDb);
+    const db = new SQL.Database(bytes);
+    try {
+      // Parameterized query — no string interpolation of host/names into SQL.
+      const placeholders = names.map(() => '?').join(',');
+      const stmt = db.prepare(
+        `SELECT name, value FROM moz_cookies ` +
+        `WHERE host LIKE ? AND name IN (${placeholders})`
+      );
+      stmt.bind([`%${host}`, ...names]);
+      const rows: { name: string; value: string }[] = [];
+      while (stmt.step()) {
+        const row = stmt.getAsObject() as { name: string; value: string };
+        rows.push({ name: row.name, value: row.value });
+      }
+      stmt.free();
+      return rows;
+    } finally {
+      db.close();
+    }
+  } finally {
+    try { unlinkSync(tmpDb); } catch {}
+    try { unlinkSync(tmpDb + '-wal'); } catch {}
+    try { unlinkSync(tmpDb + '-shm'); } catch {}
   }
 }
 
 // ── Main export ──────────────────────────────────────────────────────────────
 
-export function extractFirefoxXCookies(profileDir?: string): ChromeCookieResult {
+export async function extractFirefoxXCookies(profileDir?: string): Promise<ChromeCookieResult> {
   const dir = profileDir ?? detectFirefoxProfileDir();
   const dbPath = join(dir, 'cookies.sqlite');
 
-  let cookies = queryFirefoxCookies(dbPath, '.x.com', ['ct0', 'auth_token']);
+  let cookies = await queryFirefoxCookies(dbPath, '.x.com', ['ct0', 'auth_token']);
   if (cookies.length === 0) {
-    cookies = queryFirefoxCookies(dbPath, '.twitter.com', ['ct0', 'auth_token']);
+    cookies = await queryFirefoxCookies(dbPath, '.twitter.com', ['ct0', 'auth_token']);
   }
 
   const cookieMap = new Map(cookies.map(c => [c.name, c.value]));

--- a/src/graphql-bookmarks.ts
+++ b/src/graphql-bookmarks.ts
@@ -504,7 +504,7 @@ export async function syncBookmarksGraphQL(
     const config = loadChromeSessionConfig({ browserId: options.browser });
 
     if (config.browser.cookieBackend === 'firefox') {
-      const cookies = extractFirefoxXCookies(options.firefoxProfileDir);
+      const cookies = await extractFirefoxXCookies(options.firefoxProfileDir);
       csrfToken = cookies.csrfToken;
       cookieHeader = cookies.cookieHeader;
     } else {

--- a/tests/browsers.test.ts
+++ b/tests/browsers.test.ts
@@ -38,6 +38,15 @@ test('getBrowser: firefox has firefox cookieBackend', () => {
   assert.equal(browser.keychainEntries.length, 0);
 });
 
+test('getBrowser: firefox has user-data paths for every supported OS', () => {
+  const browser = getBrowser('firefox');
+  assert.ok(browser.macPath, 'Firefox macPath must be set');
+  assert.ok(browser.linuxPath, 'Firefox linuxPath must be set');
+  assert.ok(browser.winPath, 'Firefox winPath must be set');
+  // Windows Firefox lives under %APPDATA% (Roaming), not Local
+  assert.match(browser.winPath!, /AppData[\\/]Roaming[\\/]Mozilla[\\/]Firefox/);
+});
+
 test('getBrowser: brave has correct keychain entries', () => {
   const browser = getBrowser('brave');
   const services = browser.keychainEntries.map(e => e.service);


### PR DESCRIPTION
## What

Fixes Firefox session-sync on Windows. `ft sync --browser firefox` was hard-throwing with:

> Firefox cookie extraction is currently supported on macOS and Linux only

even though cross-platform browser support had otherwise landed in `src/browsers.ts`. Two root causes, one commit:

1. **Firefox not in the Windows registry entry.** `src/browsers.ts` had `macPath` and `linuxPath` for Firefox but no `winPath`. Added `'AppData/Roaming/Mozilla/Firefox'` and routed `firefoxBaseDir()` through `browserUserDataDir(getBrowser('firefox'))` so the browser registry is the single source of truth.

2. **`firefox-cookies.ts` shelled out to `sqlite3.exe`**, which isn't on Windows `PATH` by default. Replaced with the bundled `sql.js-fts5` WASM SQLite that the project already uses for its FTS5 index (see `src/db.ts`). Zero new dependencies, fully cross-platform. As a side benefit this also removes the implicit "sqlite3 binary on PATH" requirement from the macOS/Linux Firefox paths.

## Why

Current main has a "Firefox on Windows" UX that reads: "show the user a wall of help text, then throw." The registry already knows about Windows for Chromium-family browsers; this patch closes the last gap so the Firefox backend matches.

## What changed

- `src/browsers.ts` — Firefox entry gets `winPath: 'AppData/Roaming/Mozilla/Firefox'`
- `src/firefox-cookies.ts` — `firefoxBaseDir()` now uses `browserUserDataDir()`; `queryFirefoxCookies()` rewritten to use `sql.js-fts5` instead of `execFileSync('sqlite3', ...)`; still copies `cookies.sqlite` + `-wal` + `-shm` to tmpdir so Firefox can hold its WAL lock undisturbed
- `src/graphql-bookmarks.ts` — one-line `await` update (sql.js init is async; the caller is already inside an async function)
- `src/cli.ts` — removed the two now-stale "macOS/Linux only" strings from the welcome banner and first-run hint
- `tests/browsers.test.ts` — regression test asserting Firefox has a `winPath` under `AppData/Roaming`

## Verification

Verified end-to-end on **Windows 11** against a real Firefox `default-release` profile logged into x.com:

| Check | Result |
|---|---|
| `npm run build` (tsc) | clean |
| Full test suite | **149/149 pass** (including the new registry regression) |
| `ft sync --browser firefox` on Windows | **works** — 1091 bookmarks synced from a real account |
| `ft search`, `ft stats`, `ft viz` downstream | working against the real synced data |

## Scope notes

- This only touches the Firefox code path. Chromium DPAPI path is untouched.
- `extractFirefoxXCookies` is now `async` because `initSqlJs()` is async. The sole caller in `graphql-bookmarks.ts` is already inside an async function, so the change is a one-line `await`.
- The tmpdir copy dance is preserved so nothing changes about safety under a live Firefox with pending WAL writes.

## Things I noticed but did not touch

- `npm test`'s `tests/**/*.test.ts` glob isn't expanded by `cmd.exe` on Windows, so `npm test` fails on Windows even without this patch. Orthogonal pre-existing issue — happy to fix in a follow-up PR if you'd like (`glob`/`fast-glob` or a tiny runner script).
- `package-lock.json` has stale `name: "ft-bookmarks"` / `version: "1.3.0"` fields vs `package.json`'s `fieldtheory@1.3.2`. `npm install` self-corrects, but I kept the lockfile untouched in this commit to keep the diff surgical.

Happy to split any of this up if you'd prefer smaller commits.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Modifies the Firefox session cookie extraction path used for GraphQL sync by switching from a system `sqlite3` binary to embedded `sql.js` WASM and making extraction async; failures here would block sync for Firefox users across platforms.
> 
> **Overview**
> Adds **Windows support for Firefox session-based sync** by registering Firefox’s Windows user-data directory and updating CLI messaging to state Windows is supported.
> 
> Reworks `firefox-cookies.ts` to avoid shelling out to `sqlite3` by reading `cookies.sqlite` via bundled `sql.js-fts5` (with tmpdir DB/WAL/SHM copying) and makes `extractFirefoxXCookies` async; `graphql-bookmarks.ts` is updated to `await` it. Adds a test ensuring Firefox has a valid `winPath` under `AppData/Roaming`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c5808faf40a8ce8c4ed088777cc8f169e2c788b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->