### PR TITLE
fix: correct field names in fetch-media so post media downloads

### DIFF
--- a/src/bookmark-media.ts
+++ b/src/bookmark-media.ts
@@ -79,12 +79,12 @@ export async function fetchBookmarkMediaBatch(
     if (bookmark.mediaObjects?.length) {
       for (const mo of bookmark.mediaObjects) {
         if (mo.type === 'video' || mo.type === 'animated_gif') {
-          const mp4s = (mo.variants ?? [])
-            .filter((v) => v.contentType === 'video/mp4' && v.url)
+          const mp4s = (mo.videoVariants ?? [])
+            .filter((v) => v.url)
             .sort((a, b) => (b.bitrate ?? 0) - (a.bitrate ?? 0));
           if (mp4s.length > 0 && mp4s[0].url) { mediaUrls.push(mp4s[0].url); continue; }
         }
-        if (mo.mediaUrl) mediaUrls.push(mo.mediaUrl);
+        if (mo.url) mediaUrls.push(mo.url);
       }
     } else {
       mediaUrls.push(...(bookmark.media ?? []));

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,12 +5,14 @@ export interface BookmarkMediaVariant {
 }
 
 export interface BookmarkMediaObject {
+  url?: string;
   mediaUrl?: string;
   previewUrl?: string;
   type?: string;
   extAltText?: string;
   width?: number;
   height?: number;
+  videoVariants?: BookmarkMediaVariant[];
   variants?: BookmarkMediaVariant[];
 }
 


### PR DESCRIPTION
## Summary
- `mediaObjects[].variants` → `videoVariants` (matches actual bookmark data)
- `mediaObjects[].mediaUrl` → `url` (matches actual bookmark data)
- Removed strict `contentType === 'video/mp4'` filter — some video variants lack `contentType`, causing them to be silently skipped

Without this fix, `ft fetch-media` only downloads profile images. All post media (photos, videos, GIFs) is skipped because the field lookups return `undefined`.

Fixes #54

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small mapping changes to media field names and variant selection logic, primarily affecting what URLs get downloaded (videos/GIFs now included).
> 
> **Overview**
> Fixes `fetchBookmarkMediaBatch` media URL resolution to match real bookmark data by switching from `mediaObjects[].variants` to `mediaObjects[].videoVariants` and from `mediaObjects[].mediaUrl` to `mediaObjects[].url`, and by no longer requiring a `contentType` match when selecting the best video variant.
> 
> Updates `BookmarkMediaObject` types accordingly so post media (photos/videos/GIFs), not just profile images, is included in downloads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b90985b82835f518be32e2a0073de25f2d5c2201. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->