### PR TITLE
fix: Correct GLOB wildcard to LIKE to properly parse ISO dates on all OS environments

### DIFF
--- a/src/bookmarks-db.ts
+++ b/src/bookmarks-db.ts
@@ -153,8 +153,8 @@ function bookmarkSortClause(direction: 'asc' | 'desc' = 'desc'): string {
   return `
     ORDER BY
       CASE
-        WHEN b.bookmarked_at GLOB '____-__-__*' THEN b.bookmarked_at
-        WHEN b.posted_at GLOB '____-__-__*' THEN b.posted_at
+        WHEN b.bookmarked_at LIKE '____-__-__%' THEN b.bookmarked_at
+        WHEN b.posted_at LIKE '____-__-__%' THEN b.posted_at
         ELSE ''
       END ${normalized},
       CAST(b.tweet_id AS INTEGER) ${normalized}

--- a/src/bookmarks-viz.ts
+++ b/src/bookmarks-viz.ts
@@ -166,7 +166,7 @@ async function queryVizData(): Promise<VizData> {
       ELSE '00'
     END`;
     const monthBucketExpr = `CASE
-      WHEN bookmarked_at GLOB '____-__-__*' THEN substr(bookmarked_at, 1, 7)
+      WHEN bookmarked_at LIKE '____-__-__%' THEN substr(bookmarked_at, 1, 7)
       ELSE substr(bookmarked_at, -4) || '-' || ${legacyMonthNumberExpr}
     END`;
 
@@ -183,7 +183,7 @@ async function queryVizData(): Promise<VizData> {
     const dowRows = db.exec(
       `SELECT 
          CASE
-           WHEN bookmarked_at GLOB '____-__-__*' THEN 
+           WHEN bookmarked_at LIKE '____-__-__%' THEN 
              CASE strftime('%w', bookmarked_at)
                WHEN '0' THEN 'Sun' WHEN '1' THEN 'Mon' WHEN '2' THEN 'Tue'
                WHEN '3' THEN 'Wed' WHEN '4' THEN 'Thu' WHEN '5' THEN 'Fri' WHEN '6' THEN 'Sat' END
@@ -195,12 +195,18 @@ async function queryVizData(): Promise<VizData> {
 
     // Hour of day — chars 12-13 for legacy, strftime('%H') for ISO
     const hourRows = db.exec(
-      `SELECT 
-         CASE
-           WHEN bookmarked_at GLOB '____-__-__*' THEN CAST(strftime('%H', bookmarked_at) AS INTEGER)
-           ELSE CAST(substr(bookmarked_at, 12, 2) AS INTEGER)
-         END as h, COUNT(*) as c
-       FROM bookmarks WHERE bookmarked_at IS NOT NULL
+      `SELECT h, COUNT(*) as c
+       FROM (
+         SELECT
+           CASE
+             WHEN bookmarked_at LIKE '____-__-__%' THEN
+               CASE WHEN strftime('%H', bookmarked_at) IS NOT NULL THEN CAST(strftime('%H', bookmarked_at) AS INTEGER) ELSE NULL END
+             WHEN length(bookmarked_at) > 13 THEN CAST(substr(bookmarked_at, 12, 2) AS INTEGER)
+             ELSE NULL
+           END as h
+         FROM bookmarks WHERE bookmarked_at IS NOT NULL
+       )
+       WHERE h IS NOT NULL
        GROUP BY h ORDER BY h`
     );
 

--- a/tests/bookmarks-db.test.ts
+++ b/tests/bookmarks-db.test.ts
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 import { mkdtemp, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
-import { buildIndex, searchBookmarks, getStats, formatSearchResults, getBookmarkById } from '../src/bookmarks-db.js';
+import { buildIndex, searchBookmarks, getStats, formatSearchResults, getBookmarkById, listBookmarks } from '../src/bookmarks-db.js';
 import { openDb, saveDb } from '../src/db.js';
 import { twitterBookmarksIndexPath } from '../src/paths.js';
 
@@ -114,6 +114,41 @@ test('searchBookmarks: no results for unmatched query', async () => {
     await buildIndex();
     const results = await searchBookmarks({ query: 'cryptocurrency', limit: 10 });
     assert.equal(results.length, 0);
+  });
+});
+
+test('listBookmarks: sorts ISO bookmark timestamps instead of tweet_id fallback', async () => {
+  await withIsolatedDataDir(async () => {
+    const sortableFixtures = [
+      {
+        ...FIXTURES[0],
+        id: 'iso-newer',
+        tweetId: '1',
+        text: 'Newer ISO bookmark',
+        url: 'https://x.com/alice/status/1',
+        bookmarkedAt: '2026-03-10T12:00:00.000Z',
+        postedAt: '2020-01-01T00:00:00Z',
+      },
+      {
+        ...FIXTURES[1],
+        id: 'iso-older',
+        tweetId: '999',
+        text: 'Older ISO bookmark',
+        url: 'https://x.com/bob/status/999',
+        bookmarkedAt: '2024-11-27T10:53:54.664Z',
+        postedAt: '2020-01-01T00:00:00Z',
+      },
+    ];
+
+    const jsonl = sortableFixtures.map((r) => JSON.stringify(r)).join('\n') + '\n';
+    await writeFile(path.join(process.env.FT_DATA_DIR!, 'bookmarks.jsonl'), jsonl);
+    await buildIndex({ force: true });
+
+    const results = await listBookmarks({ sort: 'desc', limit: 10 });
+    assert.deepEqual(
+      results.slice(0, 2).map((row) => row.id),
+      ['iso-newer', 'iso-older'],
+    );
   });
 });
 

--- a/tests/bookmarks-viz.test.ts
+++ b/tests/bookmarks-viz.test.ts
@@ -1,0 +1,79 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { buildIndex } from '../src/bookmarks-db.js';
+import { renderViz } from '../src/bookmarks-viz.js';
+
+// Mix of legacy Twitter date strings and new v1.3.0 ISO timestamps
+const FIXTURES = [
+  {
+    id: '1', tweetId: '1', url: 'https://x.com/alice/status/1', text: 'Legacy Date Bookmark', authorHandle: 'alice', authorName: 'Alice',
+    syncedAt: '2026-01-01T00:00:00Z', 
+    postedAt: 'Sat Mar 28 10:00:00 +0000 2020', 
+    bookmarkedAt: 'Sat Mar 28 18:55:23 +0000 2020', // Hour 18
+    language: 'en', engagement: { likeCount: 100 }, mediaObjects: [], links: [], tags: [], ingestedVia: 'graphql'
+  },
+  {
+    id: '2', tweetId: '2', url: 'https://x.com/bob/status/2', text: 'ISO Date Bookmark', authorHandle: 'bob', authorName: 'Bob',
+    syncedAt: '2026-02-01T00:00:00Z', 
+    postedAt: '2024-11-26T00:00:00Z', 
+    bookmarkedAt: '2024-11-27T10:53:54.664Z', // Hour 10
+    language: 'en', engagement: { likeCount: 50 }, mediaObjects: [], links: [], tags: [], ingestedVia: 'graphql'
+  },
+  {
+    id: '3', tweetId: '3', url: 'https://x.com/charlie/status/3', text: 'Malformed Legacy Date Bookmark', authorHandle: 'charlie', authorName: 'Charlie',
+    syncedAt: '2026-03-01T00:00:00Z', 
+    postedAt: '2022', 
+    bookmarkedAt: 'ShortDate', // Simulating malformed data
+    language: 'en', engagement: { likeCount: 50 }, mediaObjects: [], links: [], tags: [], ingestedVia: 'graphql'
+  }
+];
+
+async function withIsolatedDataDir(fn: () => Promise<void>): Promise<void> {
+  const dir = await mkdtemp(path.join(tmpdir(), 'ft-test-viz-'));
+  const jsonl = FIXTURES.map((r) => JSON.stringify(r)).join('\n') + '\n';
+  await writeFile(path.join(dir, 'bookmarks.jsonl'), jsonl);
+
+  const saved = process.env.FT_DATA_DIR;
+  process.env.FT_DATA_DIR = dir;
+  try {
+    await fn();
+  } finally {
+    process.env.FT_DATA_DIR = saved;
+  }
+}
+
+test('renderViz: correctly parses and renders both ISO and legacy date formats', async () => {
+  await withIsolatedDataDir(async () => {
+    await buildIndex();
+    
+    const output = await renderViz();
+    
+    // 1. Check RHYTHM chart (monthly labels)
+    // Legacy: "Sat Mar 28 ... 2020" -> "Mar 2020"
+    assert.ok(output.includes('Mar 2020'), 'Failed to parse legacy month format for Rhythm chart');
+    // ISO: "2024-11-27T..." -> "Nov 2024"
+    assert.ok(output.includes('Nov 2024'), 'Failed to parse ISO month format for Rhythm chart');
+    // Ensure we don't have the "00" gibberish fallback
+    assert.ok(!output.includes('00 2020') && !output.includes('00 2024'), 'Fallback 00 month was unexpectedly used');
+
+    // 2. Check TIME CAPSULES
+    // Legacy: "Sat Mar 28 ... 2020" -> "2020" and " Mar 28"
+    assert.ok(output.includes('2020'), 'Failed to render legacy year in Time Capsules');
+    assert.ok(output.includes('Mar 28'), 'Failed to render legacy month/day in Time Capsules');
+    // ISO: "2024-11-26T..." -> "2024" and "Nov 26"
+    // 3. Check DAILY ARC (hourly buckets)
+    // Legacy bookmark is at 18:55 (Hour 18)
+    assert.ok(output.includes('18:00'), 'Failed to render legacy hour format in Daily Arc');
+    // ISO bookmark is at 10:53 (Hour 10)
+    assert.ok(output.includes('10:00'), 'Failed to render ISO hour format in Daily Arc');
+    
+    // CRITICAL: Check the malformed 'ShortDate' bookmark.
+    // Without the `length > 13` guard, SQLite evaluates `CAST(substr('ShortDate', 12, 2) AS INTEGER)`
+    // as CAST('' AS INTEGER), which silently outputs `0` (Midnight).
+    // Because we only have two valid bookmarks (at 18 and 10), "00:00" should NOT be present.
+    assert.ok(!output.includes('00:00'), 'Malformed date incorrectly fell back to Midnight (00) due to missing length guard');
+  });
+});


### PR DESCRIPTION
@afar1 - I apologize that my previous pr #44 had a defect. It was due to a late change after I took some advice from a copilot review bot that I ran on the same branch in my own fork. I hadn't noticed until tonight that that change broke `ft viz` to make it show the Rhythm section like this:

    00 996Z  █████████                                3
    00 997Z  █████████                                3
    00 999Z  ████████████                             4

I have since worked on this pr to fix the issue and added test coverage.

### Description

In PR #44, the visual dashboard SQL queries were updated to support the new ISO `bookmarkedAt` format by dynamically parsing dates. However, based on an incorrect Copilot review suggestion, those queries used SQLite `GLOB` with underscores (`GLOB '____-__-__*'`) to match a `YYYY-MM-DD` shape.
That pattern is not valid for this purpose in SQLite: `GLOB` uses `?` as the single-character wildcard, while `_` is a wildcard for `LIKE`.
As a result, the query effectively looked for literal underscores instead of date patterns. On many environments (depending on OS/SQLite behavior), ISO dates failed to match and incorrectly fell back to legacy parsing, causing bad month buckets in `RHYTHM` (for example `00 992Z`-style output).

### The Fix

1. Updated date-pattern matching from `GLOB '____-__-__*'` to `LIKE '____-__-__%'` in:
  • `src/bookmarks-viz.ts` (viz date parsing paths)
  • `src/bookmarks-db.ts` (`bookmarkSortClause` sort path)
2. Restored the `length(bookmarked_at) > 13` safety guard in hourly parsing to prevent malformed/truncated legacy timestamps from silently casting to `0` and skewing `DAILY ARC`.
3. Kept behavior aligned with the intent of PR #44 while making wildcard semantics correct and portable across environments.

### Test Coverage

• Added `tests/bookmarks-viz.test.ts` to verify:
  • ISO and legacy date parsing both render correctly in viz output
  • malformed legacy dates do not leak into midnight (`00:00`) buckets
• Added a regression test in `tests/bookmarks-db.test.ts`:
  • `listBookmarks: sorts ISO bookmark timestamps instead of tweet_id fallback`
  • proves timeline sorting now correctly uses ISO timestamp ordering (the path that still had `GLOB` before this fix)
  This closes the original defect in both viz and list/sort code paths and adds explicit regression protection for each.
