### PR TITLE
fix: use dynamic version from package.json for --version output

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -401,7 +401,7 @@ export function buildCli() {
   program
     .name('ft')
     .description('Self-custody for your X/Twitter bookmarks. Sync, search, classify, and explore locally.')
-    .version('1.2.2')
+    .version(getLocalVersion())
     .showHelpAfterError()
     .hook('preAction', () => {
       console.log(logo());


### PR DESCRIPTION
## Summary
- `ft --version` was hardcoded to `1.2.2` instead of reading from `package.json`
- Replaced the hardcoded string with the existing `getLocalVersion()` function

Closes #56

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: swaps a hardcoded CLI version string for `getLocalVersion()` without changing runtime behavior beyond `ft --version` output.
> 
> **Overview**
> Updates the `ft` CLI to report its version dynamically via `getLocalVersion()` (reading `package.json`) instead of a hardcoded `1.2.2`, keeping `--version` in sync with releases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d589e5e237d7a88becc2124b63d133ee5757ee21. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->