### PR TITLE
[codex] Fix GraphQL bookmark dates and fetch-media post assets

### DIFF
--- a/src/bookmark-media.ts
+++ b/src/bookmark-media.ts
@@ -79,12 +79,13 @@ export async function fetchBookmarkMediaBatch(
     if (bookmark.mediaObjects?.length) {
       for (const mo of bookmark.mediaObjects) {
         if (mo.type === 'video' || mo.type === 'animated_gif') {
-          const mp4s = (mo.variants ?? [])
-            .filter((v) => v.contentType === 'video/mp4' && v.url)
+          const mp4s = (mo.videoVariants ?? mo.variants ?? [])
+            .filter((v) => v.url && (!v.contentType || v.contentType === 'video/mp4'))
             .sort((a, b) => (b.bitrate ?? 0) - (a.bitrate ?? 0));
           if (mp4s.length > 0 && mp4s[0].url) { mediaUrls.push(mp4s[0].url); continue; }
         }
-        if (mo.mediaUrl) mediaUrls.push(mo.mediaUrl);
+        const mediaUrl = mo.url ?? mo.mediaUrl;
+        if (mediaUrl) mediaUrls.push(mediaUrl);
       }
     } else {
       mediaUrls.push(...(bookmark.media ?? []));

--- a/src/bookmarks-db.ts
+++ b/src/bookmarks-db.ts
@@ -1,5 +1,6 @@
 import type { Database } from 'sql.js';
 import { openDb, saveDb } from './db.js';
+import { parseTimestampMs, toIsoDate } from './date-utils.js';
 import { readJsonLines } from './fs.js';
 import { twitterBookmarksCachePath, twitterBookmarksIndexPath } from './paths.js';
 import type { BookmarkRecord, QuotedTweetSnapshot } from './types.js';
@@ -80,6 +81,31 @@ function parseCsv(value: unknown): string[] {
     .split(',')
     .map((entry) => entry.trim())
     .filter(Boolean);
+}
+
+function chronologicalDateRange(values: unknown[]): { earliest: string | null; latest: string | null } {
+  let earliestMs = Number.POSITIVE_INFINITY;
+  let latestMs = Number.NEGATIVE_INFINITY;
+  let earliest: string | null = null;
+  let latest: string | null = null;
+
+  for (const value of values) {
+    if (typeof value !== 'string') continue;
+    const ms = parseTimestampMs(value);
+    if (ms == null) continue;
+    const isoDate = toIsoDate(value);
+    if (!isoDate) continue;
+    if (ms < earliestMs) {
+      earliestMs = ms;
+      earliest = isoDate;
+    }
+    if (ms > latestMs) {
+      latestMs = ms;
+      latest = isoDate;
+    }
+  }
+
+  return { earliest, latest };
 }
 
 function mapTimelineRow(row: unknown[]): BookmarkTimelineItem {
@@ -636,7 +662,10 @@ export async function getStats(): Promise<{
   try {
     const total = db.exec('SELECT COUNT(*) FROM bookmarks')[0]?.values[0]?.[0] as number;
     const authors = db.exec('SELECT COUNT(DISTINCT author_handle) FROM bookmarks')[0]?.values[0]?.[0] as number;
-    const range = db.exec('SELECT MIN(posted_at), MAX(posted_at) FROM bookmarks WHERE posted_at IS NOT NULL')[0]?.values[0];
+    const postedAtRows = db.exec('SELECT posted_at FROM bookmarks WHERE posted_at IS NOT NULL');
+    const range = chronologicalDateRange(
+      (postedAtRows[0]?.values ?? []).map((row) => row[0])
+    );
 
     const topAuthorsRows = db.exec(
       `SELECT author_handle, COUNT(*) as c FROM bookmarks
@@ -661,7 +690,7 @@ export async function getStats(): Promise<{
     return {
       totalBookmarks: total,
       uniqueAuthors: authors,
-      dateRange: { earliest: (range?.[0] as string) ?? null, latest: (range?.[1] as string) ?? null },
+      dateRange: range,
       topAuthors,
       languageBreakdown,
     };

--- a/src/bookmarks-viz.ts
+++ b/src/bookmarks-viz.ts
@@ -1,4 +1,5 @@
 import { openDb } from './db.js';
+import { parseTimestampMs, toIsoDate, toIsoMonth, toMonthDayLabel, toUtcHour, toWeekdayShort, toYearLabel } from './date-utils.js';
 import { twitterBookmarksIndexPath } from './paths.js';
 
 // ── ANSI helpers ─────────────────────────────────────────────────────────────
@@ -142,66 +143,156 @@ interface VizData {
   domains: { name: string; count: number }[];
 }
 
+interface TimelineAggregateRow {
+  authorHandle?: string;
+  postedAt?: string | null;
+  syncedAt?: string | null;
+}
+
+function sortCountEntries<T extends string | number>(entries: Iterable<[T, number]>): Array<{ key: T; count: number }> {
+  return [...entries]
+    .sort((a, b) => a[0] === b[0] ? b[1] - a[1] : a[0] < b[0] ? -1 : 1)
+    .map(([key, count]) => ({ key, count }));
+}
+
+function aggregateTimelineData(rows: TimelineAggregateRow[]): {
+  dateRange: { earliest: string; latest: string };
+  monthlyActivity: { month: string; count: number }[];
+  dayOfWeekActivity: { day: string; count: number }[];
+  hourActivity: { hour: number; count: number }[];
+  recentAuthors: { handle: string; count: number }[];
+  risingVoices: { handle: string; count: number }[];
+} {
+  const monthCounts = new Map<string, number>();
+  const dayCounts = new Map<string, number>();
+  const hourCounts = new Map<number, number>();
+  const authorPostedMonths = new Map<string, Set<string>>();
+  const authorPostedCounts = new Map<string, number>();
+  const recentSessionCounts = new Map<string, number>();
+
+  let earliestMs = Number.POSITIVE_INFINITY;
+  let latestMs = Number.NEGATIVE_INFINITY;
+  let earliest = '?';
+  let latest = '?';
+  let latestPostedMonth: string | null = null;
+  let latestSyncMs = Number.NEGATIVE_INFINITY;
+  let latestSyncAt: string | null = null;
+
+  for (const row of rows) {
+    const postedAt = row.postedAt ?? null;
+    const syncedAt = row.syncedAt ?? null;
+    const handle = row.authorHandle ?? undefined;
+
+    const postedMs = parseTimestampMs(postedAt);
+    if (postedMs != null) {
+      const isoDate = toIsoDate(postedAt);
+      const isoMonth = toIsoMonth(postedAt);
+      const weekday = toWeekdayShort(postedAt);
+      const hour = toUtcHour(postedAt);
+
+      if (isoDate) {
+        if (postedMs < earliestMs) {
+          earliestMs = postedMs;
+          earliest = isoDate;
+        }
+        if (postedMs > latestMs) {
+          latestMs = postedMs;
+          latest = isoDate;
+        }
+      }
+
+      if (isoMonth) {
+        monthCounts.set(isoMonth, (monthCounts.get(isoMonth) ?? 0) + 1);
+        if (latestPostedMonth == null || isoMonth > latestPostedMonth) {
+          latestPostedMonth = isoMonth;
+        }
+        if (handle) {
+          authorPostedCounts.set(handle, (authorPostedCounts.get(handle) ?? 0) + 1);
+          const months = authorPostedMonths.get(handle) ?? new Set<string>();
+          months.add(isoMonth);
+          authorPostedMonths.set(handle, months);
+        }
+      }
+
+      if (weekday) dayCounts.set(weekday, (dayCounts.get(weekday) ?? 0) + 1);
+      if (hour != null) hourCounts.set(hour, (hourCounts.get(hour) ?? 0) + 1);
+    }
+
+    const syncedMs = parseTimestampMs(syncedAt);
+    if (syncedMs != null && syncedMs >= latestSyncMs) {
+      if (syncedMs > latestSyncMs) recentSessionCounts.clear();
+      latestSyncMs = syncedMs;
+      latestSyncAt = syncedAt;
+      if (handle) recentSessionCounts.set(handle, (recentSessionCounts.get(handle) ?? 0) + 1);
+    }
+  }
+
+  const monthNameMap: Record<string, string> = {
+    '01': 'Jan', '02': 'Feb', '03': 'Mar', '04': 'Apr', '05': 'May', '06': 'Jun',
+    '07': 'Jul', '08': 'Aug', '09': 'Sep', '10': 'Oct', '11': 'Nov', '12': 'Dec',
+  };
+
+  const monthlyActivity = sortCountEntries(monthCounts.entries()).map(({ key, count }) => {
+    const [year, monthNum] = String(key).split('-');
+    return { month: `${monthNameMap[monthNum] ?? monthNum} ${year}`, count };
+  });
+
+  const dayOfWeekActivity = sortCountEntries(dayCounts.entries()).map(({ key, count }) => ({
+    day: String(key),
+    count,
+  }));
+
+  const hourActivity = sortCountEntries(hourCounts.entries()).map(({ key, count }) => ({
+    hour: Number(key),
+    count,
+  }));
+
+  const recentAuthors = [...recentSessionCounts.entries()]
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+    .slice(0, 10)
+    .map(([handle, count]) => ({ handle, count }));
+
+  const risingVoices = latestPostedMonth == null
+    ? []
+    : [...authorPostedCounts.entries()]
+        .filter(([handle, count]) => count >= 3 && authorPostedMonths.get(handle)?.size === 1 && authorPostedMonths.get(handle)?.has(latestPostedMonth))
+        .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+        .slice(0, 8)
+        .map(([handle, count]) => ({ handle, count }));
+
+  return {
+    dateRange: { earliest, latest },
+    monthlyActivity,
+    dayOfWeekActivity,
+    hourActivity,
+    recentAuthors: latestSyncAt ? recentAuthors : [],
+    risingVoices,
+  };
+}
+
 async function queryVizData(): Promise<VizData> {
   const db = await openDb(twitterBookmarksIndexPath());
 
   try {
     const total = db.exec('SELECT COUNT(*) FROM bookmarks')[0]?.values[0]?.[0] as number;
     const authors = db.exec('SELECT COUNT(DISTINCT author_handle) FROM bookmarks')[0]?.values[0]?.[0] as number;
-    const range = db.exec('SELECT MIN(posted_at), MAX(posted_at) FROM bookmarks WHERE posted_at IS NOT NULL')[0]?.values[0];
+    const timelineRows = db.exec(
+      `SELECT author_handle, posted_at, synced_at
+       FROM bookmarks
+       WHERE posted_at IS NOT NULL OR synced_at IS NOT NULL OR author_handle IS NOT NULL`
+    );
+    const timelineData = aggregateTimelineData(
+      (timelineRows[0]?.values ?? []).map((row) => ({
+        authorHandle: (row[0] as string) ?? undefined,
+        postedAt: (row[1] as string) ?? null,
+        syncedAt: (row[2] as string) ?? null,
+      }))
+    );
 
     const topAuthorsRows = db.exec(
       `SELECT author_handle, COUNT(*) as c FROM bookmarks
        WHERE author_handle IS NOT NULL
        GROUP BY author_handle ORDER BY c DESC LIMIT 20`
-    );
-
-    // Twitter legacy format: "Sat Mar 28 18:55:23 +0000 2026"
-    // Normalize both legacy and ISO timestamps into the same YYYY-MM bucket.
-    const legacyMonthNumberExpr = `CASE substr(bookmarked_at, 5, 3)
-      WHEN 'Jan' THEN '01' WHEN 'Feb' THEN '02' WHEN 'Mar' THEN '03'
-      WHEN 'Apr' THEN '04' WHEN 'May' THEN '05' WHEN 'Jun' THEN '06'
-      WHEN 'Jul' THEN '07' WHEN 'Aug' THEN '08' WHEN 'Sep' THEN '09'
-      WHEN 'Oct' THEN '10' WHEN 'Nov' THEN '11' WHEN 'Dec' THEN '12'
-      ELSE '00'
-    END`;
-    const monthBucketExpr = `CASE
-      WHEN bookmarked_at GLOB '____-__-__*' THEN substr(bookmarked_at, 1, 7)
-      ELSE substr(bookmarked_at, -4) || '-' || ${legacyMonthNumberExpr}
-    END`;
-
-    const monthlyRows = db.exec(
-      `SELECT
-         ${monthBucketExpr} as ym,
-         COUNT(*) as c
-       FROM bookmarks WHERE bookmarked_at IS NOT NULL
-       GROUP BY ym ORDER BY ym`
-    );
-
-    // Day of week — first 3 chars for legacy, strftime('%w') for ISO
-    // SQLite %w: 0=Sunday, 1=Monday... We can map them if we want, but the chart just uses 'dow' as a string key
-    const dowRows = db.exec(
-      `SELECT 
-         CASE
-           WHEN bookmarked_at GLOB '____-__-__*' THEN 
-             CASE strftime('%w', bookmarked_at)
-               WHEN '0' THEN 'Sun' WHEN '1' THEN 'Mon' WHEN '2' THEN 'Tue'
-               WHEN '3' THEN 'Wed' WHEN '4' THEN 'Thu' WHEN '5' THEN 'Fri' WHEN '6' THEN 'Sat' END
-           ELSE substr(bookmarked_at, 1, 3)
-         END as dow, COUNT(*) as c
-       FROM bookmarks WHERE bookmarked_at IS NOT NULL
-       GROUP BY dow ORDER BY c DESC`
-    );
-
-    // Hour of day — chars 12-13 for legacy, strftime('%H') for ISO
-    const hourRows = db.exec(
-      `SELECT 
-         CASE
-           WHEN bookmarked_at GLOB '____-__-__*' THEN CAST(strftime('%H', bookmarked_at) AS INTEGER)
-           ELSE CAST(substr(bookmarked_at, 12, 2) AS INTEGER)
-         END as h, COUNT(*) as c
-       FROM bookmarks WHERE bookmarked_at IS NOT NULL
-       GROUP BY h ORDER BY h`
     );
 
     // Domains from links_json
@@ -241,14 +332,6 @@ async function queryVizData(): Promise<VizData> {
 
     const avgLen = db.exec('SELECT AVG(length(text)) FROM bookmarks')[0]?.values[0]?.[0] as number;
 
-    // Recent 30 days top authors
-    const recentAuthorsRows = db.exec(
-      `SELECT author_handle, COUNT(*) as c FROM bookmarks
-       WHERE author_handle IS NOT NULL
-       AND bookmarked_at >= (SELECT MAX(bookmarked_at) FROM bookmarks)
-       GROUP BY author_handle ORDER BY c DESC LIMIT 10`
-    );
-
     // Time capsules: oldest posts, one per year to spread the range
     const capsuleRows = db.exec(
       `SELECT author_handle, text, tweet_id, posted_at, substr(posted_at, -4) as yr
@@ -286,41 +369,6 @@ async function queryVizData(): Promise<VizData> {
       postedAt: r[3] as string,
     }));
 
-    // Rising voices: authors with 3+ bookmarks, all from the most recent month
-    const latestMonth = db.exec(
-      `SELECT ${monthBucketExpr}
-       FROM bookmarks WHERE bookmarked_at IS NOT NULL
-       ORDER BY bookmarked_at DESC LIMIT 1`
-    )[0]?.values[0]?.[0] as string | undefined;
-
-    let risingVoices: { handle: string; count: number }[] = [];
-    if (latestMonth) {
-      const risingRows = db.exec(
-        `SELECT author_handle, COUNT(*) as c FROM bookmarks
-         WHERE author_handle IS NOT NULL
-         GROUP BY author_handle
-         HAVING c >= 3
-         AND MIN(${monthBucketExpr}) = ?
-         ORDER BY c DESC LIMIT 8`,
-        [latestMonth]
-      );
-      risingVoices = (risingRows[0]?.values ?? []).map((r) => ({
-        handle: r[0] as string,
-        count: r[1] as number,
-      }));
-    }
-
-    const monthNameMap: Record<string, string> = {
-      '01': 'Jan', '02': 'Feb', '03': 'Mar', '04': 'Apr', '05': 'May', '06': 'Jun',
-      '07': 'Jul', '08': 'Aug', '09': 'Sep', '10': 'Oct', '11': 'Nov', '12': 'Dec',
-    };
-    const rawMonthly = (monthlyRows[0]?.values ?? []).map((r) => {
-      const month = r[0] as string; // "2026-03"
-      const [year, monthNum] = month.split('-');
-      const label = `${monthNameMap[monthNum] ?? monthNum} ${year}`;
-      return { month, label, count: r[1] as number };
-    });
-
     // Categories
     let categories: { name: string; count: number }[] = [];
     try {
@@ -352,32 +400,17 @@ async function queryVizData(): Promise<VizData> {
     return {
       total,
       uniqueAuthors: authors,
-      dateRange: {
-        earliest: (range?.[0] as string) ?? '?',
-        latest: (range?.[1] as string) ?? '?',
-      },
+      dateRange: timelineData.dateRange,
       topAuthors: (topAuthorsRows[0]?.values ?? []).map((r) => ({
         handle: r[0] as string,
         count: r[1] as number,
       })),
-      monthlyActivity: rawMonthly.map((r) => ({
-        month: r.label,
-        count: r.count,
-      })),
-      dayOfWeekActivity: (dowRows[0]?.values ?? []).map((r) => ({
-        day: r[0] as string,
-        count: r[1] as number,
-      })),
-      hourActivity: (hourRows[0]?.values ?? []).map((r) => ({
-        hour: r[0] as number,
-        count: r[1] as number,
-      })),
+      monthlyActivity: timelineData.monthlyActivity,
+      dayOfWeekActivity: timelineData.dayOfWeekActivity,
+      hourActivity: timelineData.hourActivity,
       topDomains,
       mediaStats,
-      recentAuthors: (recentAuthorsRows[0]?.values ?? []).map((r) => ({
-        handle: r[0] as string,
-        count: r[1] as number,
-      })),
+      recentAuthors: timelineData.recentAuthors,
       languages: (langRows[0]?.values ?? []).map((r) => ({
         lang: r[0] as string,
         count: r[1] as number,
@@ -385,7 +418,7 @@ async function queryVizData(): Promise<VizData> {
       avgTextLength: avgLen,
       timeCapsules,
       hiddenGems,
-      risingVoices,
+      risingVoices: timelineData.risingVoices,
       categories,
       domains,
     };
@@ -410,7 +443,7 @@ function renderHeader(data: VizData): string[] {
     `${C.text}${data.total.toLocaleString()} bookmarks${C.dim}  ·  ${C.text}${data.uniqueAuthors.toLocaleString()} voices${C.dim}  ·  ${C.text}${data.languages.length} languages`, W
   ));
   lines.push(boxRow(
-    `${C.dim}${data.dateRange.earliest.slice(0, 16)} → ${data.dateRange.latest.slice(0, 16)}`, W
+    `${C.dim}${data.dateRange.earliest} → ${data.dateRange.latest}`, W
   ));
   lines.push(boxBottom(W));
   return lines;
@@ -440,12 +473,13 @@ function renderTopAuthors(data: VizData): string[] {
 
 function renderActivity(data: VizData): string[] {
   const lines: string[] = [];
+  if (data.monthlyActivity.length === 0) return [];
   const counts = data.monthlyActivity.map((m) => m.count);
   const maxCount = Math.max(...counts, 1);
 
   lines.push('');
-  lines.push(`  ${C.warm}${BOLD}RHYTHM${RESET}`);
-  lines.push(`  ${C.dim}monthly bookmarking cadence${RESET}`);
+  lines.push(`  ${C.warm}${BOLD}PUBLICATION RHYTHM${RESET}`);
+  lines.push(`  ${C.dim}monthly cadence of posts in your library${RESET}`);
   lines.push('');
 
   // Sparkline overview
@@ -478,8 +512,8 @@ function renderDayOfWeek(data: VizData): string[] {
   const counts = ordered.map((d) => d.count);
 
   lines.push('');
-  lines.push(`  ${C.green}${BOLD}WEEKLY PULSE${RESET}`);
-  lines.push(`  ${C.dim}which days you bookmark${RESET}`);
+  lines.push(`  ${C.green}${BOLD}POST WEEKDAYS${RESET}`);
+  lines.push(`  ${C.dim}which weekdays your saved posts were published${RESET}`);
   lines.push('');
   lines.push(`  ${brailleChart(counts, 14, C.green)}`);
   lines.push('');
@@ -507,8 +541,8 @@ function renderHourOfDay(data: VizData): string[] {
   const maxCount = Math.max(...allHours, 1);
 
   lines.push('');
-  lines.push(`  ${C.cyan}${BOLD}DAILY ARC${RESET}`);
-  lines.push(`  ${C.dim}when you reach for the bookmark button${RESET}`);
+  lines.push(`  ${C.cyan}${BOLD}POSTING HOURS${RESET}`);
+  lines.push(`  ${C.dim}UTC posting hours for the tweets you saved${RESET}`);
   lines.push('');
 
   // Vertical bar chart using blocks
@@ -691,10 +725,6 @@ function truncateText(text: string, max: number): string {
   return clean.slice(0, max - 1) + '…';
 }
 
-function twitterDateYear(date: string): string {
-  return date.slice(-4);
-}
-
 function renderTimeCapsules(data: VizData): string[] {
   const lines: string[] = [];
   if (data.timeCapsules.length === 0) return [];
@@ -705,8 +735,8 @@ function renderTimeCapsules(data: VizData): string[] {
   lines.push('');
 
   for (const b of data.timeCapsules) {
-    const year = twitterDateYear(b.postedAt);
-    const monthDay = b.postedAt.slice(4, 10); // " Mar 28"
+    const year = toYearLabel(b.postedAt);
+    const monthDay = toMonthDayLabel(b.postedAt).padStart(6, ' ');
     const color = lerpColor([240, 200, 100], [200, 160, 80], 0.5);
     const url = `x.com/${b.author}/status/${b.tweetId}`;
     lines.push(`  ${color}${year}${RESET}${C.dim}${monthDay}${RESET}  ${C.text}@${b.author}${RESET}`);
@@ -744,7 +774,7 @@ function renderRisingVoices(data: VizData): string[] {
 
   lines.push('');
   lines.push(`  ${C.green}${BOLD}RISING${RESET}`);
-  lines.push(`  ${C.dim}new voices — all bookmarks from your most recent month${RESET}`);
+  lines.push(`  ${C.dim}voices concentrated in the latest publication month in your library${RESET}`);
   lines.push('');
 
   for (const v of data.risingVoices) {

--- a/src/date-utils.ts
+++ b/src/date-utils.ts
@@ -1,0 +1,47 @@
+const WEEKDAYS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'] as const;
+
+export function parseTimestampMs(value?: string | null): number | null {
+  if (!value) return null;
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+export function toIsoDate(value?: string | null): string | null {
+  const ms = parseTimestampMs(value);
+  if (ms == null) return null;
+  return new Date(ms).toISOString().slice(0, 10);
+}
+
+export function toIsoMonth(value?: string | null): string | null {
+  const ms = parseTimestampMs(value);
+  if (ms == null) return null;
+  return new Date(ms).toISOString().slice(0, 7);
+}
+
+export function toWeekdayShort(value?: string | null): string | null {
+  const ms = parseTimestampMs(value);
+  if (ms == null) return null;
+  return WEEKDAYS[new Date(ms).getUTCDay()] ?? null;
+}
+
+export function toUtcHour(value?: string | null): number | null {
+  const ms = parseTimestampMs(value);
+  if (ms == null) return null;
+  return new Date(ms).getUTCHours();
+}
+
+export function toYearLabel(value?: string | null): string {
+  const ms = parseTimestampMs(value);
+  if (ms == null) return value?.slice(-4) ?? '????';
+  return new Date(ms).toISOString().slice(0, 4);
+}
+
+export function toMonthDayLabel(value?: string | null): string {
+  const ms = parseTimestampMs(value);
+  if (ms == null) return value?.slice(4, 10) ?? ' ?? ??';
+  return new Date(ms).toLocaleDateString('en-US', {
+    month: 'short',
+    day: '2-digit',
+    timeZone: 'UTC',
+  });
+}

--- a/src/graphql-bookmarks.ts
+++ b/src/graphql-bookmarks.ts
@@ -3,6 +3,7 @@ import { ensureDataDir, twitterBookmarksCachePath, twitterBookmarksMetaPath, twi
 import { loadChromeSessionConfig } from './config.js';
 import { extractChromeXCookies } from './chrome-cookies.js';
 import { extractFirefoxXCookies } from './firefox-cookies.js';
+import { parseTimestampMs } from './date-utils.js';
 import type { BookmarkBackfillState, BookmarkCacheMeta, BookmarkRecord, QuotedTweetSnapshot } from './types.js';
 import { exportBookmarksForSyncSeed, updateQuotedTweets, updateBookmarkText } from './bookmarks-db.js';
 
@@ -102,26 +103,24 @@ function parseSnowflake(value?: string | null): bigint | null {
   }
 }
 
-function parseDateMs(value?: string | null): number | null {
-  if (!value) return null;
-  const parsed = Date.parse(value);
-  return Number.isFinite(parsed) ? parsed : null;
-}
-
 const MAX_FUTURE_BOOKMARK_SKEW_MS = 5 * 60_000;
 
 export function sanitizeBookmarkedAt(record: BookmarkRecord): BookmarkRecord {
-  const bookmarkedAtMs = parseDateMs(record.bookmarkedAt);
+  if (record.ingestedVia === 'graphql') {
+    return record.bookmarkedAt == null ? record : { ...record, bookmarkedAt: null };
+  }
+
+  const bookmarkedAtMs = parseTimestampMs(record.bookmarkedAt);
   if (bookmarkedAtMs == null) {
     return record.bookmarkedAt == null ? record : { ...record, bookmarkedAt: null };
   }
 
-  const postedAtMs = parseDateMs(record.postedAt);
+  const postedAtMs = parseTimestampMs(record.postedAt);
   if (postedAtMs != null && bookmarkedAtMs < postedAtMs) {
     return { ...record, bookmarkedAt: null };
   }
 
-  const syncedAtMs = parseDateMs(record.syncedAt);
+  const syncedAtMs = parseTimestampMs(record.syncedAt);
   if (syncedAtMs != null && bookmarkedAtMs > syncedAtMs + MAX_FUTURE_BOOKMARK_SKEW_MS) {
     return { ...record, bookmarkedAt: null };
   }
@@ -142,13 +141,19 @@ function sanitizeRecords(records: BookmarkRecord[]): { records: BookmarkRecord[]
 function parseBookmarkTimestamp(record: BookmarkRecord): number | null {
   const candidates = [record.bookmarkedAt, record.postedAt, record.syncedAt];
   for (const candidate of candidates) {
-    const parsed = parseDateMs(candidate);
+    const parsed = parseTimestampMs(candidate);
     if (parsed != null) return parsed;
   }
   return null;
 }
 
 function compareBookmarkChronology(a: BookmarkRecord, b: BookmarkRecord): number {
+  const aSortIndex = parseSnowflake(a.sortIndex);
+  const bSortIndex = parseSnowflake(b.sortIndex);
+  if (aSortIndex != null && bSortIndex != null && aSortIndex !== bSortIndex) {
+    return aSortIndex > bSortIndex ? 1 : -1;
+  }
+
   const aTimestamp = parseBookmarkTimestamp(a);
   const bTimestamp = parseBookmarkTimestamp(b);
   if (aTimestamp != null && bTimestamp != null && aTimestamp !== bTimestamp) {
@@ -334,19 +339,6 @@ export function convertTweetToRecord(tweetResult: any, now: string): BookmarkRec
   };
 }
 
-const TWITTER_SNOWFLAKE_EPOCH = 1288834974657n;
-
-function snowflakeToIso(snowflake: string): string | null {
-  try {
-    const id = BigInt(snowflake);
-    const ms = Number(id >> 22n) + Number(TWITTER_SNOWFLAKE_EPOCH);
-    const date = new Date(ms);
-    return Number.isFinite(date.getTime()) ? date.toISOString() : null;
-  } catch {
-    return null;
-  }
-}
-
 export function parseBookmarksResponse(json: any, now?: string): PageResult {
   const ts = now ?? new Date().toISOString();
   const instructions = json?.data?.bookmark_timeline_v2?.timeline?.instructions ?? [];
@@ -371,10 +363,7 @@ export function parseBookmarksResponse(json: any, now?: string): PageResult {
 
     const record = convertTweetToRecord(tweetResult, ts);
     if (record) {
-      // Extract bookmarkedAt from the entry's sortIndex (snowflake timestamp)
-      if (entry.sortIndex) {
-        record.bookmarkedAt = snowflakeToIso(entry.sortIndex) ?? record.bookmarkedAt;
-      }
+      record.sortIndex = typeof entry.sortIndex === 'string' ? entry.sortIndex : null;
       records.push(sanitizeBookmarkedAt(record));
     }
   }
@@ -523,9 +512,7 @@ export async function syncBookmarksGraphQL(
   const loaded = await loadExistingBookmarks();
   let existing = loaded.records;
   const bookmarkedAtRepaired = loaded.repaired;
-  const newestKnownId = incremental
-    ? existing.slice().sort((a, b) => compareBookmarkChronology(b, a))[0]?.id
-    : undefined;
+  const newestKnownId = incremental ? existing[0]?.id : undefined;
   const previousMeta = (await pathExists(metaPath))
     ? await readJson<BookmarkCacheMeta>(metaPath)
     : undefined;

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,12 +5,16 @@ export interface BookmarkMediaVariant {
 }
 
 export interface BookmarkMediaObject {
+  url?: string;
   mediaUrl?: string;
+  expandedUrl?: string;
   previewUrl?: string;
   type?: string;
+  altText?: string;
   extAltText?: string;
   width?: number;
   height?: number;
+  videoVariants?: BookmarkMediaVariant[];
   variants?: BookmarkMediaVariant[];
 }
 
@@ -59,6 +63,8 @@ export interface BookmarkRecord {
   text: string;
   postedAt?: string | null;
   bookmarkedAt?: string | null;
+  /** X's opaque bookmark ordering key. Useful for chronology, not timestamps. */
+  sortIndex?: string | null;
   syncedAt: string;
   conversationId?: string;
   inReplyToStatusId?: string;

--- a/tests/bookmark-media.test.ts
+++ b/tests/bookmark-media.test.ts
@@ -1,0 +1,80 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, writeFile } from 'node:fs/promises';
+import { rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fetchBookmarkMediaBatch } from '../src/bookmark-media.js';
+
+async function withMediaDataDir(records: any[], fn: () => Promise<void>): Promise<void> {
+  const dir = await mkdtemp(path.join(tmpdir(), 'ft-media-test-'));
+  await writeFile(path.join(dir, 'bookmarks.jsonl'), records.map((r) => JSON.stringify(r)).join('\n') + '\n');
+
+  const saved = process.env.FT_DATA_DIR;
+  process.env.FT_DATA_DIR = dir;
+  try {
+    await fn();
+  } finally {
+    if (saved !== undefined) process.env.FT_DATA_DIR = saved;
+    else delete process.env.FT_DATA_DIR;
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+test('fetchBookmarkMediaBatch downloads post media from GraphQL mediaObjects shape', async () => {
+  const photoUrl = 'https://pbs.twimg.com/media/example.jpg';
+  const videoUrl = 'https://video.twimg.com/ext_tw_video/example.mp4';
+  const profileUrl = 'https://pbs.twimg.com/profile_images/123/avatar_normal.jpg';
+  const records = [{
+    id: '1',
+    tweetId: '1',
+    url: 'https://x.com/alice/status/1',
+    text: 'media test',
+    authorHandle: 'alice',
+    authorName: 'Alice',
+    authorProfileImageUrl: profileUrl,
+    syncedAt: '2026-04-09T00:00:00.000Z',
+    mediaObjects: [
+      { type: 'photo', url: photoUrl },
+      { type: 'video', videoVariants: [{ url: videoUrl, bitrate: 832000 }] },
+    ],
+    links: [],
+    tags: [],
+    ingestedVia: 'graphql',
+  }];
+
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+    const url = String(input instanceof Request ? input.url : input);
+    const method = init?.method ?? 'GET';
+    const contentType = url.endsWith('.mp4') ? 'video/mp4' : 'image/jpeg';
+    if (method === 'HEAD') {
+      return new Response(null, {
+        status: 200,
+        headers: { 'content-length': '4', 'content-type': contentType },
+      });
+    }
+    return new Response(Uint8Array.from([1, 2, 3, 4]), {
+      status: 200,
+      headers: { 'content-type': contentType },
+    });
+  };
+
+  try {
+    await withMediaDataDir(records, async () => {
+      const manifest = await fetchBookmarkMediaBatch({ limit: 10, maxBytes: 1024 });
+      const downloaded = manifest.entries
+        .filter((entry) => entry.status === 'downloaded')
+        .map((entry) => entry.sourceUrl)
+        .sort();
+
+      assert.deepEqual(downloaded, [
+        photoUrl,
+        profileUrl.replace('_normal.', '_400x400.'),
+        videoUrl,
+      ].sort());
+    });
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});

--- a/tests/bookmarks-db.test.ts
+++ b/tests/bookmarks-db.test.ts
@@ -13,9 +13,9 @@ const FIXTURES = [
   { id: '3', tweetId: '3', url: 'https://x.com/alice/status/3', text: 'Deep learning models need massive compute', authorHandle: 'alice', authorName: 'Alice Smith', syncedAt: '2026-03-01T00:00:00Z', postedAt: '2026-03-01T12:00:00Z', language: 'en', engagement: { likeCount: 200, repostCount: 30 }, mediaObjects: [{ type: 'photo', url: 'https://img.com/1.jpg' }], links: [], tags: [], ingestedVia: 'graphql' },
 ];
 
-async function withIsolatedDataDir(fn: () => Promise<void>): Promise<void> {
+async function withIsolatedDataDir(fn: () => Promise<void>, fixtures: any[] = FIXTURES): Promise<void> {
   const dir = await mkdtemp(path.join(tmpdir(), 'ft-test-'));
-  const jsonl = FIXTURES.map((r) => JSON.stringify(r)).join('\n') + '\n';
+  const jsonl = fixtures.map((r) => JSON.stringify(r)).join('\n') + '\n';
   await writeFile(path.join(dir, 'bookmarks.jsonl'), jsonl);
 
   const saved = process.env.FT_DATA_DIR;
@@ -128,6 +128,46 @@ test('getStats returns correct aggregate data', async () => {
     assert.equal(stats.languageBreakdown[0].language, 'en');
     assert.equal(stats.languageBreakdown[0].count, 3);
   });
+});
+
+test('getStats returns chronological date range for legacy Twitter timestamps', async () => {
+  const fixtures = [
+    {
+      id: 'old',
+      tweetId: '10',
+      url: 'https://x.com/old/status/10',
+      text: 'Old tweet',
+      authorHandle: 'old',
+      authorName: 'Old',
+      syncedAt: '2026-04-01T00:00:00Z',
+      postedAt: 'Fri Apr 03 12:00:00 +0000 2020',
+      mediaObjects: [],
+      links: [],
+      tags: [],
+      ingestedVia: 'graphql',
+    },
+    {
+      id: 'new',
+      tweetId: '20',
+      url: 'https://x.com/new/status/20',
+      text: 'New tweet',
+      authorHandle: 'new',
+      authorName: 'New',
+      syncedAt: '2026-04-01T00:00:00Z',
+      postedAt: 'Wed Apr 08 06:30:15 +0000 2026',
+      mediaObjects: [],
+      links: [],
+      tags: [],
+      ingestedVia: 'graphql',
+    },
+  ];
+
+  await withIsolatedDataDir(async () => {
+    await buildIndex({ force: true });
+    const stats = await getStats();
+    assert.equal(stats.dateRange.earliest, '2020-04-03');
+    assert.equal(stats.dateRange.latest, '2026-04-08');
+  }, fixtures);
 });
 
 test('formatSearchResults: formats results with author, date, text, url', () => {

--- a/tests/bookmarks-viz.test.ts
+++ b/tests/bookmarks-viz.test.ts
@@ -1,0 +1,85 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, writeFile } from 'node:fs/promises';
+import { rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { buildIndex } from '../src/bookmarks-db.js';
+import { renderViz } from '../src/bookmarks-viz.js';
+
+async function withVizDataDir(records: any[], fn: () => Promise<void>): Promise<void> {
+  const dir = await mkdtemp(path.join(tmpdir(), 'ft-viz-test-'));
+  await writeFile(path.join(dir, 'bookmarks.jsonl'), records.map((r) => JSON.stringify(r)).join('\n') + '\n');
+
+  const saved = process.env.FT_DATA_DIR;
+  process.env.FT_DATA_DIR = dir;
+  try {
+    await fn();
+  } finally {
+    if (saved !== undefined) process.env.FT_DATA_DIR = saved;
+    else delete process.env.FT_DATA_DIR;
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+test('renderViz uses publication timing instead of fabricated bookmark timing', async () => {
+  const records = [
+    {
+      id: '1',
+      tweetId: '1',
+      url: 'https://x.com/alice/status/1',
+      text: 'One',
+      authorHandle: 'alice',
+      authorName: 'Alice',
+      postedAt: 'Wed Apr 08 06:30:15 +0000 2026',
+      bookmarkedAt: null,
+      syncedAt: '2026-04-09T08:00:00.000Z',
+      mediaObjects: [],
+      links: [],
+      tags: [],
+      ingestedVia: 'graphql',
+    },
+    {
+      id: '2',
+      tweetId: '2',
+      url: 'https://x.com/bob/status/2',
+      text: 'Two',
+      authorHandle: 'bob',
+      authorName: 'Bob',
+      postedAt: 'Tue Apr 07 18:10:00 +0000 2026',
+      bookmarkedAt: null,
+      syncedAt: '2026-04-09T08:00:00.000Z',
+      mediaObjects: [],
+      links: [],
+      tags: [],
+      ingestedVia: 'graphql',
+    },
+    {
+      id: '3',
+      tweetId: '3',
+      url: 'https://x.com/alice/status/3',
+      text: 'Three',
+      authorHandle: 'alice',
+      authorName: 'Alice',
+      postedAt: 'Mon Mar 30 00:05:00 +0000 2026',
+      bookmarkedAt: null,
+      syncedAt: '2026-04-09T08:00:00.000Z',
+      mediaObjects: [],
+      links: [],
+      tags: [],
+      ingestedVia: 'graphql',
+    },
+  ];
+
+  await withVizDataDir(records, async () => {
+    await buildIndex({ force: true });
+    const output = await renderViz();
+
+    assert.match(output, /PUBLICATION RHYTHM/);
+    assert.match(output, /POST WEEKDAYS/);
+    assert.match(output, /POSTING HOURS/);
+    assert.doesNotMatch(output, /monthly bookmarking cadence/);
+    assert.doesNotMatch(output, /when you reach for the bookmark button/);
+    assert.doesNotMatch(output, /000Z/);
+  });
+});

--- a/tests/graphql-bookmarks.test.ts
+++ b/tests/graphql-bookmarks.test.ts
@@ -298,12 +298,8 @@ test('convertTweetToRecord: handles missing quoted tweet gracefully', () => {
   assert.equal(result.quotedTweet, undefined);
 });
 
-test('parseBookmarksResponse: extracts bookmarkedAt from sortIndex', () => {
+test('parseBookmarksResponse: preserves sortIndex for bookmark ordering without fabricating bookmarkedAt', () => {
   const tr = makeTweetResult();
-  // Snowflake for a known date: encode March 11 2026 00:00:00 UTC (after tweet created_at of March 10 12:00)
-  // Twitter epoch: 1288834974657, target ms: 1773273600000
-  // offset = 1773273600000 - 1288834974657 = 484438625343
-  // snowflake = offset << 22 = 2031520476165046272
   const resp = {
     data: {
       bookmark_timeline_v2: {
@@ -324,11 +320,8 @@ test('parseBookmarksResponse: extracts bookmarkedAt from sortIndex', () => {
   };
   const { records } = parseBookmarksResponse(resp, NOW);
   assert.equal(records.length, 1);
-  assert.ok(records[0].bookmarkedAt);
-  // Should decode to March 11 2026
-  const parsed = new Date(records[0].bookmarkedAt!);
-  assert.ok(parsed.getFullYear() === 2026);
-  assert.ok(parsed.getMonth() === 2); // March = month 2
+  assert.equal(records[0].sortIndex, '2031520476165046272');
+  assert.equal(records[0].bookmarkedAt, null);
 });
 
 test('parseBookmarksResponse: handles missing sortIndex gracefully', () => {
@@ -339,7 +332,7 @@ test('parseBookmarksResponse: handles missing sortIndex gracefully', () => {
   assert.equal(records[0].bookmarkedAt, null); // no sortIndex = stays null
 });
 
-test('parseBookmarksResponse: clears sortIndex timestamps earlier than tweet creation', () => {
+test('parseBookmarksResponse: keeps sortIndex opaque even when it decodes to an impossible date', () => {
   const tr = makeTweetResult({
     legacy: {
       created_at: 'Fri Apr 03 12:00:00 +0000 2026',
@@ -368,6 +361,7 @@ test('parseBookmarksResponse: clears sortIndex timestamps earlier than tweet cre
   const { records } = parseBookmarksResponse(resp, NOW);
   assert.equal(records.length, 1);
   assert.equal(records[0].bookmarkedAt, null);
+  assert.equal(records[0].sortIndex, '1861891119789912064');
 });
 
 test('parseBookmarksResponse: parses entries and cursor', () => {
@@ -542,6 +536,7 @@ test('sanitizeBookmarkedAt: clears timestamps too far after syncedAt', () => {
 
 test('sanitizeBookmarkedAt: preserves valid timestamp within range', () => {
   const record = sanitizeBookmarkedAt(makeRecord({
+    ingestedVia: 'api',
     postedAt: 'Tue Mar 10 12:00:00 +0000 2026',
     syncedAt: '2026-03-28T00:00:00.000Z',
     bookmarkedAt: '2026-03-15T00:00:00.000Z',
@@ -556,6 +551,17 @@ test('sanitizeBookmarkedAt: returns record unchanged when bookmarkedAt is null',
 
   assert.equal(result.bookmarkedAt, null);
   assert.strictEqual(result, input); // same reference — no unnecessary copy
+});
+
+test('sanitizeBookmarkedAt: clears GraphQL bookmark dates even when they look plausible', () => {
+  const result = sanitizeBookmarkedAt(makeRecord({
+    ingestedVia: 'graphql',
+    postedAt: '2026-03-10T12:00:00.000Z',
+    syncedAt: '2026-03-28T00:00:00.000Z',
+    bookmarkedAt: '2026-03-15T00:00:00.000Z',
+  }));
+
+  assert.equal(result.bookmarkedAt, null);
 });
 
 test('formatSyncResult: formats all fields', () => {


### PR DESCRIPTION
## What changed

- stop treating GraphQL `sortIndex` as a bookmark timestamp and keep it only as an ordering key
- clear synthetic GraphQL `bookmarkedAt` values and fix stats and viz output to use real parsed dates
- update `ft fetch-media` to read the current GraphQL `mediaObjects` shape (`url` / `videoVariants`) while keeping fallbacks for older fields
- add regression coverage for bookmark chronology, stats/viz output, and media downloads

## Why

X's GraphQL bookmarks timeline preserves order but does not expose a trustworthy bookmark timestamp. We were decoding `sortIndex` into fake `bookmarkedAt` values, which polluted downstream stats and visualizations. Separately, the media downloader had drifted to legacy field names, so post media URLs and video variants were skipped.

## Impact

- bookmark ordering is preserved without inventing fake bookmark times
- `ft stats` date ranges are chronological again
- `ft viz` reflects publication and sync timing instead of fabricated bookmark timing
- `ft fetch-media` downloads post photos, videos, and GIFs again

## Root cause

- synthetic `bookmarkedAt` values were derived from `sortIndex`
- the GraphQL producer and media downloader had diverged on media field names

## Commit summary

- `fix: stop fabricating bookmark dates and fetch post media`

## Validation

- `npm run build`
- `npm test`

## Credit

Thanks @beefkatsu for reporting #65 and #54.