### PR TITLE
fix: correct dashboard footer date range by sorting on tweet IDs

### DIFF
--- a/src/bookmarks-viz.ts
+++ b/src/bookmarks-viz.ts
@@ -148,7 +148,11 @@ async function queryVizData(): Promise<VizData> {
   try {
     const total = db.exec('SELECT COUNT(*) FROM bookmarks')[0]?.values[0]?.[0] as number;
     const authors = db.exec('SELECT COUNT(DISTINCT author_handle) FROM bookmarks')[0]?.values[0]?.[0] as number;
-    const range = db.exec('SELECT MIN(posted_at), MAX(posted_at) FROM bookmarks WHERE posted_at IS NOT NULL')[0]?.values[0];
+    
+    // Get true chronological range using Snowflake IDs, not text sorting
+    const earliestRow = db.exec('SELECT posted_at FROM bookmarks WHERE posted_at IS NOT NULL ORDER BY CAST(tweet_id AS INTEGER) ASC LIMIT 1');
+    const latestRow = db.exec('SELECT posted_at FROM bookmarks WHERE posted_at IS NOT NULL ORDER BY CAST(tweet_id AS INTEGER) DESC LIMIT 1');
+    const range = [earliestRow[0]?.values[0]?.[0], latestRow[0]?.values[0]?.[0]];
 
     const topAuthorsRows = db.exec(
       `SELECT author_handle, COUNT(*) as c FROM bookmarks
@@ -398,19 +402,30 @@ async function queryVizData(): Promise<VizData> {
 
 const W = 72; // box width
 
+function formatHeaderDate(dateStr: string): string {
+  if (dateStr === '?') return '?';
+  const d = new Date(dateStr);
+  if (!isNaN(d.getTime())) {
+    return d.toLocaleDateString('en-US', { month: 'short', year: 'numeric' });
+  }
+  // Fallback for malformed legacy strings: extract Month and Year
+  const parts = dateStr.split(' ');
+  return parts.length >= 6 ? `${parts[1]} ${parts[5]}` : dateStr.slice(0, 10);
+}
+
 function renderHeader(data: VizData): string[] {
+  const W = 68;
   const lines: string[] = [];
+
   lines.push('');
   lines.push(boxTop(W));
-  lines.push(boxRow(
-    `${C.title}${BOLD}  ✦  FIELD THEORY  ·  BOOKMARK OBSERVATORY  ✦  ${RESET}`, W
-  ));
+  lines.push(boxRow(`  ${C.gold}✦${RESET}  ${BOLD}FIELD THEORY${RESET}  ${C.dim}·${RESET}  BOOKMARK OBSERVATORY  ${C.gold}✦${RESET}`, W));
   lines.push(boxDivider(W));
   lines.push(boxRow(
     `${C.text}${data.total.toLocaleString()} bookmarks${C.dim}  ·  ${C.text}${data.uniqueAuthors.toLocaleString()} voices${C.dim}  ·  ${C.text}${data.languages.length} languages`, W
   ));
   lines.push(boxRow(
-    `${C.dim}${data.dateRange.earliest.slice(0, 16)} → ${data.dateRange.latest.slice(0, 16)}`, W
+    `${C.dim}${formatHeaderDate(data.dateRange.earliest)} → ${formatHeaderDate(data.dateRange.latest)}${RESET}`, W
   ));
   lines.push(boxBottom(W));
   return lines;

--- a/tests/bookmarks-viz-range.test.ts
+++ b/tests/bookmarks-viz-range.test.ts
@@ -1,0 +1,59 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { buildIndex } from '../src/bookmarks-db.js';
+import { renderViz } from '../src/bookmarks-viz.js';
+
+const FIXTURES = [
+  { 
+    id: '1', tweetId: '1000', url: 'https://x.com/a/status/1', text: 'Oldest tweet', authorHandle: 'a', authorName: 'A',
+    postedAt: 'Wed Sep 30 12:00:00 +0000 2020', // "W" is late alphabetically, but 2020 is early chronologically
+    bookmarkedAt: '2020-09-30T12:00:00.000Z', language: 'en', engagement: { likeCount: 10 }, mediaObjects: [], links: [], tags: [], ingestedVia: 'graphql',
+    syncedAt: '2026-04-10T00:00:00.000Z'
+  },
+  { 
+    id: '2', tweetId: '2000', url: 'https://x.com/c/status/3', text: 'Padding for rising voices', authorHandle: 'c', authorName: 'C',
+    postedAt: 'Fri Mar 01 12:00:00 +0000 2021',
+    bookmarkedAt: '2021-03-01T12:00:00.000Z', language: 'en', engagement: { likeCount: 20 }, mediaObjects: [], links: [], tags: [], ingestedVia: 'graphql',
+    syncedAt: '2026-04-10T00:00:00.000Z'
+  },
+  { 
+    id: '3', tweetId: '3000', url: 'https://x.com/b/status/2', text: 'Newest tweet', authorHandle: 'b', authorName: 'B',
+    postedAt: 'Fri Apr 01 12:00:00 +0000 2026', // "F" is early alphabetically, but 2026 is late chronologically
+    bookmarkedAt: '2026-04-01T12:00:00.000Z', language: 'en', engagement: { likeCount: 20 }, mediaObjects: [], links: [], tags: [], ingestedVia: 'graphql',
+    syncedAt: '2026-04-10T00:00:00.000Z'
+  }
+];
+
+async function withIsolatedDataDir(fn: () => Promise<void>): Promise<void> {
+  const dir = await mkdtemp(path.join(tmpdir(), 'ft-test-viz-range-'));
+  const jsonl = FIXTURES.map((r) => JSON.stringify(r)).join('\n') + '\n';
+  await writeFile(path.join(dir, 'bookmarks.jsonl'), jsonl);
+
+  const saved = process.env.FT_DATA_DIR;
+  process.env.FT_DATA_DIR = dir;
+  try {
+    await fn();
+  } finally {
+    process.env.FT_DATA_DIR = saved;
+  }
+}
+
+test('renderViz: computes chronological date range correctly using tweet_id', async () => {
+  await withIsolatedDataDir(async () => {
+    await buildIndex();
+    const output = await renderViz();
+    
+    // The buggy MIN/MAX string sorting would yield:
+    // MIN: Fri Apr 01... (2026)
+    // MAX: Wed Sep 30... (2020)
+    // The correct output should be Sep 2020 to Apr 2026
+    
+    assert.ok(output.includes('Sep 2020 → Apr 2026'), 'Date range rendered incorrectly, text sorting is likely still active');
+    
+    // Ensure we are NOT seeing the broken 16-character slice (like 'Fri Apr 01 16:02')
+    assert.ok(!output.includes('Fri Apr 01'), 'Date range is still using raw string slices');
+  });
+});


### PR DESCRIPTION
### Description
This PR contains a minor fix for the date range displayed in the `ft viz` dashboard footer, which was previously showing incorrect values due to how SQLite sorts raw Twitter date strings.

Before: 

<img width="1160" height="244" alt="image" src="https://github.com/user-attachments/assets/e28855f3-cdcd-4a8c-8d1a-ccff29ce7be4" />

After:

<img width="1118" height="220" alt="image" src="https://github.com/user-attachments/assets/14fc144b-c5fc-4a9c-b890-082d1376a098" />


### The Problem
The dashboard used `MIN(posted_at)` and `MAX(posted_at)` to calculate the range. Because Twitter legacy dates start with the day of the week (e.g., `Fri Apr 01...` vs `Wed Sep 30...`), SQLite performs an alphabetical sort rather than a chronological one. This resulted in a bogus range (e.g., `Fri Apr 01 → Wed Sep 30`) that ignored the actual years.

### The Fix
1. **Accurate Range Query**: Updated the query in `src/bookmarks-viz.ts` to retrieve the earliest and latest bookmarks by sorting on the mathematically-sequential `tweet_id` (Snowflake ID) instead of the text date strings.
2. **Clean Formatting**: Added a `formatHeaderDate` helper to parse the resulting timestamps and display them cleanly as `MMM YYYY` (e.g., `Mar 2018 → Apr 2026`) instead of raw 16-character string slices.
3. **Visual Polish**: Improved the spacing and icons in the dashboard header for better readability.


### Testing
- **Unit Test**: Added `tests/bookmarks-viz-range.test.ts` to verify that chronological sorting of Snowflake IDs correctly establishes the date range even when the alphabetical order of the timestamp strings is inverted.
