### PR TITLE
Use package metadata for CLI version output

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -401,7 +401,7 @@ export function buildCli() {
   program
     .name('ft')
     .description('Self-custody for your X/Twitter bookmarks. Sync, search, classify, and explore locally.')
-    .version('1.2.2')
+    .version(getLocalVersion())
     .showHelpAfterError()
     .hook('preAction', () => {
       console.log(logo());


### PR DESCRIPTION
Replace the hardcoded Commander version string with getLocalVersion() so `ft --version` stays aligned with the npm version. This avoids stale CLI version output in future releases.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: replaces a hardcoded CLI version string with a local `package.json` lookup, affecting only version reporting/help output.
> 
> **Overview**
> Updates the CLI to report its version via `getLocalVersion()` (reading local `package.json`) instead of a hardcoded `.version('1.2.2')`, keeping `ft --version` aligned with the published npm package version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6af49965f7a59bfa5d3add390a38f770aab5bd26. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->