### PR TITLE
[codex] Harden Firefox session sync on Windows

### DIFF
--- a/src/browsers.ts
+++ b/src/browsers.ts
@@ -88,6 +88,7 @@ const BROWSERS: BrowserDef[] = [
     keychainEntries: [],
     macPath: 'Library/Application Support/Firefox',
     linuxPath: '.mozilla/firefox',
+    winPath: 'AppData/Roaming/Mozilla/Firefox',
   },
 ];
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -299,6 +299,7 @@ function showSyncWelcome(): void {
   Browser ids: ${browsers}
   Use --browser <name> to choose.
   Default auto-detect prefers installed Chrome-family browsers.
+  Firefox on Windows requires Node.js 22.5+ or sqlite3 on PATH.
 `);
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -299,7 +299,6 @@ function showSyncWelcome(): void {
   Browser ids: ${browsers}
   Use --browser <name> to choose.
   Default auto-detect prefers installed Chrome-family browsers.
-  Firefox cookie extraction currently works on macOS and Linux.
 `);
 }
 

--- a/src/firefox-cookies.ts
+++ b/src/firefox-cookies.ts
@@ -20,6 +20,47 @@ interface NodeSqliteModule {
 }
 
 let nodeSqliteModule: NodeSqliteModule | null | undefined;
+let sqlite3BinaryAvailable: boolean | undefined;
+
+const FIREFOX_WINDOWS_BACKEND_REQUIREMENT =
+  'Firefox on Windows requires Node.js 22.5+ or sqlite3 on PATH.';
+
+function hasSqlite3Binary(): boolean {
+  if (sqlite3BinaryAvailable !== undefined) return sqlite3BinaryAvailable;
+  try {
+    execFileSync('sqlite3', ['-version'], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      timeout: 5000,
+    });
+    sqlite3BinaryAvailable = true;
+  } catch {
+    sqlite3BinaryAvailable = false;
+  }
+  return sqlite3BinaryAvailable;
+}
+
+export function ensureFirefoxCookieBackendAvailable(
+  os: string = platform(),
+  hasNodeSqlite?: boolean,
+  hasSqlite3?: boolean,
+): void {
+  if (os !== 'win32') return;
+
+  const nodeSqliteAvailable = hasNodeSqlite ?? loadNodeSqlite() !== null;
+  if (nodeSqliteAvailable) return;
+
+  const sqlite3Available = hasSqlite3 ?? hasSqlite3Binary();
+  if (sqlite3Available) return;
+
+  throw new Error(
+    `${FIREFOX_WINDOWS_BACKEND_REQUIREMENT}\n` +
+    'Fix:\n' +
+    '  1. Upgrade to Node.js 22.5+ (recommended), or\n' +
+    '  2. Install sqlite3 and make sure it is on PATH, or\n' +
+    '  3. Pass cookies manually:  ft sync --cookies <ct0> <auth_token>'
+  );
+}
 
 // ── Profile detection ────────────────────────────────────────────────────────
 
@@ -202,6 +243,7 @@ function queryFirefoxCookies(
 export function extractFirefoxXCookies(profileDir?: string): ChromeCookieResult {
   const dir = profileDir ?? detectFirefoxProfileDir();
   const dbPath = join(dir, 'cookies.sqlite');
+  ensureFirefoxCookieBackendAvailable();
 
   let cookies = queryFirefoxCookies(dbPath, '.x.com', ['ct0', 'auth_token']);
   if (cookies.length === 0) {

--- a/src/firefox-cookies.ts
+++ b/src/firefox-cookies.ts
@@ -1,19 +1,33 @@
 import { execFileSync } from 'node:child_process';
-import { existsSync, readFileSync, unlinkSync, copyFileSync } from 'node:fs';
-import { join } from 'node:path';
-import { tmpdir, homedir, platform } from 'node:os';
-import { randomUUID } from 'node:crypto';
+import { existsSync, readFileSync, copyFileSync, mkdtempSync, rmSync } from 'node:fs';
+import { basename, join } from 'node:path';
+import { tmpdir, platform } from 'node:os';
+import { createRequire } from 'node:module';
 import type { ChromeCookieResult } from './chrome-cookies.js';
+import { getBrowser, browserUserDataDir } from './browsers.js';
+
+const require = createRequire(import.meta.url);
+
+interface SqliteRow {
+  [key: string]: unknown;
+}
+
+interface NodeSqliteModule {
+  DatabaseSync: new (path: string, options?: { readOnly?: boolean }) => {
+    prepare(sql: string): { all(...params: unknown[]): SqliteRow[] };
+    close(): void;
+  };
+}
+
+let nodeSqliteModule: NodeSqliteModule | null | undefined;
 
 // ── Profile detection ────────────────────────────────────────────────────────
 
 function firefoxBaseDir(): string {
-  const os = platform();
-  const home = homedir();
-  if (os === 'darwin') return join(home, 'Library', 'Application Support', 'Firefox');
-  if (os === 'linux') return join(home, '.mozilla', 'firefox');
+  const dir = browserUserDataDir(getBrowser('firefox'));
+  if (dir) return dir;
   throw new Error(
-    `Firefox cookie extraction is currently supported on macOS and Linux only (detected: ${os}).\n` +
+    `Firefox cookie extraction is not supported on this platform (detected: ${platform()}).\n` +
     'Pass cookies manually:  ft sync --cookies <ct0> <auth_token>'
   );
 }
@@ -71,6 +85,58 @@ export function detectFirefoxProfileDir(): string {
 
 // ── Cookie query ─────────────────────────────────────────────────────────────
 
+function loadNodeSqlite(): NodeSqliteModule | null {
+  if (nodeSqliteModule !== undefined) return nodeSqliteModule;
+  try {
+    nodeSqliteModule = require('node:sqlite') as NodeSqliteModule;
+  } catch {
+    nodeSqliteModule = null;
+  }
+  return nodeSqliteModule;
+}
+
+function createFirefoxSnapshot(dbPath: string): { snapshotPath: string; cleanup: () => void } {
+  const snapshotDir = mkdtempSync(join(tmpdir(), 'ft-ff-cookies-'));
+  const snapshotPath = join(snapshotDir, basename(dbPath));
+  try {
+    copyFileSync(dbPath, snapshotPath);
+    const walPath = dbPath + '-wal';
+    const shmPath = dbPath + '-shm';
+    if (existsSync(walPath)) copyFileSync(walPath, snapshotPath + '-wal');
+    if (existsSync(shmPath)) copyFileSync(shmPath, snapshotPath + '-shm');
+    return {
+      snapshotPath,
+      cleanup: () => rmSync(snapshotDir, { recursive: true, force: true }),
+    };
+  } catch (e) {
+    rmSync(snapshotDir, { recursive: true, force: true });
+    throw e;
+  }
+}
+
+function queryWithNodeSqlite(
+  snapshotPath: string,
+  host: string,
+  names: string[],
+): { name: string; value: string }[] | null {
+  const sqlite = loadNodeSqlite();
+  if (!sqlite) return null;
+
+  const db = new sqlite.DatabaseSync(snapshotPath, { readOnly: true });
+  try {
+    const placeholders = names.map(() => '?').join(', ');
+    const stmt = db.prepare(
+      `SELECT name, value FROM moz_cookies WHERE host LIKE ? AND name IN (${placeholders});`
+    );
+    return stmt.all(`%${host}`, ...names).map((row) => ({
+      name: String(row.name ?? ''),
+      value: String(row.value ?? ''),
+    }));
+  } finally {
+    db.close();
+  }
+}
+
 function queryFirefoxCookies(
   dbPath: string,
   host: string,
@@ -83,51 +149,51 @@ function queryFirefoxCookies(
     );
   }
 
-  // Build parameterized-safe SQL. host and names are hardcoded by callers,
-  // but we escape anyway to prevent injection if the API is ever widened.
   const safeHost = host.replace(/'/g, "''");
   const nameList = names.map(n => `'${n.replace(/'/g, "''")}'`).join(',');
   const sql = `SELECT name, value FROM moz_cookies WHERE host LIKE '%${safeHost}' AND name IN (${nameList});`;
-
-  const tryQuery = (path: string): string =>
+  const tryQueryWithBinary = (path: string): string =>
     execFileSync('sqlite3', ['-json', path, sql], {
       encoding: 'utf8',
       stdio: ['pipe', 'pipe', 'pipe'],
       timeout: 10000,
     }).trim();
 
-  let output: string;
-  try {
-    output = tryQuery(dbPath);
-  } catch {
-    // Firefox may hold a WAL lock — copy the DB and query the copy
-    const tmpDb = join(tmpdir(), `ft-ff-cookies-${randomUUID()}.db`);
-    try {
-      copyFileSync(dbPath, tmpDb);
-      const walPath = dbPath + '-wal';
-      const shmPath = dbPath + '-shm';
-      if (existsSync(walPath)) copyFileSync(walPath, tmpDb + '-wal');
-      if (existsSync(shmPath)) copyFileSync(shmPath, tmpDb + '-shm');
-      output = tryQuery(tmpDb);
-    } catch (e2: any) {
-      throw new Error(
-        `Could not read Firefox cookies database.\n` +
-        `Path: ${dbPath}\n` +
-        `Error: ${e2.message}\n` +
-        'If Firefox is open, try closing it and retrying.'
-      );
-    } finally {
-      try { unlinkSync(tmpDb); } catch {}
-      try { unlinkSync(tmpDb + '-wal'); } catch {}
-      try { unlinkSync(tmpDb + '-shm'); } catch {}
-    }
-  }
+  const buildReadError = (error: unknown): Error => {
+    const message = error instanceof Error ? error.message : String(error);
+    const needsNativeSqliteHint =
+      platform() === 'win32' &&
+      !loadNodeSqlite() &&
+      /sqlite3|ENOENT/i.test(message);
+    return new Error(
+      `Could not read Firefox cookies database.\n` +
+      `Path: ${dbPath}\n` +
+      `Error: ${message}\n` +
+      (needsNativeSqliteHint
+        ? 'Fix: Use Node.js 22.5+ on Windows, or install sqlite3 on PATH.\n'
+        : '') +
+      'If Firefox is open, try closing it and retrying.'
+    );
+  };
 
-  if (!output || output === '[]') return [];
   try {
-    return JSON.parse(output);
-  } catch {
-    return [];
+    const { snapshotPath, cleanup } = createFirefoxSnapshot(dbPath);
+    try {
+      const nativeRows = queryWithNodeSqlite(snapshotPath, host, names);
+      if (nativeRows) return nativeRows;
+
+      const output = tryQueryWithBinary(snapshotPath);
+      if (!output || output === '[]') return [];
+      try {
+        return JSON.parse(output);
+      } catch {
+        return [];
+      }
+    } finally {
+      cleanup();
+    }
+  } catch (error) {
+    throw buildReadError(error);
   }
 }
 

--- a/tests/browsers.test.ts
+++ b/tests/browsers.test.ts
@@ -38,6 +38,14 @@ test('getBrowser: firefox has firefox cookieBackend', () => {
   assert.equal(browser.keychainEntries.length, 0);
 });
 
+test('getBrowser: firefox has user-data paths for every supported OS', () => {
+  const browser = getBrowser('firefox');
+  assert.ok(browser.macPath, 'Firefox macPath must be set');
+  assert.ok(browser.linuxPath, 'Firefox linuxPath must be set');
+  assert.ok(browser.winPath, 'Firefox winPath must be set');
+  assert.match(browser.winPath!, /AppData[\\/]Roaming[\\/]Mozilla[\\/]Firefox/);
+});
+
 test('getBrowser: brave has correct keychain entries', () => {
   const browser = getBrowser('brave');
   const services = browser.keychainEntries.map(e => e.service);

--- a/tests/firefox-cookies.test.ts
+++ b/tests/firefox-cookies.test.ts
@@ -4,7 +4,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { createDb, saveDb } from '../src/db.js';
-import { extractFirefoxXCookies } from '../src/firefox-cookies.js';
+import { extractFirefoxXCookies, ensureFirefoxCookieBackendAvailable } from '../src/firefox-cookies.js';
 
 async function createFirefoxProfile(cookies: Array<{ host: string; name: string; value: string }>): Promise<string> {
   const profileDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ft-firefox-profile-'));
@@ -74,4 +74,17 @@ test('extractFirefoxXCookies falls back to twitter.com cookies when x.com is abs
   } finally {
     fs.rmSync(profileDir, { recursive: true, force: true });
   }
+});
+
+test('ensureFirefoxCookieBackendAvailable: rejects unsupported Windows runtime clearly', () => {
+  assert.throws(
+    () => ensureFirefoxCookieBackendAvailable('win32', false, false),
+    /Firefox on Windows requires Node\.js 22\.5\+ or sqlite3 on PATH/,
+  );
+});
+
+test('ensureFirefoxCookieBackendAvailable: allows Windows when a supported backend exists', () => {
+  assert.doesNotThrow(() => ensureFirefoxCookieBackendAvailable('win32', true, false));
+  assert.doesNotThrow(() => ensureFirefoxCookieBackendAvailable('win32', false, true));
+  assert.doesNotThrow(() => ensureFirefoxCookieBackendAvailable('linux', false, false));
 });

--- a/tests/firefox-cookies.test.ts
+++ b/tests/firefox-cookies.test.ts
@@ -1,0 +1,77 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { createDb, saveDb } from '../src/db.js';
+import { extractFirefoxXCookies } from '../src/firefox-cookies.js';
+
+async function createFirefoxProfile(cookies: Array<{ host: string; name: string; value: string }>): Promise<string> {
+  const profileDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ft-firefox-profile-'));
+  const dbPath = path.join(profileDir, 'cookies.sqlite');
+  const db = await createDb();
+
+  db.run(`
+    CREATE TABLE moz_cookies (
+      id INTEGER PRIMARY KEY,
+      host TEXT,
+      name TEXT,
+      value TEXT,
+      path TEXT,
+      expiry INTEGER,
+      isSecure INTEGER,
+      isHttpOnly INTEGER,
+      inBrowserElement INTEGER,
+      sameSite INTEGER,
+      rawSameSite INTEGER,
+      schemeMap INTEGER,
+      lastAccessed INTEGER,
+      creationTime INTEGER
+    );
+  `);
+
+  for (const [index, cookie] of cookies.entries()) {
+    db.run(
+      `INSERT INTO moz_cookies
+        (id, host, name, value, path, expiry, isSecure, isHttpOnly, inBrowserElement, sameSite, rawSameSite, schemeMap, lastAccessed, creationTime)
+       VALUES (?, ?, ?, ?, '/', 0, 0, 0, 0, 0, 0, 0, ?, ?);`,
+      [index + 1, cookie.host, cookie.name, cookie.value, Date.now() + index, Date.now() + index],
+    );
+  }
+
+  saveDb(db, dbPath);
+  db.close();
+  return profileDir;
+}
+
+test('extractFirefoxXCookies reads x.com cookies from a provided profile dir', async () => {
+  const profileDir = await createFirefoxProfile([
+    { host: '.x.com', name: 'ct0', value: 'csrf-token' },
+    { host: '.x.com', name: 'auth_token', value: 'auth-token' },
+  ]);
+
+  try {
+    const cookies = extractFirefoxXCookies(profileDir);
+    assert.equal(cookies.csrfToken, 'csrf-token');
+    assert.match(cookies.cookieHeader, /ct0=csrf-token/);
+    assert.match(cookies.cookieHeader, /auth_token=auth-token/);
+  } finally {
+    fs.rmSync(profileDir, { recursive: true, force: true });
+  }
+});
+
+test('extractFirefoxXCookies falls back to twitter.com cookies when x.com is absent', async () => {
+  const profileDir = await createFirefoxProfile([
+    { host: '.twitter.com', name: 'ct0', value: 'legacy-csrf-token' },
+    { host: '.twitter.com', name: 'auth_token', value: 'legacy-auth-token' },
+  ]);
+
+  try {
+    const cookies = extractFirefoxXCookies(profileDir);
+    assert.equal(cookies.csrfToken, 'legacy-csrf-token');
+    assert.match(cookies.cookieHeader, /ct0=legacy-csrf-token/);
+    assert.match(cookies.cookieHeader, /auth_token=legacy-auth-token/);
+  } finally {
+    fs.rmSync(profileDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## What changed

- add Firefox `winPath` to the browser registry
- route Firefox base-dir resolution through the shared browser registry instead of hardcoded OS branches
- read Firefox cookies from a private copied snapshot so `cookies.sqlite` plus `-wal` and `-shm` stay consistent and cleanup is one temp directory
- prefer built-in `node:sqlite` for file-backed snapshot reads when available, with fallback to the existing `sqlite3` CLI path when it is not
- add regression coverage for Firefox Windows config plus `.x.com` and `.twitter.com` cookie extraction

## Why

`main` still has two real Firefox problems:

- Firefox has no Windows profile path in the browser registry
- Firefox cookie extraction still depends on an external `sqlite3` binary

PRs #64 and #61 both correctly identified that Windows Firefox gap. The main rewrite here is that this version keeps a file-backed SQLite snapshot instead of switching the Firefox path to `sql.js`, because `sql.js` imports a single database file into memory and does not consume a live profile's WAL sidecars.

## Impact

- Firefox is now discoverable on Windows through the browser registry
- temp snapshot handling is tighter and cleans up as a single private temp directory
- runtimes with `node:sqlite` available no longer need `sqlite3` on `PATH` for Firefox cookie reads
- older runtimes still fall back to the existing `sqlite3` CLI path instead of regressing the live-profile behavior

## Root cause

- Firefox lacked a Windows user-data path in the registry
- Firefox cookie extraction depended on an external `sqlite3` binary, and the obvious `sql.js` rewrite does not preserve WAL-backed live profile reads

## Commit summary

- `fix: harden Firefox session sync on Windows`

## Validation

- `./node_modules/.bin/tsc -p tsconfig.json`
- `node --import ./node_modules/tsx/dist/loader.mjs --test tests/**/*.test.ts`

## Credit

Thanks @JSRRosenbaum for PR #64 and @Bortlesboat for PR #61. Both independently identified the Firefox Windows sync gap and helped shape this rewrite.