### PR TITLE
Add CLI-first X Home timeline feed viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Field Theory CLI
 
-Sync and store locally all of your X/Twitter bookmarks. Search, classify, and make them available to Claude Code, Codex, or any agent with shell access.
+Sync and store locally your X/Twitter bookmarks and likes. Search them, classify bookmarks, and make them available to Claude Code, Codex, or any agent with shell access.
 
 Free and open source. Designed for Mac.
 
@@ -10,7 +10,7 @@ Free and open source. Designed for Mac.
 npm install -g fieldtheory
 ```
 
-Requires Node.js 20+. Chrome recommended for session sync; OAuth available for all platforms.
+Requires Node.js 20+. Chrome recommended for session sync; OAuth available for bookmark sync on all platforms.
 
 ## Quick start
 
@@ -18,16 +18,24 @@ Requires Node.js 20+. Chrome recommended for session sync; OAuth available for a
 # 1. Sync your bookmarks (needs Chrome logged into X)
 ft sync
 
-# 2. Search them
-ft search "distributed systems"
+# 2. Sync your likes into a separate local archive
+ft likes sync
 
-# 3. Explore
+# 3. Search them
+ft search "distributed systems"
+ft likes search "distributed systems"
+
+# 4. Trim old likes in throttled batches
+ft likes trim --keep 200 --batch-size 25 --pause-seconds 45
+
+# 5. Explore bookmarks
 ft viz
+ft web
 ft categories
 ft stats
 ```
 
-On first run, `ft sync` extracts your X session from Chrome and downloads your bookmarks into `~/.ft-bookmarks/`.
+On first run, `ft sync` and `ft likes sync` reuse your browser session from Chrome/Firefox and download data into `~/.ft-bookmarks/`.
 
 ## Commands
 
@@ -36,11 +44,12 @@ On first run, `ft sync` extracts your X session from Chrome and downloads your b
 | Command | Description |
 |---------|-------------|
 | `ft sync` | Download and sync bookmarks (no API required) |
-| `ft sync --full` | Full history crawl (not just incremental) |
+| `ft sync --rebuild` | Full history re-crawl of bookmarks |
 | `ft sync --gaps` | Backfill missing quoted tweets and expand truncated articles |
 | `ft sync --classify` | Sync then classify new bookmarks with LLM |
 | `ft sync --api` | Sync via OAuth API (cross-platform) |
 | `ft auth` | Set up OAuth for API-based sync (optional) |
+| `ft likes sync` | Download and sync liked posts into a separate local archive |
 
 ### Search and browse
 
@@ -49,6 +58,14 @@ On first run, `ft sync` extracts your X session from Chrome and downloads your b
 | `ft search <query>` | Full-text search with BM25 ranking |
 | `ft list` | Filter by author, date, category, domain |
 | `ft show <id>` | Show one bookmark in detail |
+| `ft unbookmark <id>` | Remove a bookmark on X and update the local bookmark archive |
+| `ft likes search <query>` | Full-text search across liked posts |
+| `ft likes list` | Filter liked posts by query, author, and like date |
+| `ft likes show <id>` | Show one liked post in detail |
+| `ft likes unlike <id>` | Unlike a post on X and update the local likes archive |
+| `ft likes trim` | Keep only the latest likes and unlike older posts on X in throttled batches |
+| `ft likes status` | Show likes archive status |
+| `ft web` | Launch a local web UI for bookmarks and likes |
 | `ft sample <category>` | Random sample from a category |
 | `ft stats` | Top authors, languages, date range |
 | `ft viz` | Terminal dashboard with sparklines, categories, and domains |
@@ -88,6 +105,7 @@ On first run, `ft sync` extracts your X session from Chrome and downloads your b
 | Command | Description |
 |---------|-------------|
 | `ft index` | Rebuild search index from JSONL cache (preserves classifications) |
+| `ft likes index` | Rebuild the likes search index from the likes cache |
 | `ft fetch-media` | Download media assets (static images only) |
 | `ft status` | Show sync status and data location |
 | `ft path` | Print data directory path |
@@ -129,6 +147,11 @@ All data is stored locally at `~/.ft-bookmarks/`:
   bookmarks.jsonl         # raw bookmark cache (one per line)
   bookmarks.db            # SQLite FTS5 search index
   bookmarks-meta.json     # sync metadata
+  bookmarks-backfill-state.json
+  likes.jsonl             # raw likes archive cache (one per line)
+  likes.db                # SQLite FTS5 search index for likes
+  likes-meta.json         # likes sync metadata
+  likes-backfill-state.json
   oauth-token.json        # OAuth token (if using API mode, chmod 600)
   md/                     # markdown knowledge base (ft wiki / ft md)
 ```
@@ -140,6 +163,43 @@ export FT_DATA_DIR=/path/to/custom/dir
 ```
 
 To remove all data: `rm -rf ~/.ft-bookmarks`
+
+Likes are intentionally a separate archive in v1. They support sync, search, list, show, status, and reindex. Classification, viz, stats, and media download remain bookmark-only features for now.
+
+Single-item remote cleanup is also supported:
+
+```bash
+ft unbookmark <tweet-id>
+ft likes unlike <tweet-id>
+```
+
+Both commands reuse your browser-authenticated X web session, then reconcile the matching local archive entry and index.
+
+For bulk likes cleanup, use the formal trim command:
+
+```bash
+ft likes trim --keep 200 --batch-size 25 --pause-seconds 45
+```
+
+The command recomputes the trim set from your current local archive on each run, so it is safe to resume after an interruption. It unlikes older posts on X in batches, rewrites `likes.jsonl`, updates `likes-meta.json`, and rebuilds `likes.db` once per batch.
+
+## Web UI
+
+Build and launch the local web UI:
+
+```bash
+npm run build
+node dist/cli.js web
+```
+
+Or during development:
+
+```bash
+npm run build
+tsx src/cli.ts web
+```
+
+The web UI is local-only by default and binds to `127.0.0.1`. It serves the built frontend assets, so run `npm run build` at least once before starting `ft web`.
 
 ## Categories
 
@@ -159,9 +219,10 @@ Use `ft classify` for LLM-powered classification that catches what regex misses.
 
 | Feature | macOS | Linux | Windows |
 |---------|-------|-------|---------|
-| Session sync (`ft sync`) | Chrome, Brave, Arc, Firefox | Firefox | Firefox |
+| Session sync (`ft sync`, `ft likes sync`) | Chrome, Brave, Arc, Firefox | Firefox | Firefox |
 | OAuth API sync (`ft sync --api`) | Yes | Yes | Yes |
-| Search, list, classify, viz, wiki | Yes | Yes | Yes |
+| Search, list, likes archive | Yes | Yes | Yes |
+| Bookmark classify, viz, wiki | Yes | Yes | Yes |
 
 Session sync extracts cookies from your browser's local database. Use `ft sync --browser <name>` to pick a browser. On platforms where session sync isn't available, use `ft auth` + `ft sync --api`.
 
@@ -173,7 +234,11 @@ Session sync extracts cookies from your browser's local database. Use `ft sync -
 
 **OAuth tokens** are stored with `chmod 600` (owner-only). Treat `~/.ft-bookmarks/oauth-token.json` like a password.
 
-**The default sync uses X's internal GraphQL API**, the same API that x.com uses in your browser. For the official v2 API, use `ft auth` + `ft sync --api`.
+**The default bookmark sync uses X's internal GraphQL API**, the same API that x.com uses in your browser. For the official v2 API, use `ft auth` + `ft sync --api`.
+
+**The likes archive sync also uses your browser-authenticated X web session.** In v1 it is browser-session based only; there is no OAuth likes sync path yet.
+
+**Remote unlike, unbookmark, and likes trim use the same browser-authenticated X web session path.** On success, the CLI also reconciles the matching local cached records and rebuilds the relevant search index.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,14 @@ Free and open source. Designed for Mac.
 ## Install
 
 ```bash
-npm install -g fieldtheory
+# Install this fork directly from GitHub
+npm install -g github:Decolo/fieldtheory-cli
+```
+
+If you later publish this fork to npm, use:
+
+```bash
+npm install -g fieldtheory-cli
 ```
 
 Requires Node.js 20+. Chrome recommended for session sync; OAuth available for bookmark sync on all platforms.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Field Theory CLI
 
-Sync and store locally your X/Twitter bookmarks and likes. Search them, classify bookmarks, and make them available to Claude Code, Codex, or any agent with shell access.
+Sync and store locally your X/Twitter bookmarks, likes, and Home timeline feed items. Search them, classify bookmarks, and make them available to Claude Code, Codex, or any agent with shell access.
 
 Free and open source. Designed for Mac.
 
@@ -28,21 +28,24 @@ ft sync
 # 2. Sync your likes into a separate local archive
 ft likes sync
 
-# 3. Search them
+# 3. Fetch your Home timeline into a local read-only feed archive
+ft feed sync --max-pages 2
+
+# 4. Search them
 ft search "distributed systems"
 ft likes search "distributed systems"
 
-# 4. Trim old likes in throttled batches
+# 5. Trim old likes in throttled batches
 ft likes trim --keep 200 --batch-size 25 --pause-seconds 45
 
-# 5. Explore bookmarks
+# 6. Explore bookmarks
 ft viz
 ft web
 ft categories
 ft stats
 ```
 
-On first run, `ft sync` and `ft likes sync` reuse your browser session from Chrome/Firefox and download data into `~/.ft-bookmarks/`.
+On first run, `ft sync`, `ft likes sync`, and `ft feed sync` reuse your browser session from Chrome/Firefox and download data into `~/.ft-bookmarks/`.
 
 ## Commands
 
@@ -57,6 +60,7 @@ On first run, `ft sync` and `ft likes sync` reuse your browser session from Chro
 | `ft sync --api` | Sync via OAuth API (cross-platform) |
 | `ft auth` | Set up OAuth for API-based sync (optional) |
 | `ft likes sync` | Download and sync liked posts into a separate local archive |
+| `ft feed sync` | Fetch Home timeline tweets into a local read-only feed archive |
 
 ### Search and browse
 
@@ -72,6 +76,9 @@ On first run, `ft sync` and `ft likes sync` reuse your browser session from Chro
 | `ft likes unlike <id>` | Unlike a post on X and update the local likes archive |
 | `ft likes trim` | Keep only the latest likes and unlike older posts on X in throttled batches |
 | `ft likes status` | Show likes archive status |
+| `ft feed list` | Browse cached Home timeline tweets with local paging |
+| `ft feed show <id>` | Show one cached feed item in detail |
+| `ft feed status` | Show feed archive status |
 | `ft web` | Launch a local web UI for bookmarks and likes |
 | `ft sample <category>` | Random sample from a category |
 | `ft stats` | Top authors, languages, date range |
@@ -159,6 +166,10 @@ All data is stored locally at `~/.ft-bookmarks/`:
   likes.db                # SQLite FTS5 search index for likes
   likes-meta.json         # likes sync metadata
   likes-backfill-state.json
+  feed.jsonl              # raw Home timeline cache (tweet-only entries)
+  feed.db                 # SQLite index for local feed browsing
+  feed-meta.json          # feed sync metadata
+  feed-state.json
   oauth-token.json        # OAuth token (if using API mode, chmod 600)
   md/                     # markdown knowledge base (ft wiki / ft md)
 ```
@@ -171,7 +182,7 @@ export FT_DATA_DIR=/path/to/custom/dir
 
 To remove all data: `rm -rf ~/.ft-bookmarks`
 
-Likes are intentionally a separate archive in v1. They support sync, search, list, show, status, and reindex. Classification, viz, stats, and media download remain bookmark-only features for now.
+Likes are intentionally a separate archive in v1. Feed items are also a separate archive family in v1. The feed surface is CLI-first, read-only, tweet-only, and focused on sync, local paging, list, show, and status. Classification, viz, stats, search, web viewing, and feed-driven actions remain later work.
 
 Single-item remote cleanup is also supported:
 
@@ -244,6 +255,8 @@ Session sync extracts cookies from your browser's local database. Use `ft sync -
 **The default bookmark sync uses X's internal GraphQL API**, the same API that x.com uses in your browser. For the official v2 API, use `ft auth` + `ft sync --api`.
 
 **The likes archive sync also uses your browser-authenticated X web session.** In v1 it is browser-session based only; there is no OAuth likes sync path yet.
+
+**The feed archive sync uses the same browser-authenticated X web session path.** In v1 it is read-only, CLI-first, and stores tweet-only Home timeline entries for local browsing.
 
 **Remote unlike, unbookmark, and likes trim use the same browser-authenticated X web session path.** On success, the CLI also reconciles the matching local cached records and rebuilds the relevant search index.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,8 @@
+# Docs
+
+## Table of Contents
+
+- [Plans](plans/)
+- [Local web archive viewer plan](plans/2026-04-08-001-feat-local-web-archive-plan.md)
+- [Remote unlike and unbookmark plan](plans/2026-04-08-002-feat-remote-unlike-unbookmark-plan.md)
+- [Throttled bulk likes trim plan](plans/2026-04-09-003-feat-likes-trim-command-plan.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,10 @@
 
 ## Table of Contents
 
+- [Brainstorms](brainstorms/)
+- [X feed requirements](brainstorms/2026-04-12-x-feed-requirements.md)
 - [Plans](plans/)
 - [Local web archive viewer plan](plans/2026-04-08-001-feat-local-web-archive-plan.md)
 - [Remote unlike and unbookmark plan](plans/2026-04-08-002-feat-remote-unlike-unbookmark-plan.md)
 - [Throttled bulk likes trim plan](plans/2026-04-09-003-feat-likes-trim-command-plan.md)
+- [CLI-first X home timeline viewer plan](plans/2026-04-12-004-feat-x-feed-cli-viewer-plan.md)

--- a/docs/brainstorms/2026-04-12-x-feed-requirements.md
+++ b/docs/brainstorms/2026-04-12-x-feed-requirements.md
@@ -1,0 +1,83 @@
+---
+date: 2026-04-12
+topic: x-feed
+---
+
+# X Feed
+
+## Problem Frame
+The current CLI already syncs X bookmarks and likes into a local archive, supports remote unlike and unbookmark actions, and exposes a local web viewer. The next opportunity is to extend the same session-backed GraphQL approach to the Home timeline so the tool can help the user inspect feed content, archive it locally, and later rank or act on it using the user's historical likes and bookmarks.
+
+The user wants to start with a minimal feed viewer first, while preserving a path toward feed archiving, feed triage, smart digest generation, and recommendation-driven like/bookmark actions.
+
+For phase 1, the immediate user job is to inspect the Home timeline from the terminal without needing to stay inside x.com, and to make the feed accessible to later local workflows. The minimum visible benefit over the native X timeline is a CLI-native, scriptable, read-only view that can later connect to local search, digest, and action workflows.
+
+## Requirements
+
+**Phase 1: Feed Viewer**
+- R1. The product must support a read-only Home timeline workflow as the first phase.
+- R2. The first phase must preserve the current design principle of reusing the local logged-in X browser session and the existing GraphQL-based fetch pattern.
+- R3. The first phase must focus on viewing feed items rather than immediately becoming a full X client replacement.
+- R4. The phase-1 feed viewer must be CLI-first as the canonical surface.
+- R5. Any web-based feed viewing is deferred until after the CLI-first phase is proven useful.
+- R6. Phase 1 only needs to support tweet entries from the Home timeline.
+- R7. Non-tweet entries such as promoted units, modules, and other unsupported timeline containers may be skipped in phase 1 rather than rendered.
+- R8. Phase 1 should fetch Home timeline tweets and cache the fetched batch locally rather than treating the viewer as stdout-only.
+- R9. Phase 1 should support paged browsing across fetched Home timeline results rather than limiting the user to a single fetched batch.
+
+**Future Expansion**
+- R10. The design must preserve stable item identity so later feed archive, triage, and digest features can refer to the same feed items without rethinking identifiers.
+- R11. The design must preserve a separation between feed fetching, local storage, and remote actions so later automation does not force a redesign of the fetch path.
+- R12. The design must allow a later feed archive capability that stores fetched Home timeline items locally for search, recall, and web viewing.
+- R13. The design must allow a later feed triage capability where feed items become a queue for defer, ignore, or action decisions.
+- R14. The design must allow a later smart digest capability that ranks, summarizes, and filters feed items instead of simply replaying raw timeline order.
+
+**Recommendation and Action Loop**
+- R15. Future feed features must be able to use the user's historical likes and bookmarks as signals for ranking or recommendation.
+- R16. The future product direction should support recommendation-driven decisions about whether a feed item is worth liking or bookmarking.
+- R17. Recommendations may suggest actions, but execution should remain user-confirmed unless a later requirements document explicitly changes that rule.
+- R18. The product direction should preserve a path from recommendation to execution, including later support for applying like and bookmark actions to feed items.
+
+## Success Criteria
+- A user can view their Home timeline from the terminal in a way that is meaningfully useful even before archive and digest features exist.
+- A user can fetch and continue browsing multiple pages of Home timeline tweets from the CLI without opening the web app.
+- A planner can design a phase-1 feed viewer without inventing the overall product direction.
+- The future feed archive, triage, digest, and recommendation concepts are recorded so they are not lost between sessions.
+- The remaining open questions are explicit enough that the next brainstorm step can narrow phase-1 scope cleanly.
+
+## Scope Boundaries
+- Phase 1 is not a full-featured X client.
+- Phase 1 does not need to include autonomous like or bookmark execution.
+- Phase 1 does not need to render promoted or non-tweet timeline modules.
+- Phase 1 local caching does not yet make the feature a full feed archive product with search, retention policy, or web browsing requirements.
+- This brainstorm does not yet define implementation details such as GraphQL operation names, storage schemas, endpoint shapes, or UI structure.
+
+## Key Decisions
+- Start with viewer first: The user wants the first increment to be a read-only Home timeline capability.
+- CLI first: phase 1 should ship as a terminal-first experience, with web deferred.
+- Preserve the broader roadmap: Feed archive, feed triage, smart digest, and recommendation-driven actions remain in scope as follow-on directions and should influence the design.
+- Use historical signals later: Likes and bookmarks should become core ranking signals for future recommendation and assistive action flows.
+- Keep humans in the loop: future feed-driven like and bookmark actions should remain user-confirmed unless a later document explicitly expands to automation.
+
+## Dependencies / Assumptions
+- Verified assumption: the current codebase already uses browser-session-backed requests to `x.com/i/api/graphql/...` for bookmarks and likes.
+- Verified assumption: the current codebase already has a local web viewer for archived bookmarks and likes.
+- Unverified assumption: X still exposes a Home timeline GraphQL surface that is accessible with the same session model and acceptable request headers.
+
+Pre-planning gate:
+- Validate that Home timeline access still works with the current session model before committing to implementation scope.
+- If Home timeline access is not viable, stop and reframe the feature around another accessible feed-like surface instead of forcing the current concept.
+
+## Outstanding Questions
+
+### Resolve Before Planning
+- None currently.
+
+### Deferred to Planning
+- [Affects R2][Technical] Which Home timeline GraphQL operation and cursor shape should be used for reliable feed fetching?
+- [Affects R12][Technical] If feed archiving follows, should feed items live in a dedicated archive or share infrastructure patterns with likes and bookmarks while keeping separate storage?
+- [Affects R14][Needs research] What ranking and summarization strategy is strong enough for a smart digest without introducing excessive complexity or model cost?
+- [Affects R18][Needs research] What guardrails should exist before recommendation-driven like and bookmark execution becomes user-facing automation?
+
+## Next Steps
+→ `/prompts:ce-plan` for structured implementation planning

--- a/docs/plans/2026-04-08-001-feat-local-web-archive-plan.md
+++ b/docs/plans/2026-04-08-001-feat-local-web-archive-plan.md
@@ -1,0 +1,224 @@
+---
+title: feat: Add local web archive viewer
+type: feat
+status: completed
+date: 2026-04-08
+---
+
+# feat: Add local web archive viewer
+
+## Overview
+
+Add a local-only web UI for browsing and searching bookmarks and likes. The implementation should reuse the existing local archive and SQLite query layer, add a minimal Hono API, and ship a Vite + React frontend that the CLI can serve directly.
+
+## Problem Frame
+
+The repo already supports local sync and CLI exploration for bookmarks and likes, but there is no browser-based interface for scanning, filtering, and opening archived items. The user wants a simple page to visualize both archives without turning this into a hosted product or redesigning storage.
+
+## Requirements Trace
+
+- R1. Users can start a local web app from the CLI and open it in a browser.
+- R2. The web app can browse bookmarks and likes from the existing local archive.
+- R3. The UI supports search plus the main list/detail flow for both archive types.
+- R4. The implementation reuses current local storage and query modules instead of inventing a new backend model.
+- R5. Build, tests, and docs cover the new web surface.
+
+## Scope Boundaries
+
+- Local-only read UI; no auth, accounts, or remote deployment work.
+- No new sync engine, no background jobs, and no write actions.
+- No bookmark/like merge model in v1; bookmarks and likes stay separate tabs.
+- No attempt to replace `ft viz`, markdown export, or classification workflows.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `src/cli.ts` is the single CLI composition point and should remain the place where the new `web` command is registered.
+- `src/bookmarks-db.ts` already exposes list, search, count, stats, and detail reads for bookmarks.
+- `src/likes-db.ts` already exposes list, search, and detail reads for likes.
+- `src/bookmarks-service.ts` and `src/likes-service.ts` already provide status summaries suitable for a lightweight API status endpoint.
+- `src/paths.ts` centralizes archive paths; the web layer should continue reading the same data directory.
+
+### Institutional Learnings
+
+- None found in repo-local `docs/solutions/`; the repo relies on direct module reuse and small surfaces.
+
+### External References
+
+- Not required. The repo already has enough local patterns, and this work stays on standard framework paths.
+
+## Key Technical Decisions
+
+- Use `Hono` plus `@hono/node-server` for the local API and static file host: minimal Node footprint and good fit for local-only serving.
+- Use `Vite + React + TypeScript` for the frontend: fast local iteration and a clean build step that can emit static assets for the CLI to serve.
+- Keep API responses thin and close to existing DB return types: avoids duplicate view models and limits drift.
+- Serve the built frontend from the same local process started by `ft web`: one command, one port, no extra orchestration.
+- Add a small `open` helper for `--open` instead of bundling heavier browser-launch dependencies.
+
+## Open Questions
+
+### Resolved During Planning
+
+- Should this be a separate service process? No. A single local process is simpler and fits the product shape.
+- Should bookmarks and likes be merged into one combined feed? No. Separate tabs preserve the existing storage model and reduce scope.
+- Should the first version support edit or sync controls in the UI? No. Read-only browsing keeps the surface small and safe.
+
+### Deferred to Implementation
+
+- Exact response normalization for empty or missing DB files: finalize once the API helpers are written and tested against temp data dirs.
+- Final UI copy and small visual details: resolve during implementation while keeping the structure stable.
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```text
+ft web
+  -> start local Hono server
+  -> /api/status        -> bookmarks-service + likes-service
+  -> /api/bookmarks     -> bookmarks-db list/count
+  -> /api/bookmarks/:id -> bookmarks-db detail
+  -> /api/likes         -> likes-db list
+  -> /api/likes/:id     -> likes-db detail
+  -> /assets/* + /      -> built Vite React app
+
+React app
+  -> fetch status once
+  -> tab switch: bookmarks | likes
+  -> query form updates list endpoint
+  -> click item loads detail endpoint
+```
+
+## Implementation Units
+
+- [ ] **Unit 1: Add local web backend surface**
+
+**Goal:** Create a small Hono app that exposes read-only archive endpoints and can serve the built frontend.
+
+**Requirements:** R1, R2, R4
+
+**Dependencies:** None
+
+**Files:**
+- Create: `src/web-api.ts`
+- Create: `src/web.ts`
+- Modify: `src/cli.ts`
+- Test: `tests/web-api.test.ts`
+
+**Approach:**
+- Build a `createWebApp()` factory around Hono for testability.
+- Add status, list, and detail endpoints for bookmarks and likes.
+- Parse query parameters into the existing DB filter shapes without changing storage modules.
+- Add a CLI command `ft web` that starts the local server, prints the URL, and optionally opens the browser.
+
+**Execution note:** Start with failing API behavior tests for list/detail/status responses.
+
+**Patterns to follow:**
+- `src/cli.ts`
+- `src/bookmarks-db.ts`
+- `src/likes-db.ts`
+- `src/bookmarks-service.ts`
+- `src/likes-service.ts`
+
+**Test scenarios:**
+- Happy path: `GET /api/status` returns bookmark and like counts plus cache metadata from a temp data dir.
+- Happy path: `GET /api/bookmarks?limit=2` returns list items in existing bookmark timeline shape.
+- Happy path: `GET /api/bookmarks/:id` returns one bookmark record by id.
+- Happy path: `GET /api/likes?query=...` returns filtered likes using the likes index.
+- Edge case: missing bookmark or like id returns `404` JSON error.
+- Edge case: empty archive files still return `200` with empty lists and zero counts where appropriate.
+- Error path: invalid numeric query params fall back safely instead of crashing the server.
+- Integration: Hono handlers exercise the real DB/query modules against temp archive/index files without mocking internal collaborators.
+
+**Verification:**
+- A local request to the app returns valid JSON for bookmarks, likes, and status using real temp fixture data.
+
+- [ ] **Unit 2: Build the frontend archive viewer**
+
+**Goal:** Add a simple React UI with tabs, search/filter controls, result lists, and a detail panel for bookmarks and likes.
+
+**Requirements:** R1, R2, R3
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Create: `index.html`
+- Create: `vite.config.ts`
+- Create: `tsconfig.web.json`
+- Create: `web/src/main.tsx`
+- Create: `web/src/App.tsx`
+- Create: `web/src/styles.css`
+
+**Approach:**
+- Keep the UI as a single small app with two archive modes and shared fetch state.
+- Show counts/status at the top, filters in a compact control bar, list on the left, and detail view on the right.
+- Preserve bookmarks-only fields such as category/domain when present, and keep likes UI simpler.
+
+**Patterns to follow:**
+- Existing repo tone in `README.md` and CLI output: practical, local-first, no SaaS framing.
+
+**Test scenarios:**
+- Test expectation: none -- frontend behavior will be validated through build output and browser-level manual verification in this iteration.
+
+**Verification:**
+- The built frontend loads from the local server, switches tabs, searches, renders lists, and shows detail for both archive types.
+
+- [ ] **Unit 3: Wire build, docs, and command ergonomics**
+
+**Goal:** Make the web app shippable through normal repo commands and document how to use it.
+
+**Requirements:** R1, R5
+
+**Dependencies:** Unit 1, Unit 2
+
+**Files:**
+- Modify: `package.json`
+- Modify: `README.md`
+- Modify: `tasks/todo.md`
+
+**Approach:**
+- Add frontend build dependencies and scripts.
+- Make the default build produce both CLI/server output and static frontend assets.
+- Document the `ft web` command, what it serves, and how it relates to bookmarks and likes.
+
+**Patterns to follow:**
+- Existing command documentation style in `README.md`
+
+**Test scenarios:**
+- Happy path: the repo build completes with both TypeScript backend output and Vite frontend output.
+- Integration: `ft web` can serve the built frontend assets after a normal build.
+
+**Verification:**
+- `npm run build` succeeds and the CLI can start the web app without missing asset errors.
+
+## System-Wide Impact
+
+- **Interaction graph:** new CLI command calls a local server layer, which reads existing status and DB modules and serves a static frontend bundle.
+- **Error propagation:** API handlers should turn missing records into `404` JSON and unexpected server faults into `500` JSON without crashing the process.
+- **State lifecycle risks:** no new persistent state is introduced; the web app only reads existing local files.
+- **API surface parity:** the UI should expose both bookmarks and likes rather than creating a bookmarks-only web surface.
+- **Integration coverage:** API tests must use real archive files and indexes in temp directories.
+- **Unchanged invariants:** sync, index, search, classify, and likes archive storage remain unchanged.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Frontend build setup complicates the existing TypeScript-only repo | Keep frontend isolated in Vite config and leave backend `tsc` compilation intact |
+| API shape drifts from existing local query modules | Reuse DB return types closely and test through the public HTTP interface |
+| Missing built assets break `ft web` | Validate asset existence and document build expectations clearly |
+
+## Documentation / Operational Notes
+
+- Update `README.md` with the new command and local web viewer capability.
+- Keep `docs/README.md` as the entry point for plan artifacts.
+- No deploy or runtime monitoring beyond local manual verification is required.
+
+## Sources & References
+
+- Related code: `src/cli.ts`
+- Related code: `src/bookmarks-db.ts`
+- Related code: `src/likes-db.ts`
+- Related code: `src/bookmarks-service.ts`
+- Related code: `src/likes-service.ts`

--- a/docs/plans/2026-04-08-002-feat-remote-unlike-unbookmark-plan.md
+++ b/docs/plans/2026-04-08-002-feat-remote-unlike-unbookmark-plan.md
@@ -1,0 +1,232 @@
+---
+title: feat: Add remote unlike and unbookmark commands
+type: feat
+status: completed
+date: 2026-04-08
+---
+
+# feat: Add remote unlike and unbookmark commands
+
+## Overview
+
+Add destructive CLI commands that reuse the existing browser-session X integration to remove a like or bookmark on X, then reconcile the local archive so CLI and web views reflect the remote change.
+
+## Problem Frame
+
+The repo already reads the user's X session from Chrome or Firefox and uses X's internal web GraphQL API for bookmark and likes sync. The user now wants the write-side equivalent while preserving the current implementation style instead of introducing OAuth, browser automation, or a separate sync service.
+
+## Requirements Trace
+
+- R1. The CLI can unlike a post on X using the same browser-session auth model already used for sync.
+- R2. The CLI can remove a bookmark on X using the same browser-session auth model already used for sync.
+- R3. Successful destructive actions reconcile local cache and search indexes so removed items no longer appear in normal local browse/search flows.
+- R4. Failures surface actionable CLI errors without leaving local state in a silently inconsistent state.
+- R5. Tests, docs, and command help cover the new write actions.
+
+## Scope Boundaries
+
+- No bulk delete flow in this iteration.
+- No web UI write controls in this iteration.
+- No OAuth write path; this feature stays browser-session based.
+- No archive tombstone/history model unless implementation proves hard deletion is unsafe.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `src/graphql-bookmarks.ts` and `src/graphql-likes.ts` already own X web session extraction, GraphQL headers, retry policy, and archive persistence patterns.
+- `src/chrome-cookies.ts`, `src/firefox-cookies.ts`, and `src/config.ts` centralize browser session reuse and should remain the only cookie extraction path.
+- `src/cli.ts` is the single command registration point and already contains bookmark and likes command groups.
+- `src/bookmarks-db.ts` and `src/likes-db.ts` expose indexing flows that can be reused after cache mutation.
+- `tests/cli-likes.test.ts` shows the current CLI integration test style with temp data dirs and real command execution.
+
+### Institutional Learnings
+
+- None found in repo-local `docs/solutions/`; current repo practice is to extend existing modules directly and keep the public CLI surface small.
+
+### External References
+
+- No stable public documentation exists for X's internal web GraphQL mutations. Exact mutation identifiers and payload shapes are implementation-time discovery work against the live web client.
+
+## Key Technical Decisions
+
+- Add dedicated mutation modules instead of overloading sync modules: keeps read-side sync logic separate from destructive remote writes.
+- Reuse the existing browser-session header construction and retry conventions: minimizes auth drift between sync and write actions.
+- Reconcile local archive only after a confirmed remote success: avoids deleting local records when the remote mutation fails.
+- Remove records from local JSONL cache and rebuild or update the corresponding SQLite index as part of the command flow: keeps search/list/web output aligned with remote state.
+- Default CLI behavior should remain explicit and narrow, with a single tweet id per invocation and clear user-facing confirmation of what changed.
+
+## Open Questions
+
+### Resolved During Planning
+
+- Should this be implemented via browser automation? No. The repo already uses direct authenticated HTTP calls and should stay on that path.
+- Should local data be marked stale instead of updated immediately? No. The user asked to see the result, so the command should reconcile local state immediately after remote success.
+- Should the first version support batch operations? No. Single-item commands keep risk and error handling simpler.
+
+### Deferred to Implementation
+
+- Exact X GraphQL mutation names, query ids, and request bodies for unlike and unbookmark must be captured from the live X web client during implementation.
+- Whether the local index layer should support targeted delete or simply rebuild after removal can be finalized once the affected DB helpers are inspected during implementation.
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```text
+ft likes unlike <tweetId>
+  -> resolve browser session cookies
+  -> POST X internal GraphQL unlike mutation
+  -> on success: remove record from likes.jsonl
+  -> rebuild/update likes.db
+  -> print removed state
+
+ft bookmarks remove <tweetId>
+  -> resolve browser session cookies
+  -> POST X internal GraphQL unbookmark mutation
+  -> on success: remove record from bookmarks.jsonl
+  -> rebuild/update bookmarks.db
+  -> print removed state
+```
+
+## Implementation Units
+
+- [ ] **Unit 1: Add remote write primitives for unlike and unbookmark**
+
+**Goal:** Introduce focused modules that can authenticate with the existing browser session and execute the two X web mutations.
+
+**Requirements:** R1, R2, R4
+
+**Dependencies:** None
+
+**Files:**
+- Create: `src/graphql-actions.ts`
+- Modify: `src/graphql-bookmarks.ts`
+- Modify: `src/graphql-likes.ts`
+- Test: `tests/graphql-actions.test.ts`
+
+**Approach:**
+- Extract or share the existing session/header setup so write commands can authenticate exactly like sync.
+- Add one function for unlike and one for unbookmark with consistent result types and actionable failures.
+- Keep mutation ids and payload builders isolated so future X web changes are localized.
+
+**Execution note:** Start with failing behavior tests for remote success, auth failure, and upstream error mapping.
+
+**Patterns to follow:**
+- `src/graphql-bookmarks.ts`
+- `src/graphql-likes.ts`
+- `tests/graphql-bookmarks.test.ts`
+- `tests/graphql-likes.test.ts`
+
+**Test scenarios:**
+- Happy path: unlike mutation sends the expected authenticated request and returns success metadata for the removed tweet id.
+- Happy path: unbookmark mutation sends the expected authenticated request and returns success metadata for the removed tweet id.
+- Error path: `401` or `403` returns the same re-login guidance style used by sync commands.
+- Error path: non-auth upstream failures include status code and truncated response body without crashing.
+- Integration: shared header/session resolution works for both action functions without duplicating cookie extraction logic.
+
+**Verification:**
+- Action helpers can be invoked from tests with mocked X responses and produce deterministic success/error results.
+
+- [ ] **Unit 2: Reconcile local archives after confirmed remote removal**
+
+**Goal:** Ensure a successful destructive action updates the matching local JSONL cache and index so follow-up reads are consistent.
+
+**Requirements:** R3, R4
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `src/bookmarks-db.ts`
+- Modify: `src/likes-db.ts`
+- Modify: `src/paths.ts`
+- Modify: `src/types.ts`
+- Create: `src/archive-actions.ts`
+- Test: `tests/archive-actions.test.ts`
+
+**Approach:**
+- Add a small archive reconciliation layer that removes a record by tweet id from the correct JSONL file and refreshes the corresponding SQLite index.
+- Keep bookmark and likes handling symmetric where possible, but do not force a merged abstraction if the schemas differ materially.
+- Return enough metadata for the CLI to print what changed locally.
+
+**Patterns to follow:**
+- `src/fs.ts`
+- `src/bookmarks-db.ts`
+- `src/likes-db.ts`
+
+**Test scenarios:**
+- Happy path: removing an existing like deletes it from `likes.jsonl` and it no longer appears in `likes list` / search-backed reads after reindex.
+- Happy path: removing an existing bookmark deletes it from `bookmarks.jsonl` and it no longer appears in bookmark list/detail reads after reindex.
+- Edge case: attempting to reconcile an id absent from local cache returns a clear result without corrupting files.
+- Error path: index rebuild failure surfaces as a command error after remote success and does not silently report completion.
+- Integration: reconciliation operates against real temp JSONL and SQLite files rather than mocked storage.
+
+**Verification:**
+- Temp-data integration tests prove removed records disappear from the public DB query layer after reconciliation.
+
+- [ ] **Unit 3: Expose destructive CLI commands and document them**
+
+**Goal:** Add end-user commands for unlike and unbookmark, wire them to remote mutation plus local reconciliation, and document usage.
+
+**Requirements:** R1, R2, R3, R4, R5
+
+**Dependencies:** Unit 1, Unit 2
+
+**Files:**
+- Modify: `src/cli.ts`
+- Modify: `README.md`
+- Modify: `docs/README.md`
+- Modify: `tasks/todo.md`
+- Test: `tests/cli-actions.test.ts`
+
+**Approach:**
+- Add one command under `likes` for `unlike <id>` and one bookmark-side command for removing a bookmark.
+- Keep output terse and specific: remote success, local removal status, and any follow-up guidance.
+- Reuse existing browser options (`--browser`, `--cookies`, Chrome profile overrides) so destructive actions behave like sync commands.
+
+**Patterns to follow:**
+- `src/cli.ts`
+- `tests/cli-likes.test.ts`
+- `README.md`
+
+**Test scenarios:**
+- Happy path: `ft likes unlike <id>` invokes the remote action, reconciles local likes, and prints a success summary.
+- Happy path: `ft bookmarks remove <id>` invokes the remote action, reconciles local bookmarks, and prints a success summary.
+- Edge case: missing local archive record after remote success still reports remote success and explains the local state outcome.
+- Error path: remote mutation failure prevents local deletion and exits with actionable guidance.
+- Error path: invalid or missing tweet id is rejected by CLI argument validation.
+- Integration: real CLI execution against temp local data updates subsequent `likes list` or `list/show` results.
+
+**Verification:**
+- Targeted CLI tests pass and a live local command run removes a real item from X and the local archive.
+
+## System-Wide Impact
+
+- **Interaction graph:** new CLI commands will bridge browser cookie extraction, X GraphQL mutation calls, local cache mutation, and search index rebuilds.
+- **Error propagation:** remote failures must stop before local mutation; local reconciliation failures must be surfaced explicitly after remote success.
+- **State lifecycle risks:** the dangerous window is remote success followed by local reconcile failure; command output must say so clearly and leave the user able to resync.
+- **API surface parity:** bookmark and likes destructive flows should expose similar browser options and output style.
+- **Integration coverage:** CLI tests need to prove public command behavior and post-action query behavior, not just helper internals.
+- **Unchanged invariants:** sync, search, web viewing, classification, and OAuth bookmark sync remain unchanged outside post-action local data refresh.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| X changes internal mutation ids or payload shape | Isolate mutation metadata and keep failures explicit so future updates are localized |
+| Remote success but local reindex fails | Print a partial-success warning and keep `ft likes sync` / `ft sync` as the recovery path |
+| Destructive commands are too easy to misuse | Keep scope to single-id commands with explicit success output and no batch mode |
+
+## Documentation / Operational Notes
+
+- Update the command table and security notes in `README.md` to mention write actions still use browser-authenticated X web session.
+- Update `docs/README.md` so the new plan is discoverable.
+- No deploy or production monitoring work is required; this is a local CLI feature.
+
+## Sources & References
+
+- Related code: `src/cli.ts`
+- Related code: `src/graphql-bookmarks.ts`
+- Related code: `src/graphql-likes.ts`
+- Related code: `src/chrome-cookies.ts`
+- Related code: `src/firefox-cookies.ts`

--- a/docs/plans/2026-04-09-003-feat-likes-trim-command-plan.md
+++ b/docs/plans/2026-04-09-003-feat-likes-trim-command-plan.md
@@ -1,0 +1,168 @@
+---
+title: feat: Add throttled bulk likes trim command
+type: feat
+status: completed
+date: 2026-04-09
+---
+
+# feat: Add throttled bulk likes trim command
+
+## Overview
+
+Add a formal CLI command to trim the local likes archive down to the most recent N likes while unliking the older posts on X in controlled batches with configurable pauses between batches.
+
+## Problem Frame
+
+The repo now supports single-item `ft likes unlike <id>`, and the user has already started a one-off bulk unlike run using an ad hoc Node script. That approach works but is operationally weak: it rebuilds the local index after every item, has no first-class CLI ergonomics, and gives no built-in batch throttling to reduce the chance of X rate limiting. The user wants the bulk behavior promoted into the product as a formal command, then used to finish the current trim so only the latest 200 likes remain.
+
+## Requirements Trace
+
+- R1. Add a first-class CLI command to keep only the latest `N` likes and unlike the older likes on X.
+- R2. Support batch processing with a configurable pause between batches to reduce rate-limit risk.
+- R3. Keep local archive files and the likes SQLite index aligned with remote state during bulk execution.
+- R4. Make the command resumable by recomputing the trim set from the current archive state on each run.
+- R5. Provide clear CLI output describing totals, per-batch progress, and final state.
+- R6. Update tests and docs for the new command.
+
+## Scope Boundaries
+
+- No bulk bookmark trim in this iteration.
+- No web UI write controls in this iteration.
+- No background queue or daemonized retry worker.
+- No tombstone/history model for removed likes.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `src/cli.ts` already contains the likes command group and the single-item destructive command style.
+- `src/graphql-actions.ts` contains the remote `unlikeTweet()` mutation primitive.
+- `src/archive-actions.ts` currently removes one cached like and rebuilds the index immediately.
+- `src/likes-db.ts` already owns the canonical likes index rebuild path.
+- `tests/cli-actions.test.ts` is the right high-level CLI behavior test entry point for destructive actions.
+
+### Current Runtime State
+
+- A previous ad hoc bulk unlike process was still running at planning time and must be stopped before formal execution.
+- Current local likes count is `563`, so the trim target remains active and the formal command must be able to resume from partial progress.
+
+## Key Technical Decisions
+
+- Introduce a dedicated bulk trim command under `likes` instead of encoding the workflow in docs or one-off scripts.
+- Add a bulk archive reconciliation helper that rewrites `likes.jsonl` once per batch and rebuilds `likes.db` once per batch, not once per item.
+- Recompute the trim candidate set from the archive at command start so interrupted runs are naturally resumable.
+- Process oldest removable likes in batches while preserving the newest `keep` records by `likedAt` fallback `postedAt`.
+- Stop on the first remote failure within a batch and leave already-completed removals persisted; the next run resumes from the new archive state.
+
+## Open Questions
+
+### Resolved During Planning
+
+- Should the command add pauses before every request? No. Pausing between batches is simpler and matches the user's request.
+- Should the command be resumable across interruptions? Yes. Recomputing from the current archive state is enough; no extra checkpoint file is required.
+
+### Unresolved Questions
+
+- None.
+
+## High-Level Technical Design
+
+> *Directional guidance only, not implementation code.*
+
+```text
+ft likes trim --keep 200 --batch-size 25 --pause-seconds 45
+  -> load likes archive
+  -> sort by likedAt desc, keep newest 200
+  -> split older records into batches of 25
+  -> for each batch:
+       unlike each tweet on X
+       if all remote unlikes succeeded up to current point:
+         rewrite likes.jsonl without those ids
+         update likes meta count
+         rebuild likes.db once
+       sleep 45s before next batch
+  -> print final remaining count and keep boundary
+```
+
+## Implementation Units
+
+- [ ] **Unit 1: Add bulk likes trim primitives**
+
+**Goal:** Add a reusable helper that computes the trim set, executes batched remote unlikes, and reconciles the local archive once per batch.
+
+**Requirements:** R1, R2, R3, R4, R5
+
+**Dependencies:** Existing single-item unlike primitive
+
+**Files:**
+- Modify: `src/archive-actions.ts`
+- Create or modify: `src/likes-service.ts`
+- Modify: `src/types.ts`
+- Test: `tests/archive-actions.test.ts`
+
+**Approach:**
+- Add helpers to read and sort the current likes archive by recency.
+- Add a bulk removal path that deletes multiple ids from the archive and rebuilds the index once.
+- Add a trim executor that accepts `keep`, `batchSize`, `pauseSeconds`, and progress callbacks.
+
+**Patterns to follow:**
+- `src/archive-actions.ts`
+- `src/graphql-actions.ts`
+- `src/likes-db.ts`
+
+**Test scenarios:**
+- Happy path: trim planning keeps the newest `N` likes and selects older likes for removal.
+- Happy path: batch archive reconciliation removes multiple likes and rebuilds the index once.
+- Edge case: if total likes are already `<= keep`, the trim operation becomes a no-op.
+- Error path: a remote unlike failure stops further work and preserves unprocessed likes locally.
+
+**Verification:**
+- Temp-data tests prove the helper removes only the intended ids and leaves the newest likes untouched.
+
+- [ ] **Unit 2: Expose the CLI command and document it**
+
+**Goal:** Add `ft likes trim` with clear progress output and operator-facing options, then document usage.
+
+**Requirements:** R1, R2, R4, R5, R6
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `src/cli.ts`
+- Modify: `README.md`
+- Modify: `docs/README.md`
+- Modify: `tasks/todo.md`
+- Test: `tests/cli-actions.test.ts`
+
+**Approach:**
+- Add `likes trim` under the existing likes command group.
+- Surface `--keep`, `--batch-size`, and `--pause-seconds`.
+- Print a compact summary before, during, and after execution.
+
+**Patterns to follow:**
+- `src/cli.ts`
+- `tests/cli-actions.test.ts`
+- `README.md`
+
+**Test scenarios:**
+- Happy path: CLI trims likes against mocked X responses and the local cache ends at the expected remaining count.
+- Edge case: CLI reports that no trim is needed when likes are already under the keep threshold.
+- Error path: CLI surfaces remote failures and does not remove unprocessed likes from the archive.
+
+**Verification:**
+- Targeted CLI tests pass and the real command completes against the user's archive until 200 likes remain.
+
+## Risks & Mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| X rate limits bulk unlike traffic | Pause between batches and keep batch size configurable |
+| Local index rebuild is expensive | Rebuild once per batch instead of once per item |
+| Interrupted runs leave partial progress | Recompute trim candidates from current local state on the next run |
+| Concurrent ad hoc process mutates the same archive | Stop the old process before running the formal command |
+
+## Documentation / Operational Notes
+
+- Add the new command to the main command table and write path notes in `README.md`.
+- Add the new plan entry to `docs/README.md`.
+- Record real execution results in `tasks/todo.md` review notes.

--- a/docs/plans/2026-04-12-004-feat-x-feed-cli-viewer-plan.md
+++ b/docs/plans/2026-04-12-004-feat-x-feed-cli-viewer-plan.md
@@ -1,0 +1,314 @@
+---
+title: feat: Add CLI-first X home timeline viewer
+type: feat
+status: active
+date: 2026-04-12
+origin: docs/brainstorms/2026-04-12-x-feed-requirements.md
+---
+
+# feat: Add CLI-first X home timeline viewer
+
+## Overview
+
+Add a new `feed` archive family that fetches tweet-only entries from the X Home timeline using the same browser-session-backed GraphQL approach as bookmarks and likes, caches fetched batches locally, indexes them for local paging, and exposes a CLI-first read-only viewer.
+
+## Problem Frame
+
+The repo already supports two X-backed local archives: bookmarks and likes. Both reuse the local logged-in browser session, fetch GraphQL timeline-shaped data, persist a JSONL cache plus SQLite index, and expose CLI commands for sync and read access. The new requirement is to extend that product model to the Home timeline without turning the tool into a full X client. Phase 1 is specifically a terminal-first viewer that fetches tweet entries, skips unsupported non-tweet modules, caches fetched results locally, and lets the user continue browsing multiple pages from the CLI (see origin: `docs/brainstorms/2026-04-12-x-feed-requirements.md`).
+
+This is a standard-risk change with one high-uncertainty edge: the Home timeline GraphQL contract is not already implemented in the repo and is not backed by official public documentation. The plan therefore treats endpoint validation and response-shape capture as the first implementation unit and keeps the rest of the feature narrow.
+
+## Requirements Trace
+
+- R1. Support a read-only Home timeline workflow as the first phase.
+- R2. Reuse the current logged-in X browser session and GraphQL fetch pattern.
+- R3. Keep the first phase focused on viewing feed items rather than becoming a full X client.
+- R4. Ship the feature as a CLI-first surface.
+- R6. Support tweet entries only and skip unsupported non-tweet units.
+- R8. Fetch Home timeline tweets and cache fetched batches locally.
+- R9. Support paged browsing across fetched results.
+- Success criterion: the feature is useful from the terminal before archive search, digesting, or actions exist.
+- Success criterion: the user can fetch and continue browsing multiple pages of Home timeline tweets from the CLI without opening the web app.
+
+## Scope Boundaries
+
+- No web UI feed surface in this iteration.
+- No full feed archive product semantics yet: no retention policy, no search UX, and no feed-specific markdown/wiki export.
+- No feed-driven like or bookmark actions in this iteration.
+- No rendering of promoted units, conversation modules, or other unsupported non-tweet timeline containers.
+- No attempt to unify bookmarks, likes, and feed into a generic multi-source archive abstraction in this iteration.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `src/graphql-bookmarks.ts` and `src/graphql-likes.ts` establish the existing X GraphQL archive pipeline: fetch -> normalize -> JSONL/meta/state -> rebuild SQLite index.
+- `src/x-graphql.ts` already centralizes session resolution and request header construction and is the right shared seam for any additional timeline fetcher.
+- `src/paths.ts` establishes the per-archive storage convention: one JSONL cache, one meta file, one state file when needed, and one SQLite index per archive family.
+- `src/likes-db.ts` and `src/bookmarks-db.ts` show the preferred read path: build a dedicated timeline-oriented SQLite schema and expose `list*`, `get*ById`, and count helpers with `limit` / `offset`.
+- `src/cli.ts` shows the desired operator surface: a top-level archive group with `sync`, `status`, `list`, and `show`, plus existing sync options for browser/session overrides and progress output.
+- `tests/graphql-likes.test.ts` and `tests/graphql-bookmarks.test.ts` are the closest parser/merge/fixture precedents.
+- `tests/cli-likes.test.ts`, `tests/likes-db.test.ts`, and `tests/likes-service.test.ts` are the closest CLI, list/show, and status behavior precedents.
+
+### Institutional Learnings
+
+- There is no `docs/solutions/` directory in this repo, so there are no recorded institutional learnings to inherit.
+- `docs/plans/2026-04-08-001-feat-local-web-archive-plan.md` is the strongest precedent for adding a new read surface over existing local archives and favors thin surfaces over existing archive modules.
+- `docs/plans/2026-04-08-002-feat-remote-unlike-unbookmark-plan.md` reinforces the separation between remote X interactions and local archive reconciliation.
+- `docs/plans/2026-04-09-003-feat-likes-trim-command-plan.md` reinforces the repo's bias toward narrow first-class commands over speculative generalization.
+
+### External References
+
+- No external framework or API documentation is authoritative for the Home timeline GraphQL surface. Planning relies on repo-grounded X GraphQL patterns and treats Home timeline contract validation as an explicit implementation prerequisite rather than a settled assumption.
+
+## Key Technical Decisions
+
+- Introduce a separate `feed` archive family instead of extending bookmarks or likes in place. This preserves the repo's existing archive symmetry without forcing a generic abstraction before the third surface is understood.
+- Split remote fetch pagination from local browse pagination. Remote GraphQL cursoring remains an implementation detail of `feed sync`, while the user-facing browse experience uses the existing local `limit` / `offset` pattern over a SQLite index.
+- Treat Home timeline contract capture and validation as part of the productized implementation, not an untracked manual prerequisite. The first implementation unit should capture the query contract in sanitized fixtures and tests so the feature does not depend on tacit local knowledge.
+- Keep phase 1 read-only and tweet-only. Unsupported timeline entries should be counted and skipped rather than partially rendered, because the requirement is a useful viewer, not X parity.
+- Persist feed ordering explicitly. `FeedRecord` should carry the X timeline `sortIndex` when present plus a per-sync fetch position fallback so local browsing can preserve X-provided ordering within and across fetched batches without pretending the feed is chronological.
+- Preserve future feed evolution by storing stable feed item ids and keeping fetch, local storage, and later remote actions separated. This satisfies the roadmap requirements without prematurely designing a full automation layer.
+
+## Open Questions
+
+### Resolved During Planning
+
+- Should phase 1 be CLI, web, or both? CLI only for phase 1, with any web surface deferred by the origin requirements.
+- Should phase 1 be stdout-only or locally cached? Locally cached, following the existing archive family storage model.
+- Should paging be live-only or support continued browsing? Support continued local browsing from cached fetched results using `limit` / `offset`.
+- Should phase 1 attempt to support all Home timeline entry types? No. Support tweet entries only and skip unsupported non-tweet modules.
+
+### Deferred to Implementation
+
+- The exact Home timeline GraphQL operation name, query id, field toggles, and cursor extraction rules are intentionally deferred to Unit 1 because they depend on validating the live X response shape and capturing a sanitized representative response fixture.
+- The exact file-level boundary between shared helpers in `src/x-graphql.ts` and feed-specific fetch logic is intentionally deferred until the real Home response shape is in hand.
+- Whether the local feed cache should later graduate into a durable archive with search, digesting, and web browsing remains intentionally deferred to later product work.
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```text
+ft feed sync --max-pages N
+  -> resolve X session from browser cookies
+  -> capture / codify Home timeline query contract in fixture-backed parser tests
+  -> fetch Home timeline GraphQL pages
+  -> keep TimelineTweet-style entries only
+  -> normalize to FeedRecord[] with stable id + sortIndex + fetch position
+  -> write feed.jsonl + feed-meta.json + feed-state.json
+  -> rebuild feed.db
+
+ft feed list --limit 30 --offset 30
+  -> query feed.db ordered by persisted feed order
+  -> print compact timeline rows from local cache
+
+ft feed show <id>
+  -> read one indexed feed item
+  -> print detail from local cache
+```
+
+## Implementation Units
+
+- [ ] **Unit 1: Validate and normalize the Home timeline fetch contract**
+
+**Goal:** Add a dedicated feed fetcher that can authenticate with the existing browser-session model, fetch Home timeline pages, normalize tweet entries into a feed-specific record shape, and persist cache/meta/state files.
+
+**Requirements:** R1, R2, R6, R8
+
+**Dependencies:** Existing X session helpers and JSONL/meta file conventions
+
+**Files:**
+- Modify: `src/types.ts`
+- Modify: `src/paths.ts`
+- Modify: `src/x-graphql.ts`
+- Create: `src/graphql-feed.ts`
+- Test: `tests/graphql-feed.test.ts`
+
+**Approach:**
+- Start by capturing the Home timeline request contract from the browser network surface and codifying it into sanitized test fixtures: operation name, query id, feature/field toggles, cursor placement, and one representative response body. If this capture fails, stop implementation and return to re-planning.
+- Introduce a feed-specific raw record type in `src/types.ts` rather than overloading `LikeRecord` or `BookmarkRecord`.
+- Add feed storage paths in `src/paths.ts` that match the existing per-archive naming convention.
+- Reuse `resolveXSessionAuth()`, `buildGraphqlUrl()`, and `buildXGraphqlHeaders()` in `src/x-graphql.ts` where possible; only extract more shared logic if the feed fetcher would otherwise become a copy of likes/bookmarks.
+- Implement the feed fetcher as a dedicated module that:
+  - validates the Home timeline GraphQL contract,
+  - filters for tweet entries only,
+  - records skipped unsupported entries for operator visibility,
+  - persists `sortIndex` and per-page fetch position so local browsing can preserve feed order,
+  - writes JSONL/meta/state files,
+  - preserves enough ordering and timestamp fields for later local browsing.
+- Treat missing or invalid Home timeline contract details as a first-class failure with a clear operator-facing error instead of silently producing an empty cache.
+
+**Execution note:** Start with a failing parser-level behavior test that captures one valid tweet page, one unsupported-entry page, and one contract-failure response.
+
+**Patterns to follow:**
+- `src/graphql-likes.ts`
+- `src/graphql-bookmarks.ts`
+- `src/x-graphql.ts`
+- `tests/graphql-likes.test.ts`
+
+**Test scenarios:**
+- Happy path: a valid Home timeline response containing tweet entries produces normalized `FeedRecord` items with stable ids, author metadata, URLs, timestamps, `sortIndex`, and per-page fetch position.
+- Happy path: multiple fetched pages merge into one cache result with a saved resume cursor or equivalent fetch state.
+- Edge case: a response containing only unsupported non-tweet entries yields zero cached items but reports skipped-entry counts rather than failing silently.
+- Edge case: duplicate tweet ids across fetched pages are merged without duplicating local records, while preserving the newest feed-order metadata for local browsing.
+- Error path: an expired-session or unauthorized response raises a clear error instructing the user to refresh browser auth.
+- Error path: a structurally unexpected Home timeline response fails with an explicit contract error instead of writing misleading cache files.
+- Integration: a temp data dir sync writes `feed.jsonl`, `feed-meta.json`, and `feed-state.json` with counts and timestamps that match the fetched result.
+
+**Verification:**
+- Fixture-driven tests prove the fetcher accepts tweet entries, rejects unsupported contract shapes explicitly, and persists the expected cache artifacts in a temp data dir.
+
+- [ ] **Unit 2: Add a local feed index and read models for paging**
+
+**Goal:** Build a feed-specific SQLite index and read API that support local paging and detailed item lookup over cached feed records.
+
+**Requirements:** R1, R8, R9
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Create: `src/feed-db.ts`
+- Create or modify: `src/feed-service.ts`
+- Test: `tests/feed-db.test.ts`
+- Test: `tests/feed-service.test.ts`
+
+**Approach:**
+- Create a feed-specific SQLite schema modeled after `likes-db` rather than trying to extend the likes or bookmarks tables.
+- Expose the same local browsing surface the repo already uses for archive families:
+  - build/rebuild index,
+  - count feed items,
+  - list feed items with `limit`, `offset`, and stable ordering,
+  - get one feed item by id,
+  - format a status view for CLI output.
+- Keep local paging strictly database-backed. The user should browse cached rows with offset-based pagination, while remote cursoring stays private to the fetcher.
+- Define the canonical local ordering explicitly: order by the most recent sync batch first, then by persisted X `sortIndex` descending when present, then by per-page fetch position, then by tweet id fallback. When the same tweet reappears in a later sync, update its stored order metadata so it bubbles to the newer fetched position.
+- Include skipped-entry and last-sync information in the feed status view if the state/meta model captures it, so operators can tell the difference between an empty feed and a fully skipped page.
+
+**Patterns to follow:**
+- `src/likes-db.ts`
+- `src/bookmarks-db.ts`
+- `src/likes-service.ts`
+- `tests/likes-db.test.ts`
+- `tests/likes-service.test.ts`
+
+**Test scenarios:**
+- Happy path: rebuilding the feed index from cached JSONL creates listable rows ordered by the persisted feed-order model rather than tweet timestamps alone.
+- Happy path: `getFeedById` returns the full indexed item for a known id.
+- Edge case: list pagination with `limit` and `offset` returns the expected non-overlapping windows across one cached fetch.
+- Edge case: a tweet refetched in a later sync moves to the newer local browse position rather than remaining stuck at its old slot.
+- Edge case: records lacking one ordering field still sort predictably using the defined fallback chain.
+- Error path: status and list helpers behave predictably when the cache exists but the index has not yet been built or is missing.
+- Integration: rebuilding the feed index after a temp-data fetch produces counts that match the feed meta file and list output.
+
+**Verification:**
+- Temp-data index tests prove the feed archive can be rebuilt, paged, and queried using the same local model as existing archive families.
+
+- [ ] **Unit 3: Expose the CLI-first feed viewer**
+
+**Goal:** Add a top-level `feed` command group that lets the user fetch, inspect status, list paged results, and show one cached feed item from the terminal.
+
+**Requirements:** R1, R4, R8, R9
+
+**Dependencies:** Unit 1, Unit 2
+
+**Files:**
+- Modify: `src/cli.ts`
+- Test: `tests/cli-feed.test.ts`
+
+**Approach:**
+- Add a new `feed` command group to `src/cli.ts` alongside `likes` and `bookmarks`.
+- Expose a narrow phase-1 command set:
+  - `ft feed sync` for fetching and caching Home timeline pages
+  - `ft feed status` for cache/index summary
+  - `ft feed list` for paged local browsing
+  - `ft feed show <id>` for one cached item
+- Reuse the repo's existing sync ergonomics where they make sense: browser selection, direct cookie overrides, page limits, delays, and progress reporting.
+- Keep phase-1 output text-first and consistent with `likes list` / `likes status`. Do not add search, web integration, or remote actions in this unit.
+- Ensure missing-data and expired-auth paths remain operator-readable and aligned with existing archive guidance.
+
+**Patterns to follow:**
+- `src/cli.ts`
+- `tests/cli-likes.test.ts`
+- `tests/likes-status.test.ts`
+
+**Test scenarios:**
+- Happy path: CLI help includes the new `feed` command group and its primary subcommands.
+- Happy path: `ft feed status` prints a feed-specific summary including local cache path and last sync information.
+- Happy path: `ft feed list --limit 1 --offset 1` prints a paged local view of cached feed items.
+- Happy path: `ft feed show <id>` prints detailed output for a known cached feed item.
+- Edge case: `ft feed list` on an empty but initialized cache prints no rows without crashing.
+- Edge case: `ft feed show <missing-id>` exits non-zero with a clear not-found message.
+- Error path: `ft feed sync` surfaces expired-auth or contract-validation failures without building a misleading local index.
+- Integration: a temp data dir flow can run sync against mocked X responses, build the index, and then browse the cached results through CLI commands.
+
+**Verification:**
+- CLI tests prove the command group is discoverable and the public read-only workflow works against temp cache/index fixtures.
+
+- [ ] **Unit 4: Document the new archive family and operator boundaries**
+
+**Goal:** Update docs and working checklist artifacts so the new feed surface is discoverable and its intentional phase-1 limits are recorded.
+
+**Requirements:** R3, R4, R6, R8, R9
+
+**Dependencies:** Unit 3
+
+**Files:**
+- Modify: `README.md`
+- Modify: `docs/README.md`
+- Modify: `tasks/todo.md`
+
+**Approach:**
+- Add the new CLI surface to the README command documentation with a clear explanation that phase 1 is read-only, tweet-only, and CLI-first.
+- Add the plan entry to `docs/README.md`.
+- Update `tasks/todo.md` to track implementation progress and review notes once work begins.
+- Document the operator boundary explicitly so future work on search, web viewing, digesting, and feed-driven actions starts from the recorded roadmap rather than expanding phase 1 opportunistically.
+
+**Patterns to follow:**
+- `README.md`
+- `docs/README.md`
+- `tasks/todo.md`
+
+**Test scenarios:**
+- Test expectation: none -- this unit is documentation and task-tracking only.
+
+**Verification:**
+- The README and docs index make the new command set and phase-1 boundaries visible to a repo reader without requiring code inspection.
+
+## System-Wide Impact
+
+- **Interaction graph:** The new `feed` archive family adds another X GraphQL ingestion path and another local SQLite index, but should not alter bookmark or like behavior.
+- **Error propagation:** Home timeline auth and contract failures should stop `feed sync` before cache/meta/index writes are treated as authoritative. Local read commands should keep the same missing-data behavior as other archive families.
+- **State lifecycle risks:** The feed cache will be append/merge oriented like other archives, so duplicate handling and clear rebuild semantics matter. Remote cursor state and local browse pagination must remain separate to avoid confusing operators.
+- **API surface parity:** The new archive family should feel symmetrical with `likes` and `bookmarks` at the CLI level, but symmetry should not force a generic shared schema or merged archive abstraction.
+- **Integration coverage:** The highest-value integration proof is a mocked-X sync into a temp data dir followed by index build and CLI browsing from the cached feed.
+- **Unchanged invariants:** Existing `bookmarks`, `likes`, web APIs, and remote action flows remain unchanged in this plan.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| X Home timeline GraphQL contract differs materially from likes/bookmarks or changes unexpectedly | Make contract validation and fixture capture the first implementation unit and fail explicitly on unsupported shapes |
+| A third archive family creates code drift through copy-paste duplication | Reuse `src/x-graphql.ts`, `src/paths.ts`, and existing DB/CLI patterns, but limit abstraction to seams proven necessary by feed specifics |
+| Skipping non-tweet entries makes some fetched pages appear sparse | Record skipped-entry counts in state/status so operators can distinguish sparse tweet output from a broken sync |
+| Local paging semantics become confused with remote cursor paging | Keep remote cursor handling private to `feed sync` and expose only local `limit` / `offset` browse semantics in CLI commands |
+| The feed cache is mistaken for a complete archive product | Document phase-1 boundaries clearly in README, docs index, and task notes |
+
+## Documentation / Operational Notes
+
+- Add the new plan entry to `docs/README.md`.
+- Add CLI usage examples for the new `feed` command group to `README.md`.
+- Record the working checklist in `tasks/todo.md` before implementation begins.
+- If implementation proves Home timeline access is not viable, stop and return to `ce:brainstorm` rather than silently substituting another surface.
+
+## Sources & References
+
+- **Origin document:** `docs/brainstorms/2026-04-12-x-feed-requirements.md`
+- Related code: `src/graphql-likes.ts`
+- Related code: `src/graphql-bookmarks.ts`
+- Related code: `src/x-graphql.ts`
+- Related code: `src/likes-db.ts`
+- Related code: `src/cli.ts`
+- Related plan: `docs/plans/2026-04-08-001-feat-local-web-archive-plan.md`
+- Related plan: `docs/plans/2026-04-08-002-feat-remote-unlike-unbookmark-plan.md`
+- Related plan: `docs/plans/2026-04-09-003-feat-likes-trim-command-plan.md`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "fieldtheory",
+  "name": "fieldtheory-cli",
   "version": "1.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "fieldtheory",
+      "name": "fieldtheory-cli",
       "version": "1.3.2",
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,31 +1,333 @@
 {
-  "name": "ft-bookmarks",
-  "version": "1.3.0",
+  "name": "fieldtheory",
+  "version": "1.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "ft-bookmarks",
-      "version": "1.3.0",
+      "name": "fieldtheory",
+      "version": "1.3.2",
       "license": "MIT",
       "dependencies": {
+        "@hono/node-server": "^1.19.13",
         "commander": "^14.0.3",
         "dotenv": "^17.3.1",
+        "hono": "^4.12.12",
+        "react": "^19.2.4",
+        "react-dom": "^19.2.4",
         "sql.js": "^1.14.1",
-        "sql.js-fts5": "^1.4.0",
-        "zod": "^4.3.6"
+        "sql.js-fts5": "^1.4.0"
       },
       "bin": {
+        "fieldtheory": "bin/ft.mjs",
         "ft": "bin/ft.mjs"
       },
       "devDependencies": {
         "@types/node": "^25.5.0",
+        "@types/react": "^19.2.14",
+        "@types/react-dom": "^19.2.3",
         "@types/sql.js": "^1.4.11",
+        "@vitejs/plugin-react": "^5.1.0",
         "tsx": "^4.21.0",
-        "typescript": "^6.0.2"
+        "typescript": "^6.0.2",
+        "vite": "^8.0.7"
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
+      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
+      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helpers": "^7.28.6",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/traverse": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.28.6",
+        "@babel/helper-validator-option": "^7.27.1",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/traverse": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
+      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
+      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.27.1.tgz",
+      "integrity": "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.27.1.tgz",
+      "integrity": "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.28.6",
+        "@babel/parser": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -470,6 +772,451 @@
         "node": ">=18"
       }
     },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.13",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.13.tgz",
+      "integrity": "sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.3.tgz",
+      "integrity": "sha512-xK9sGVbJWYb08+mTJt3/YV24WxvxpXcXtP6B172paPZ+Ts69Re9dAr7lKwJoeIx8OoeuimEiRZ7umkiUVClmmQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.123.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.123.0.tgz",
+      "integrity": "sha512-YtECP/y8Mj1lSHiUWGSRzy/C6teUKlS87dEfuVKT09LgQbUsBW1rNg+MiJ4buGu3yuADV60gbIvo9/HplA56Ew==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.13.tgz",
+      "integrity": "sha512-5ZiiecKH2DXAVJTNN13gNMUcCDg4Jy8ZjbXEsPnqa248wgOVeYRX0iqXXD5Jz4bI9BFHgKsI2qmyJynstbmr+g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.13.tgz",
+      "integrity": "sha512-tz/v/8G77seu8zAB3A5sK3UFoOl06zcshEzhUO62sAEtrEuW/H1CcyoupOrD+NbQJytYgA4CppXPzlrmp4JZKA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.13.tgz",
+      "integrity": "sha512-8DakphqOz8JrMYWTJmWA+vDJxut6LijZ8Xcdc4flOlAhU7PNVwo2MaWBF9iXjJAPo5rC/IxEFZDhJ3GC7NHvug==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.13.tgz",
+      "integrity": "sha512-4wBQFfjDuXYN/SVI8inBF3Aa+isq40rc6VMFbk5jcpolUBTe5cYnMsHZ51nFWsx3PVyyNN3vgoESki0Hmr/4BA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.13.tgz",
+      "integrity": "sha512-JW/e4yPIXLms+jmnbwwy5LA/LxVwZUWLN8xug+V200wzaVi5TEGIWQlh8o91gWYFxW609euI98OCCemmWGuPrw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.13.tgz",
+      "integrity": "sha512-ZfKWpXiUymDnavepCaM6KG/uGydJ4l2nBmMxg60Ci4CbeefpqjPWpfaZM7PThOhk2dssqBAcwLc6rAyr0uTdXg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.13.tgz",
+      "integrity": "sha512-bmRg3O6Z0gq9yodKKWCIpnlH051sEfdVwt+6m5UDffAQMUUqU0xjnQqqAUm+Gu7ofAAly9DqiQDtKu2nPDEABA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.13.tgz",
+      "integrity": "sha512-8Wtnbw4k7pMYN9B/mOEAsQ8HOiq7AZ31Ig4M9BKn2So4xRaFEhtCSa4ZJaOutOWq50zpgR4N5+L/opnlaCx8wQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.13.tgz",
+      "integrity": "sha512-D/0Nlo8mQuxSMohNJUF2lDXWRsFDsHldfRRgD9bRgktj+EndGPj4DOV37LqDKPYS+osdyhZEH7fTakTAEcW7qg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.13.tgz",
+      "integrity": "sha512-eRrPvat2YaVQcwwKi/JzOP6MKf1WRnOCr+VaI3cTWz3ZoLcP/654z90lVCJ4dAuMEpPdke0n+qyAqXDZdIC4rA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.13.tgz",
+      "integrity": "sha512-PsdONiFRp8hR8KgVjTWjZ9s7uA3uueWL0t74/cKHfM4dR5zXYv4AjB8BvA+QDToqxAFg4ZkcVEqeu5F7inoz5w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.13.tgz",
+      "integrity": "sha512-hCNXgC5dI3TVOLrPT++PKFNZ+1EtS0mLQwfXXXSUD/+rGlB65gZDwN/IDuxLpQP4x8RYYHqGomlUXzpO8aVI2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.13.tgz",
+      "integrity": "sha512-viLS5C5et8NFtLWw9Sw3M/w4vvnVkbWkO7wSNh3C+7G1+uCkGpr6PcjNDSFcNtmXY/4trjPBqUfcOL+P3sWy/g==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.9.1",
+        "@emnapi/runtime": "1.9.1",
+        "@napi-rs/wasm-runtime": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.1.tgz",
+      "integrity": "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.1.tgz",
+      "integrity": "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz",
+      "integrity": "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.13.tgz",
+      "integrity": "sha512-Fqa3Tlt1xL4wzmAYxGNFV36Hb+VfPc9PYU+E25DAnswXv3ODDu/yyWjQDbXMo5AGWkQVjLgQExuVu8I/UaZhPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.13.tgz",
+      "integrity": "sha512-/pLI5kPkGEi44TDlnbio3St/5gUFeN51YWNAk/Gnv6mEQBOahRBh52qVFVBpmrnU01n2yysvBML9Ynu7K4kGAQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.13.tgz",
+      "integrity": "sha512-3ngTAv6F/Py35BsYbeeLeecvhMKdsKm4AoOETVhAA+Qc8nrA2I0kF7oa93mE9qnIurngOSpMnQ0x2nQY2FPviA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
     "node_modules/@types/emscripten": {
       "version": "1.41.5",
       "resolved": "https://registry.npmjs.org/@types/emscripten/-/emscripten-1.41.5.tgz",
@@ -487,6 +1234,27 @@
         "undici-types": "~7.18.0"
       }
     },
+    "node_modules/@types/react": {
+      "version": "19.2.14",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
+      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
+      }
+    },
     "node_modules/@types/sql.js": {
       "version": "1.4.11",
       "resolved": "https://registry.npmjs.org/@types/sql.js/-/sql.js-1.4.11.tgz",
@@ -498,6 +1266,103 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-5.2.0.tgz",
+      "integrity": "sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.29.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-rc.3",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.18.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/@vitejs/plugin-react/node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.3.tgz",
+      "integrity": "sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.16",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.16.tgz",
+      "integrity": "sha512-Lyf3aK28zpsD1yQMiiHD4RvVb6UdMoo8xzG2XzFIfR9luPzOpcBlAsT/qfB1XWS1bxWT+UtE4WmQgsp297FYOA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001787",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001787.tgz",
+      "integrity": "sha512-mNcrMN9KeI68u7muanUpEejSLghOKlVhRqS/Za2IeyGllJ9I9otGpR9g3nsw7n4W378TE/LyIteA0+/FOZm4Kg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
     "node_modules/commander": {
       "version": "14.0.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
@@ -505,6 +1370,48 @@
       "license": "MIT",
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/dotenv": {
@@ -518,6 +1425,13 @@
       "funding": {
         "url": "https://dotenvx.com"
       }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.334",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.334.tgz",
+      "integrity": "sha512-mgjZAz7Jyx1SRCwEpy9wefDS7GvNPazLthHg8eQMJ76wBdGQQDW33TCrUTvQ4wzpmOrv2zrFoD3oNufMdyMpog==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/esbuild": {
       "version": "0.27.7",
@@ -561,6 +1475,34 @@
         "@esbuild/win32-x64": "0.27.7"
       }
     },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -576,6 +1518,16 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/get-tsconfig": {
       "version": "4.13.7",
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.7.tgz",
@@ -589,6 +1541,435 @@
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
+    "node_modules/hono": {
+      "version": "4.12.12",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
+      "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.37",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.37.tgz",
+      "integrity": "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.9",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.9.tgz",
+      "integrity": "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
+      "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
+      "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.4"
+      }
+    },
+    "node_modules/react-refresh": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.18.0.tgz",
+      "integrity": "sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resolve-pkg-maps": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
@@ -597,6 +1978,66 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.0.0-rc.13",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.13.tgz",
+      "integrity": "sha512-bvVj8YJmf0rq4pSFmH7laLa6pYrhghv3PRzrCdRAr23g66zOKVJ4wkvFtgohtPLWmthgg8/rkaqRHrpUEh0Zbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.123.0",
+        "@rolldown/pluginutils": "1.0.0-rc.13"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.0-rc.13",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.13",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.13",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.13",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.13",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.13",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.13",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.13",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.13",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.13",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.13",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.13",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.13",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.13",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.13"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/sql.js": {
@@ -611,12 +2052,38 @@
       "integrity": "sha512-O9VQo/LSt+cteAbkLJAJIkFMIEg63Quw8OeZjc60qw5JWpZ2JhCB0RHrDvcjWxstixxFx2/GXYYatwrtmue5ww==",
       "license": "MIT"
     },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
     "node_modules/tsx": {
       "version": "4.21.0",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -652,14 +2119,122 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/zod": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
       "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
       }
+    },
+    "node_modules/vite": {
+      "version": "8.0.7",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.7.tgz",
+      "integrity": "sha512-P1PbweD+2/udplnThz3btF4cf6AgPky7kk23RtHUkJIU5BIxwPprhRGmOAHs6FTI7UiGbTNrgNP6jSYD6JaRnw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.8",
+        "rolldown": "1.0.0-rc.13",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,9 +8,11 @@
     "fieldtheory": "bin/ft.mjs"
   },
   "scripts": {
-    "build": "tsc -p tsconfig.json",
+    "build": "tsc -p tsconfig.json && vite build --config web/vite.config.ts",
+    "build:web": "vite build --config web/vite.config.ts",
     "test": "tsx --test tests/**/*.test.ts",
     "dev": "tsx src/cli.ts",
+    "dev:web": "vite --config web/vite.config.ts",
     "start": "node dist/cli.js",
     "prepublishOnly": "npm run build"
   },
@@ -40,15 +42,23 @@
     "cli"
   ],
   "dependencies": {
+    "@hono/node-server": "^1.19.13",
     "commander": "^14.0.3",
     "dotenv": "^17.3.1",
+    "hono": "^4.12.12",
+    "react": "^19.2.4",
+    "react-dom": "^19.2.4",
     "sql.js": "^1.14.1",
     "sql.js-fts5": "^1.4.0"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",
+    "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3",
     "@types/sql.js": "^1.4.11",
+    "@vitejs/plugin-react": "^5.1.0",
     "tsx": "^4.21.0",
-    "typescript": "^6.0.2"
+    "typescript": "^6.0.2",
+    "vite": "^8.0.7"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "fieldtheory",
+  "name": "fieldtheory-cli",
   "version": "1.3.2",
   "description": "Field Theory CLI. Self-custody for your X/Twitter bookmarks. Local sync, full-text search, classification, and terminal dashboards.",
   "type": "module",
@@ -28,7 +28,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/afar1/fieldtheory-cli.git"
+    "url": "git+https://github.com/Decolo/fieldtheory-cli.git"
   },
   "keywords": [
     "bookmarks",

--- a/src/archive-actions.ts
+++ b/src/archive-actions.ts
@@ -1,0 +1,121 @@
+import { buildIndex } from './bookmarks-db.js';
+import { readJson, readJsonLines, writeJson, writeJsonLines, pathExists } from './fs.js';
+import { buildLikesIndex } from './likes-db.js';
+import {
+  twitterBookmarksCachePath,
+  twitterBookmarksMetaPath,
+  twitterLikesCachePath,
+  twitterLikesMetaPath,
+} from './paths.js';
+import type { BookmarkCacheMeta, BookmarkRecord, LikeRecord, LikesCacheMeta } from './types.js';
+
+export interface ArchiveRemovalResult {
+  removed: boolean;
+  tweetId: string;
+  removedRecordId?: string;
+  totalRemaining: number;
+  cachePath: string;
+  dbPath: string;
+}
+
+export interface ArchiveBulkRemovalResult {
+  removedIds: string[];
+  missingIds: string[];
+  totalRemaining: number;
+  cachePath: string;
+  dbPath: string;
+}
+
+async function rewriteBookmarkMeta(totalBookmarks: number): Promise<void> {
+  const metaPath = twitterBookmarksMetaPath();
+  const existing: BookmarkCacheMeta = await pathExists(metaPath)
+    ? await readJson<BookmarkCacheMeta>(metaPath)
+    : { provider: 'twitter', schemaVersion: 1, totalBookmarks };
+
+  await writeJson(metaPath, {
+    ...existing,
+    totalBookmarks,
+  } satisfies BookmarkCacheMeta);
+}
+
+async function rewriteLikesMeta(totalLikes: number): Promise<void> {
+  const metaPath = twitterLikesMetaPath();
+  const existing: LikesCacheMeta = await pathExists(metaPath)
+    ? await readJson<LikesCacheMeta>(metaPath)
+    : { provider: 'twitter', schemaVersion: 1, totalLikes };
+
+  await writeJson(metaPath, {
+    ...existing,
+    totalLikes,
+  } satisfies LikesCacheMeta);
+}
+
+export async function removeBookmarkFromArchive(tweetId: string): Promise<ArchiveRemovalResult> {
+  const cachePath = twitterBookmarksCachePath();
+  const existing = await readJsonLines<BookmarkRecord>(cachePath);
+  const removedRecord = existing.find((record) => record.id === tweetId || record.tweetId === tweetId);
+  const next = existing.filter((record) => record.id !== tweetId && record.tweetId !== tweetId);
+
+  await writeJsonLines(cachePath, next);
+  await rewriteBookmarkMeta(next.length);
+  const index = await buildIndex({ force: true });
+
+  return {
+    removed: Boolean(removedRecord),
+    tweetId,
+    removedRecordId: removedRecord?.id,
+    totalRemaining: next.length,
+    cachePath,
+    dbPath: index.dbPath,
+  };
+}
+
+export async function removeLikeFromArchive(tweetId: string): Promise<ArchiveRemovalResult> {
+  const cachePath = twitterLikesCachePath();
+  const existing = await readJsonLines<LikeRecord>(cachePath);
+  const removedRecord = existing.find((record) => record.id === tweetId || record.tweetId === tweetId);
+  const next = existing.filter((record) => record.id !== tweetId && record.tweetId !== tweetId);
+
+  await writeJsonLines(cachePath, next);
+  await rewriteLikesMeta(next.length);
+  const index = await buildLikesIndex({ force: true });
+
+  return {
+    removed: Boolean(removedRecord),
+    tweetId,
+    removedRecordId: removedRecord?.id,
+    totalRemaining: next.length,
+    cachePath,
+    dbPath: index.dbPath,
+  };
+}
+
+export async function removeLikesFromArchive(tweetIds: string[]): Promise<ArchiveBulkRemovalResult> {
+  const targets = new Set(tweetIds);
+  const cachePath = twitterLikesCachePath();
+  const existing = await readJsonLines<LikeRecord>(cachePath);
+  const matchedTargets = new Set<string>();
+  const removedIds = existing
+    .filter((record) => {
+      const matched = targets.has(record.id) || targets.has(record.tweetId);
+      if (matched) {
+        matchedTargets.add(record.id);
+        matchedTargets.add(record.tweetId);
+      }
+      return matched;
+    })
+    .map((record) => record.id);
+  const next = existing.filter((record) => !targets.has(record.id) && !targets.has(record.tweetId));
+
+  await writeJsonLines(cachePath, next);
+  await rewriteLikesMeta(next.length);
+  const index = await buildLikesIndex({ force: true });
+
+  return {
+    removedIds,
+    missingIds: tweetIds.filter((tweetId) => !matchedTargets.has(tweetId)),
+    totalRemaining: next.length,
+    cachePath,
+    dbPath: index.dbPath,
+  };
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -142,6 +142,16 @@ function getLocalVersion(): string {
   }
 }
 
+function getPackageName(): string {
+  try {
+    const require = createRequire(import.meta.url);
+    const pkg = require('../package.json');
+    return String(pkg.name ?? 'fieldtheory-cli');
+  } catch {
+    return 'fieldtheory-cli';
+  }
+}
+
 export function compareVersions(a: string, b: string): number {
   const pa = a.split('.').map(Number);
   const pb = b.split('.').map(Number);
@@ -153,6 +163,7 @@ export function compareVersions(a: string, b: string): number {
 
 async function checkForUpdate(): Promise<void> {
   try {
+    const packageName = getPackageName();
     const cacheFile = path.join(dataDir(), '.update-check');
     // Re-fetch from npm if cache is stale (>24hr)
     let needsFetch = true;
@@ -164,7 +175,7 @@ async function checkForUpdate(): Promise<void> {
     if (needsFetch) {
       const controller = new AbortController();
       const timeout = setTimeout(() => controller.abort(), 5000);
-      const res = await fetch('https://registry.npmjs.org/fieldtheory/latest', {
+      const res = await fetch(`https://registry.npmjs.org/${packageName}/latest`, {
         signal: controller.signal,
         headers: { accept: 'application/json' },
       });
@@ -187,8 +198,9 @@ function showCachedUpdateNotice(): void {
     const cacheFile = path.join(dataDir(), '.update-check');
     const latest = fs.readFileSync(cacheFile, 'utf-8').trim();
     const local = getLocalVersion();
+    const packageName = getPackageName();
     if (latest && compareVersions(latest, local) > 0) {
-      console.log(`\n  \u2728 Update available: ${local} \u2192 ${latest}  \u2014  npm update -g fieldtheory`);
+      console.log(`\n  \u2728 Update available: ${local} \u2192 ${latest}  \u2014  npm update -g ${packageName}`);
     }
   } catch { /* no cache yet, skip */ }
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,8 +2,11 @@
 import { Command } from 'commander';
 import { syncTwitterBookmarks } from './bookmarks.js';
 import { getBookmarkStatusView, formatBookmarkStatus } from './bookmarks-service.js';
+import { getLikesStatusView, formatLikesStatus } from './likes-service.js';
 import { runTwitterOAuthFlow } from './xauth.js';
 import { syncBookmarksGraphQL, syncGaps } from './graphql-bookmarks.js';
+import { syncLikesGraphQL, type LikesSyncProgress } from './graphql-likes.js';
+import { unlikeTweet, unbookmarkTweet } from './graphql-actions.js';
 import type { SyncProgress, GapFillProgress } from './graphql-bookmarks.js';
 import { fetchBookmarkMediaBatch } from './bookmark-media.js';
 import {
@@ -18,6 +21,13 @@ import {
   listBookmarks,
   getBookmarkById,
 } from './bookmarks-db.js';
+import {
+  buildLikesIndex,
+  searchLikes,
+  listLikes,
+  getLikeById,
+  formatLikeSearchResults,
+} from './likes-db.js';
 import { formatClassificationSummary } from './bookmark-classify.js';
 import { classifyWithLlm, classifyDomainsWithLlm } from './bookmark-classify-llm.js';
 import { resolveEngine, detectAvailableEngines } from './engine.js';
@@ -27,10 +37,21 @@ import { askMd } from './md-ask.js';
 import { lintMd, fixLintIssues } from './md-lint.js';
 import { exportBookmarks } from './md-export.js';
 import { renderViz } from './bookmarks-viz.js';
+import { removeBookmarkFromArchive, removeLikeFromArchive } from './archive-actions.js';
 import { listBrowserIds } from './browsers.js';
-import { dataDir, ensureDataDir, isFirstRun, twitterBookmarksIndexPath, mdDir } from './paths.js';
+import {
+  dataDir,
+  ensureDataDir,
+  isFirstRun,
+  isLikesFirstRun,
+  twitterBookmarksIndexPath,
+  twitterLikesIndexPath,
+  mdDir,
+} from './paths.js';
 import { PromptCancelledError, promptText } from './prompt.js';
 import { skillWithFrontmatter, installSkill, uninstallSkill } from './skill.js';
+import { assertWebAssetsBuilt, startWebServer } from './web.js';
+import { trimLikes } from './likes-trim.js';
 import fs from 'node:fs';
 import path from 'node:path';
 import { createRequire } from 'node:module';
@@ -230,8 +251,8 @@ function logo(): string {
 export function showWelcome(): void {
   console.log(logo());
   console.log(`
-  Save a local copy of your X/Twitter bookmarks. Search them,
-  classify them, and make them available to any AI agent.
+  Save a local copy of your X/Twitter bookmarks and likes. Search them,
+  classify bookmarks, and make them available to any AI agent.
   Your data never leaves your machine.
 
   Get started:
@@ -262,10 +283,11 @@ export async function showDashboard(): Promise<void> {
       }
     }
 
-    console.log(`
+  console.log(`
   \x1b[2mSync now:\x1b[0m     ft sync
   \x1b[2mSearch:\x1b[0m       ft search "query"
   \x1b[2mExplore:\x1b[0m      ft viz
+  \x1b[2mWeb UI:\x1b[0m       ft web
   \x1b[2mAll commands:\x1b[0m  ft --help
 `);
   } catch {
@@ -328,6 +350,33 @@ function requireIndex(): boolean {
   Search index not built yet.
 
   Run: ft index
+`);
+    process.exitCode = 1;
+    return false;
+  }
+  return true;
+}
+
+function requireLikesData(): boolean {
+  if (isLikesFirstRun()) {
+    console.log(`
+  No likes synced yet.
+
+  Run: ft likes sync
+`);
+    process.exitCode = 1;
+    return false;
+  }
+  return true;
+}
+
+function requireLikesIndex(): boolean {
+  if (!requireLikesData()) return false;
+  if (!fs.existsSync(twitterLikesIndexPath())) {
+    console.log(`
+  Likes search index not built yet.
+
+  Run: ft likes index
 `);
     process.exitCode = 1;
     return false;
@@ -401,8 +450,8 @@ export function buildCli() {
 
   program
     .name('ft')
-    .description('Self-custody for your X/Twitter bookmarks. Sync, search, classify, and explore locally.')
-    .version('1.2.2')
+    .description('Self-custody for your X/Twitter bookmarks and likes. Sync, search, classify bookmarks, and explore locally.')
+    .version(getLocalVersion())
     .showHelpAfterError()
     .hook('preAction', () => {
       console.log(logo());
@@ -579,6 +628,7 @@ export function buildCli() {
           console.log(`\n  Explore:`);
           console.log(`        ft search "machine learning"`);
           console.log(`        ft viz`);
+          console.log(`        ft web`);
           console.log(`        ft categories`);
           console.log(`\n  You can also just tell Claude to use the ft CLI to search and`);
           console.log(`  explore your bookmarks. It already knows how.\n`);
@@ -722,6 +772,41 @@ export function buildCli() {
     .action(safe(async () => {
       if (!requireIndex()) return;
       console.log(await renderViz());
+    }));
+
+  // ── web ─────────────────────────────────────────────────────────────────
+
+  program
+    .command('web')
+    .description('Serve a local web UI for bookmarks and likes')
+    .option('--host <host>', 'Host interface to bind', '127.0.0.1')
+    .option('--port <n>', 'Port to listen on', (v: string) => Number(v), 3147)
+    .option('--open', 'Open the web UI in your default browser')
+    .action(safe(async (options) => {
+      assertWebAssetsBuilt();
+      const requestedPort = typeof options.port === 'number' && !Number.isNaN(options.port)
+        ? options.port
+        : 3147;
+      const server = await startWebServer({
+        host: String(options.host),
+        port: requestedPort,
+        open: Boolean(options.open),
+      });
+
+      console.log(`  Field Theory web UI`);
+      console.log(`  URL: ${server.url}`);
+      console.log(`  Press Ctrl+C to stop.\n`);
+
+      await new Promise<void>((resolve) => {
+        const shutdown = async () => {
+          process.removeListener('SIGINT', shutdown);
+          process.removeListener('SIGTERM', shutdown);
+          await server.close();
+          resolve();
+        };
+        process.on('SIGINT', shutdown);
+        process.on('SIGTERM', shutdown);
+      });
     }));
 
   // ── classify ────────────────────────────────────────────────────────────
@@ -924,6 +1009,348 @@ export function buildCli() {
       if (!requireData()) return;
       const view = await getBookmarkStatusView();
       console.log(formatBookmarkStatus(view));
+    }));
+
+  program
+    .command('unbookmark')
+    .description('Remove one bookmark on X and reconcile the local archive')
+    .argument('<id>', 'Bookmarked post id')
+    .option('--browser <id>', 'Browser to read cookies from (chrome, brave, chromium, firefox)')
+    .option('--cookies <value...>', 'Pass cookies directly: <ct0> [auth_token]')
+    .option('--chrome-user-data-dir <path>', 'Chrome-family user-data directory')
+    .option('--chrome-profile-directory <name>', 'Chrome-family profile directory name')
+    .option('--firefox-profile-dir <path>', 'Firefox profile directory path')
+    .action(safe(async (id: string, options) => {
+      let csrfToken: string | undefined;
+      let cookieHeader: string | undefined;
+      if (options.cookies && Array.isArray(options.cookies) && options.cookies.length > 0) {
+        csrfToken = String(options.cookies[0]);
+        const authToken = options.cookies.length > 1 ? String(options.cookies[1]) : undefined;
+        const parts = [`ct0=${csrfToken}`];
+        if (authToken) parts.push(`auth_token=${authToken}`);
+        cookieHeader = parts.join('; ');
+      }
+
+      await unbookmarkTweet(String(id), {
+        browser: options.browser ? String(options.browser) : undefined,
+        csrfToken,
+        cookieHeader,
+        chromeUserDataDir: options.chromeUserDataDir ? String(options.chromeUserDataDir) : undefined,
+        chromeProfileDirectory: options.chromeProfileDirectory ? String(options.chromeProfileDirectory) : undefined,
+        firefoxProfileDir: options.firefoxProfileDir ? String(options.firefoxProfileDir) : undefined,
+      });
+
+      try {
+        const local = await removeBookmarkFromArchive(String(id));
+        console.log(`\n  ✓ Removed bookmark on X: ${id}`);
+        console.log(`  Local archive: ${local.removed ? 'removed cached record' : 'record not found locally'}`);
+        console.log(`  Remaining bookmarks: ${local.totalRemaining}`);
+        console.log(`  Cache: ${local.cachePath}`);
+        console.log(`  Index: ${local.dbPath}\n`);
+      } catch (error) {
+        throw new Error(
+          `Removed bookmark on X, but failed to update the local archive.\n` +
+          `Recovery: run ft sync or ft index.\n` +
+          `Details: ${(error as Error).message}`
+        );
+      }
+    }));
+
+  // ── likes ───────────────────────────────────────────────────────────────
+
+  const likes = program
+    .command('likes')
+    .description('Sync and query your liked posts as a separate local archive');
+
+  likes
+    .command('sync')
+    .description('Sync liked posts from X into your local likes archive')
+    .option('--max-pages <n>', 'Max pages to fetch', (v: string) => Number(v), 500)
+    .option('--delay-ms <n>', 'Delay between requests in ms', (v: string) => Number(v), 600)
+    .option('--max-minutes <n>', 'Max runtime in minutes', (v: string) => Number(v), 30)
+    .option('--browser <id>', 'Browser to read cookies from (chrome, brave, chromium, firefox)')
+    .option('--cookies <value...>', 'Pass cookies directly: <ct0> [auth_token]')
+    .option('--chrome-user-data-dir <path>', 'Chrome-family user-data directory')
+    .option('--chrome-profile-directory <name>', 'Chrome-family profile directory name')
+    .option('--firefox-profile-dir <path>', 'Firefox profile directory path')
+    .action(safe(async (options) => {
+      const firstRun = isLikesFirstRun();
+      if (firstRun) showSyncWelcome();
+      ensureDataDir();
+
+      const startTime = Date.now();
+      let lastSync: LikesSyncProgress = { page: 0, totalFetched: 0, newAdded: 0, running: true, done: false };
+      const spinner = createSpinner(() => {
+        const elapsed = Math.round((Date.now() - startTime) / 1000);
+        return `Syncing likes...  ${lastSync.newAdded} new  │  page ${lastSync.page}  │  ${elapsed}s`;
+      });
+
+      let csrfToken: string | undefined;
+      let cookieHeader: string | undefined;
+      if (options.cookies && Array.isArray(options.cookies) && options.cookies.length > 0) {
+        csrfToken = String(options.cookies[0]);
+        const authToken = options.cookies.length > 1 ? String(options.cookies[1]) : undefined;
+        const parts = [`ct0=${csrfToken}`];
+        if (authToken) parts.push(`auth_token=${authToken}`);
+        cookieHeader = parts.join('; ');
+      }
+
+      const result = await runWithSpinner(spinner, () => syncLikesGraphQL({
+        maxPages: Number(options.maxPages) || 500,
+        delayMs: Number(options.delayMs) || 600,
+        maxMinutes: Number(options.maxMinutes) || 30,
+        browser: options.browser ? String(options.browser) : undefined,
+        csrfToken,
+        cookieHeader,
+        chromeUserDataDir: options.chromeUserDataDir ? String(options.chromeUserDataDir) : undefined,
+        chromeProfileDirectory: options.chromeProfileDirectory ? String(options.chromeProfileDirectory) : undefined,
+        firefoxProfileDir: options.firefoxProfileDir ? String(options.firefoxProfileDir) : undefined,
+        onProgress: (status: LikesSyncProgress) => {
+          lastSync = status;
+          spinner.update();
+        },
+      }));
+
+      console.log(`\n  ✓ ${result.added} new likes synced (${result.totalLikes} total)`);
+      console.log(`  ${friendlyStopReason(result.stopReason)}`);
+      console.log(`  ✓ Data: ${dataDir()}\n`);
+
+      if (result.added > 0) {
+        process.stderr.write('  Building likes search index...\n');
+        const idx = await buildLikesIndex();
+        process.stderr.write(`  ✓ ${idx.recordCount} likes indexed (${idx.newRecords} new)\n`);
+      }
+    }));
+
+  likes
+    .command('unlike')
+    .description('Unlike one post on X and reconcile the local likes archive')
+    .argument('<id>', 'Liked post id')
+    .option('--browser <id>', 'Browser to read cookies from (chrome, brave, chromium, firefox)')
+    .option('--cookies <value...>', 'Pass cookies directly: <ct0> [auth_token]')
+    .option('--chrome-user-data-dir <path>', 'Chrome-family user-data directory')
+    .option('--chrome-profile-directory <name>', 'Chrome-family profile directory name')
+    .option('--firefox-profile-dir <path>', 'Firefox profile directory path')
+    .action(safe(async (id: string, options) => {
+      let csrfToken: string | undefined;
+      let cookieHeader: string | undefined;
+      if (options.cookies && Array.isArray(options.cookies) && options.cookies.length > 0) {
+        csrfToken = String(options.cookies[0]);
+        const authToken = options.cookies.length > 1 ? String(options.cookies[1]) : undefined;
+        const parts = [`ct0=${csrfToken}`];
+        if (authToken) parts.push(`auth_token=${authToken}`);
+        cookieHeader = parts.join('; ');
+      }
+
+      await unlikeTweet(String(id), {
+        browser: options.browser ? String(options.browser) : undefined,
+        csrfToken,
+        cookieHeader,
+        chromeUserDataDir: options.chromeUserDataDir ? String(options.chromeUserDataDir) : undefined,
+        chromeProfileDirectory: options.chromeProfileDirectory ? String(options.chromeProfileDirectory) : undefined,
+        firefoxProfileDir: options.firefoxProfileDir ? String(options.firefoxProfileDir) : undefined,
+      });
+
+      try {
+        const local = await removeLikeFromArchive(String(id));
+        console.log(`\n  ✓ Unliked on X: ${id}`);
+        console.log(`  Local archive: ${local.removed ? 'removed cached record' : 'record not found locally'}`);
+        console.log(`  Remaining likes: ${local.totalRemaining}`);
+        console.log(`  Cache: ${local.cachePath}`);
+        console.log(`  Index: ${local.dbPath}\n`);
+      } catch (error) {
+        throw new Error(
+          `Unliked on X, but failed to update the local archive.\n` +
+          `Recovery: run ft likes sync or ft likes index.\n` +
+          `Details: ${(error as Error).message}`
+        );
+      }
+    }));
+
+  likes
+    .command('trim')
+    .description('Keep only the latest likes and unlike older posts on X in throttled batches')
+    .option('--keep <n>', 'Number of newest likes to keep locally and remotely', (v: string) => Number(v), 200)
+    .option('--batch-size <n>', 'How many likes to unlike per batch', (v: string) => Number(v), 25)
+    .option('--pause-seconds <n>', 'Seconds to pause between batches', (v: string) => Number(v), 45)
+    .option('--rate-limit-backoff-seconds <n>', 'Seconds to wait before retrying a 429 response', (v: string) => Number(v), 300)
+    .option('--max-rate-limit-retries <n>', 'How many times to retry the same like after a 429', (v: string) => Number(v), 3)
+    .option('--browser <id>', 'Browser to read cookies from (chrome, brave, chromium, firefox)')
+    .option('--cookies <value...>', 'Pass cookies directly: <ct0> [auth_token]')
+    .option('--chrome-user-data-dir <path>', 'Chrome-family user-data directory')
+    .option('--chrome-profile-directory <name>', 'Chrome-family profile directory name')
+    .option('--firefox-profile-dir <path>', 'Firefox profile directory path')
+    .action(safe(async (options) => {
+      if (!requireLikesData()) return;
+
+      let csrfToken: string | undefined;
+      let cookieHeader: string | undefined;
+      if (options.cookies && Array.isArray(options.cookies) && options.cookies.length > 0) {
+        csrfToken = String(options.cookies[0]);
+        const authToken = options.cookies.length > 1 ? String(options.cookies[1]) : undefined;
+        const parts = [`ct0=${csrfToken}`];
+        if (authToken) parts.push(`auth_token=${authToken}`);
+        cookieHeader = parts.join('; ');
+      }
+
+      const keep = Math.max(0, Number(options.keep) || 0);
+      const batchSize = Math.max(1, Number(options.batchSize) || 25);
+      const pauseSeconds = Math.max(0, Number(options.pauseSeconds) || 0);
+      const rateLimitBackoffSeconds = Math.max(1, Number(options.rateLimitBackoffSeconds) || 300);
+      const maxRateLimitRetries = Math.max(0, Number(options.maxRateLimitRetries) || 0);
+
+      console.log(`\n  Trimming likes archive`);
+      console.log(`  Keep newest: ${keep}`);
+      console.log(`  Batch size: ${batchSize}`);
+      console.log(`  Pause: ${pauseSeconds}s\n`);
+
+      const result = await trimLikes({
+        keep,
+        batchSize,
+        pauseSeconds,
+        rateLimitBackoffSeconds,
+        maxRateLimitRetries,
+        browser: options.browser ? String(options.browser) : undefined,
+        csrfToken,
+        cookieHeader,
+        chromeUserDataDir: options.chromeUserDataDir ? String(options.chromeUserDataDir) : undefined,
+        chromeProfileDirectory: options.chromeProfileDirectory ? String(options.chromeProfileDirectory) : undefined,
+        firefoxProfileDir: options.firefoxProfileDir ? String(options.firefoxProfileDir) : undefined,
+        onProgress: (progress) => {
+          if (progress.currentTweetId) {
+            if (progress.pausedSeconds) {
+              process.stderr.write(
+                `  Rate limited on ${progress.currentTweetId} · ` +
+                `${progress.completed}/${progress.totalToRemove} complete · ` +
+                `retrying in ${progress.pausedSeconds}s\n`,
+              );
+              return;
+            }
+            process.stderr.write(
+              `  Batch ${progress.batchNumber}/${progress.batchTotal} · ` +
+              `${progress.completed}/${progress.totalToRemove} complete · ` +
+              `unliking ${progress.currentTweetId}\n`,
+            );
+            return;
+          }
+
+          if (progress.pausedSeconds) {
+            process.stderr.write(
+              `  Batch ${progress.batchNumber}/${progress.batchTotal} complete · ` +
+              `${progress.completed}/${progress.totalToRemove} done · ` +
+              `pausing ${progress.pausedSeconds}s\n`,
+            );
+          }
+        },
+      });
+
+      if (result.removed === 0) {
+        console.log(`  No trim needed. Likes already at or below ${keep}.`);
+        console.log(`  Current likes: ${result.totalAfter}\n`);
+        return;
+      }
+
+      console.log(`  ✓ Removed ${result.removed} old likes on X`);
+      console.log(`  Remaining likes: ${result.totalAfter}`);
+      if (result.keepBoundaryId) console.log(`  Oldest kept like: ${result.keepBoundaryId}`);
+      if (result.cachePath) console.log(`  Cache: ${result.cachePath}`);
+      if (result.dbPath) console.log(`  Index: ${result.dbPath}`);
+      console.log();
+    }));
+
+  likes
+    .command('status')
+    .description('Show likes sync status and data location')
+    .action(safe(async () => {
+      if (!requireLikesData()) return;
+      const view = await getLikesStatusView();
+      console.log(formatLikesStatus(view));
+    }));
+
+  likes
+    .command('search')
+    .description('Full-text search across liked posts')
+    .argument('<query>', 'Search query (supports FTS5 syntax: AND, OR, NOT, "exact phrase")')
+    .option('--author <handle>', 'Filter by author handle')
+    .option('--after <date>', 'Likes after this date (YYYY-MM-DD)')
+    .option('--before <date>', 'Likes before this date (YYYY-MM-DD)')
+    .option('--limit <n>', 'Max results', (v: string) => Number(v), 20)
+    .action(safe(async (query: string, options) => {
+      if (!requireLikesIndex()) return;
+      const results = await searchLikes({
+        query,
+        author: options.author ? String(options.author) : undefined,
+        after: options.after ? String(options.after) : undefined,
+        before: options.before ? String(options.before) : undefined,
+        limit: Number(options.limit) || 20,
+      });
+      console.log(formatLikeSearchResults(results));
+    }));
+
+  likes
+    .command('list')
+    .description('List liked posts with filters')
+    .option('--query <query>', 'Text query (FTS5 syntax)')
+    .option('--author <handle>', 'Filter by author handle')
+    .option('--after <date>', 'Liked after (YYYY-MM-DD)')
+    .option('--before <date>', 'Liked before (YYYY-MM-DD)')
+    .option('--limit <n>', 'Max results', (v: string) => Number(v), 30)
+    .option('--offset <n>', 'Offset into results', (v: string) => Number(v), 0)
+    .option('--json', 'JSON output')
+    .action(safe(async (options) => {
+      if (!requireLikesIndex()) return;
+      const items = await listLikes({
+        query: options.query ? String(options.query) : undefined,
+        author: options.author ? String(options.author) : undefined,
+        after: options.after ? String(options.after) : undefined,
+        before: options.before ? String(options.before) : undefined,
+        limit: Number(options.limit) || 30,
+        offset: Number(options.offset) || 0,
+      });
+      if (options.json) {
+        console.log(JSON.stringify(items, null, 2));
+        return;
+      }
+      for (const item of items) {
+        const summary = item.text.length > 120 ? `${item.text.slice(0, 117)}...` : item.text;
+        console.log(`${item.id}  ${item.authorHandle ? `@${item.authorHandle}` : '@?'}  ${(item.likedAt ?? item.postedAt)?.slice(0, 10) ?? '?'}`);
+        console.log(`  ${summary}`);
+        console.log(`  ${item.url}`);
+        console.log();
+      }
+    }));
+
+  likes
+    .command('show')
+    .description('Show one liked post in detail')
+    .argument('<id>', 'Liked post id')
+    .option('--json', 'JSON output')
+    .action(safe(async (id: string, options) => {
+      if (!requireLikesIndex()) return;
+      const item = await getLikeById(String(id));
+      if (!item) {
+        console.log(`  Like not found: ${String(id)}`);
+        process.exitCode = 1;
+        return;
+      }
+      if (options.json) {
+        console.log(JSON.stringify(item, null, 2));
+        return;
+      }
+      console.log(`${item.id}  ${item.authorHandle ? `@${item.authorHandle}` : '@?'}  ${(item.likedAt ?? item.postedAt)?.slice(0, 10) ?? '?'}`);
+      console.log(item.text);
+      console.log(`\n${item.url}`);
+    }));
+
+  likes
+    .command('index')
+    .description('Rebuild the SQLite search index from the likes JSONL cache')
+    .option('--force', 'Drop and rebuild from scratch')
+    .action(safe(async (options) => {
+      if (!requireLikesData()) return;
+      process.stderr.write('Building likes search index...\n');
+      const result = await buildLikesIndex({ force: Boolean(options.force) });
+      console.log(`Indexed ${result.recordCount} likes (${result.newRecords} new) → ${result.dbPath}`);
     }));
 
   // ── path ────────────────────────────────────────────────────────────────
@@ -1150,7 +1577,7 @@ export function buildCli() {
 
   const bookmarksAlias = program.command('bookmarks').description('(alias) Bookmark commands').helpOption(false);
   for (const cmd of ['sync', 'search', 'list', 'show', 'stats', 'viz', 'classify', 'classify-domains',
-    'categories', 'domains', 'model', 'index', 'auth', 'status', 'path', 'sample', 'fetch-media']) {
+    'categories', 'domains', 'model', 'index', 'auth', 'status', 'path', 'sample', 'fetch-media', 'unbookmark']) {
     bookmarksAlias.command(cmd).description(`Alias for: ft ${cmd}`).allowUnknownOption(true)
       .action(async () => {
         const args = ['node', 'ft', cmd, ...process.argv.slice(4)];

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,9 +3,11 @@ import { Command } from 'commander';
 import { syncTwitterBookmarks } from './bookmarks.js';
 import { getBookmarkStatusView, formatBookmarkStatus } from './bookmarks-service.js';
 import { getLikesStatusView, formatLikesStatus } from './likes-service.js';
+import { getFeedStatusView, formatFeedStatus } from './feed-service.js';
 import { runTwitterOAuthFlow } from './xauth.js';
 import { syncBookmarksGraphQL, syncGaps } from './graphql-bookmarks.js';
 import { syncLikesGraphQL, type LikesSyncProgress } from './graphql-likes.js';
+import { syncFeedGraphQL, type FeedSyncProgress } from './graphql-feed.js';
 import { unlikeTweet, unbookmarkTweet } from './graphql-actions.js';
 import type { SyncProgress, GapFillProgress } from './graphql-bookmarks.js';
 import { fetchBookmarkMediaBatch } from './bookmark-media.js';
@@ -28,6 +30,7 @@ import {
   getLikeById,
   formatLikeSearchResults,
 } from './likes-db.js';
+import { listFeed, getFeedById } from './feed-db.js';
 import { formatClassificationSummary } from './bookmark-classify.js';
 import { classifyWithLlm, classifyDomainsWithLlm } from './bookmark-classify-llm.js';
 import { resolveEngine, detectAvailableEngines } from './engine.js';
@@ -43,9 +46,11 @@ import {
   dataDir,
   ensureDataDir,
   isFirstRun,
+  isFeedFirstRun,
   isLikesFirstRun,
   twitterBookmarksIndexPath,
   twitterBackfillStatePath,
+  twitterFeedIndexPath,
   twitterLikesIndexPath,
   mdDir,
 } from './paths.js';
@@ -109,6 +114,8 @@ const FRIENDLY_STOP_REASONS: Record<string, string> = {
   'caught up to newest stored bookmark': 'All caught up \u2014 no new bookmarks since last sync.',
   'no new bookmarks (stale)': 'Sync complete \u2014 reached the end of new bookmarks.',
   'end of bookmarks': 'Sync complete \u2014 all bookmarks fetched.',
+  'end of feed': 'Sync complete \u2014 all requested feed pages fetched.',
+  'no tweet entries found': 'Sync complete \u2014 no supported tweet entries were returned.',
   'max runtime reached': 'Paused after 30 minutes. Run again to continue.',
   'max pages reached': 'Paused after reaching page limit. Run again to continue.',
   'target additions reached': 'Reached target bookmark count.',
@@ -390,6 +397,33 @@ function requireLikesIndex(): boolean {
   Likes search index not built yet.
 
   Run: ft likes index
+`);
+    process.exitCode = 1;
+    return false;
+  }
+  return true;
+}
+
+function requireFeedData(): boolean {
+  if (isFeedFirstRun()) {
+    console.log(`
+  No feed items synced yet.
+
+  Run: ft feed sync
+`);
+    process.exitCode = 1;
+    return false;
+  }
+  return true;
+}
+
+function requireFeedIndex(): boolean {
+  if (!requireFeedData()) return false;
+  if (!fs.existsSync(twitterFeedIndexPath())) {
+    console.log(`
+  Feed index not built yet.
+
+  Run: ft feed sync
 `);
     process.exitCode = 1;
     return false;
@@ -1401,6 +1435,125 @@ export function buildCli() {
       process.stderr.write('Building likes search index...\n');
       const result = await buildLikesIndex({ force: Boolean(options.force) });
       console.log(`Indexed ${result.recordCount} likes (${result.newRecords} new) → ${result.dbPath}`);
+    }));
+
+  // ── feed ───────────────────────────────────────────────────────────────
+
+  const feed = program
+    .command('feed')
+    .description('Sync and browse your X Home timeline as a local read-only archive');
+
+  feed
+    .command('sync')
+    .description('Fetch Home timeline tweets from X into your local feed archive')
+    .option('--max-pages <n>', 'Max pages to fetch', (v: string) => Number(v), 5)
+    .option('--delay-ms <n>', 'Delay between requests in ms', (v: string) => Number(v), 600)
+    .option('--max-minutes <n>', 'Max runtime in minutes', (v: string) => Number(v), 5)
+    .option('--browser <id>', 'Browser to read cookies from (chrome, brave, chromium, firefox)')
+    .option('--cookies <value...>', 'Pass cookies directly: <ct0> [auth_token]')
+    .option('--chrome-user-data-dir <path>', 'Chrome-family user-data directory')
+    .option('--chrome-profile-directory <name>', 'Chrome-family profile directory name')
+    .option('--firefox-profile-dir <path>', 'Firefox profile directory path')
+    .action(safe(async (options) => {
+      const firstRun = isFeedFirstRun();
+      if (firstRun) showSyncWelcome();
+      ensureDataDir();
+
+      const startTime = Date.now();
+      let lastSync: FeedSyncProgress = { page: 0, totalFetched: 0, newAdded: 0, skippedEntries: 0, running: true, done: false };
+      const spinner = createSpinner(() => {
+        const elapsed = Math.round((Date.now() - startTime) / 1000);
+        return `Syncing feed...  ${lastSync.newAdded} new  │  ${lastSync.skippedEntries} skipped  │  page ${lastSync.page}  │  ${elapsed}s`;
+      });
+
+      let csrfToken: string | undefined;
+      let cookieHeader: string | undefined;
+      if (options.cookies && Array.isArray(options.cookies) && options.cookies.length > 0) {
+        csrfToken = String(options.cookies[0]);
+        const authToken = options.cookies.length > 1 ? String(options.cookies[1]) : undefined;
+        const parts = [`ct0=${csrfToken}`];
+        if (authToken) parts.push(`auth_token=${authToken}`);
+        cookieHeader = parts.join('; ');
+      }
+
+      const result = await runWithSpinner(spinner, () => syncFeedGraphQL({
+        maxPages: Number(options.maxPages) || 5,
+        delayMs: Number(options.delayMs) || 600,
+        maxMinutes: Number(options.maxMinutes) || 5,
+        browser: options.browser ? String(options.browser) : undefined,
+        csrfToken,
+        cookieHeader,
+        chromeUserDataDir: options.chromeUserDataDir ? String(options.chromeUserDataDir) : undefined,
+        chromeProfileDirectory: options.chromeProfileDirectory ? String(options.chromeProfileDirectory) : undefined,
+        firefoxProfileDir: options.firefoxProfileDir ? String(options.firefoxProfileDir) : undefined,
+        onProgress: (status: FeedSyncProgress) => {
+          lastSync = status;
+          spinner.update();
+        },
+      }));
+
+      console.log(`\n  ✓ ${result.added} new feed items synced (${result.totalItems} total)`);
+      console.log(`  Skipped non-tweet entries: ${result.skippedEntries}`);
+      console.log(`  ${friendlyStopReason(result.stopReason)}`);
+      console.log(`  ✓ Data: ${dataDir()}\n`);
+    }));
+
+  feed
+    .command('status')
+    .description('Show feed sync status and data location')
+    .action(safe(async () => {
+      if (!requireFeedData()) return;
+      const view = await getFeedStatusView();
+      console.log(formatFeedStatus(view));
+    }));
+
+  feed
+    .command('list')
+    .description('List cached Home timeline tweets')
+    .option('--limit <n>', 'Max results', (v: string) => Number(v), 30)
+    .option('--offset <n>', 'Offset into results', (v: string) => Number(v), 0)
+    .option('--json', 'JSON output')
+    .action(safe(async (options) => {
+      if (!requireFeedIndex()) return;
+      const items = await listFeed({
+        limit: Number(options.limit) || 30,
+        offset: Number(options.offset) || 0,
+      });
+      if (options.json) {
+        console.log(JSON.stringify(items, null, 2));
+        return;
+      }
+      for (const item of items) {
+        const summary = item.text.length > 120 ? `${item.text.slice(0, 117)}...` : item.text;
+        console.log(`${item.id}  ${item.authorHandle ? `@${item.authorHandle}` : '@?'}  ${(item.postedAt ?? item.syncedAt)?.slice(0, 10) ?? '?'}`);
+        console.log(`  ${summary}`);
+        console.log(`  ${item.url}`);
+        console.log();
+      }
+    }));
+
+  feed
+    .command('show')
+    .description('Show one cached feed item in detail')
+    .argument('<id>', 'Feed item id')
+    .option('--json', 'JSON output')
+    .action(safe(async (id: string, options) => {
+      if (!requireFeedIndex()) return;
+      const item = await getFeedById(String(id));
+      if (!item) {
+        console.log(`  Feed item not found: ${String(id)}`);
+        process.exitCode = 1;
+        return;
+      }
+      if (options.json) {
+        console.log(JSON.stringify(item, null, 2));
+        return;
+      }
+      console.log(`${item.id}  ${item.authorHandle ? `@${item.authorHandle}` : '@?'}  ${(item.postedAt ?? item.syncedAt)?.slice(0, 10) ?? '?'}`);
+      if (item.authorName) console.log(item.authorName);
+      console.log(item.text);
+      console.log(`\n${item.url}`);
+      console.log(`sortIndex: ${item.sortIndex ?? 'unknown'}  page: ${item.fetchPage ?? '?'}  position: ${item.fetchPosition ?? '?'}`);
     }));
 
   // ── path ────────────────────────────────────────────────────────────────

--- a/src/feed-db.ts
+++ b/src/feed-db.ts
@@ -1,0 +1,290 @@
+import type { Database } from 'sql.js';
+import { openDb, saveDb } from './db.js';
+import { readJsonLines } from './fs.js';
+import { twitterFeedCachePath, twitterFeedIndexPath } from './paths.js';
+import type { FeedRecord } from './types.js';
+
+export interface FeedTimelineItem {
+  id: string;
+  tweetId: string;
+  url: string;
+  text: string;
+  authorHandle?: string;
+  authorName?: string;
+  authorProfileImageUrl?: string;
+  postedAt?: string | null;
+  syncedAt: string;
+  sortIndex?: string | null;
+  fetchPage?: number | null;
+  fetchPosition?: number | null;
+  links: string[];
+  mediaCount: number;
+  linkCount: number;
+  likeCount?: number | null;
+  repostCount?: number | null;
+  replyCount?: number | null;
+  quoteCount?: number | null;
+  bookmarkCount?: number | null;
+  viewCount?: number | null;
+}
+
+export interface FeedTimelineFilters {
+  limit?: number;
+  offset?: number;
+}
+
+const SCHEMA_VERSION = 1;
+
+function parseJsonArray(value: unknown): string[] {
+  if (typeof value !== 'string' || !value.trim()) return [];
+  try {
+    const parsed = JSON.parse(value);
+    return Array.isArray(parsed) ? parsed.filter((entry): entry is string => typeof entry === 'string') : [];
+  } catch {
+    return [];
+  }
+}
+
+function mapTimelineRow(row: unknown[]): FeedTimelineItem {
+  return {
+    id: row[0] as string,
+    tweetId: row[1] as string,
+    url: row[2] as string,
+    text: row[3] as string,
+    authorHandle: (row[4] as string) ?? undefined,
+    authorName: (row[5] as string) ?? undefined,
+    authorProfileImageUrl: (row[6] as string) ?? undefined,
+    postedAt: (row[7] as string) ?? null,
+    syncedAt: row[8] as string,
+    sortIndex: (row[9] as string) ?? null,
+    fetchPage: row[10] as number | null,
+    fetchPosition: row[11] as number | null,
+    links: parseJsonArray(row[12]),
+    mediaCount: Number(row[13] ?? 0),
+    linkCount: Number(row[14] ?? 0),
+    likeCount: row[15] as number | null,
+    repostCount: row[16] as number | null,
+    replyCount: row[17] as number | null,
+    quoteCount: row[18] as number | null,
+    bookmarkCount: row[19] as number | null,
+    viewCount: row[20] as number | null,
+  };
+}
+
+function feedSortClause(): string {
+  return `
+    ORDER BY
+      COALESCE(NULLIF(f.synced_at, ''), '') DESC,
+      CASE
+        WHEN f.sort_index GLOB '[0-9]*' THEN CAST(f.sort_index AS INTEGER)
+        ELSE -1
+      END DESC,
+      COALESCE(f.fetch_page, 2147483647) ASC,
+      COALESCE(f.fetch_position, 2147483647) ASC,
+      CAST(f.tweet_id AS INTEGER) DESC
+  `;
+}
+
+function initSchema(db: Database): void {
+  db.run(`CREATE TABLE IF NOT EXISTS meta (key TEXT PRIMARY KEY, value TEXT)`);
+  db.run(`CREATE TABLE IF NOT EXISTS feed (
+    id TEXT PRIMARY KEY,
+    tweet_id TEXT NOT NULL,
+    url TEXT NOT NULL,
+    text TEXT NOT NULL,
+    author_handle TEXT,
+    author_name TEXT,
+    author_profile_image_url TEXT,
+    posted_at TEXT,
+    synced_at TEXT NOT NULL,
+    sort_index TEXT,
+    fetch_page INTEGER,
+    fetch_position INTEGER,
+    conversation_id TEXT,
+    in_reply_to_status_id TEXT,
+    quoted_status_id TEXT,
+    language TEXT,
+    like_count INTEGER,
+    repost_count INTEGER,
+    reply_count INTEGER,
+    quote_count INTEGER,
+    bookmark_count INTEGER,
+    view_count INTEGER,
+    media_count INTEGER DEFAULT 0,
+    link_count INTEGER DEFAULT 0,
+    links_json TEXT,
+    tags_json TEXT,
+    ingested_via TEXT
+  )`);
+  db.run(`CREATE INDEX IF NOT EXISTS idx_feed_synced ON feed(synced_at)`);
+  db.run(`CREATE INDEX IF NOT EXISTS idx_feed_sort_index ON feed(sort_index)`);
+  db.run(`CREATE INDEX IF NOT EXISTS idx_feed_author ON feed(author_handle)`);
+  db.run(`REPLACE INTO meta VALUES ('schema_version', '${SCHEMA_VERSION}')`);
+}
+
+function insertRecord(db: Database, record: FeedRecord): void {
+  db.run(
+    `INSERT OR REPLACE INTO feed VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+    [
+      record.id,
+      record.tweetId,
+      record.url,
+      record.text,
+      record.authorHandle ?? null,
+      record.authorName ?? null,
+      record.authorProfileImageUrl ?? null,
+      record.postedAt ?? null,
+      record.syncedAt,
+      record.sortIndex ?? null,
+      record.fetchPage ?? null,
+      record.fetchPosition ?? null,
+      record.conversationId ?? null,
+      record.inReplyToStatusId ?? null,
+      record.quotedStatusId ?? null,
+      record.language ?? null,
+      record.engagement?.likeCount ?? null,
+      record.engagement?.repostCount ?? null,
+      record.engagement?.replyCount ?? null,
+      record.engagement?.quoteCount ?? null,
+      record.engagement?.bookmarkCount ?? null,
+      record.engagement?.viewCount ?? null,
+      record.media?.length ?? 0,
+      record.links?.length ?? 0,
+      record.links?.length ? JSON.stringify(record.links) : null,
+      record.tags?.length ? JSON.stringify(record.tags) : null,
+      record.ingestedVia ?? null,
+    ],
+  );
+}
+
+export async function buildFeedIndex(options?: { force?: boolean }): Promise<{ dbPath: string; recordCount: number; newRecords: number }> {
+  const cachePath = twitterFeedCachePath();
+  const dbPath = twitterFeedIndexPath();
+  const records = await readJsonLines<FeedRecord>(cachePath);
+  const db = await openDb(dbPath);
+
+  try {
+    if (options?.force) {
+      db.run('DROP TABLE IF EXISTS feed');
+      db.run('DROP TABLE IF EXISTS meta');
+    }
+
+    initSchema(db);
+
+    const existingIds = new Set<string>();
+    try {
+      const rows = db.exec('SELECT id FROM feed');
+      for (const row of (rows[0]?.values ?? [])) existingIds.add(row[0] as string);
+    } catch {}
+
+    const newRecords = records.filter((record) => !existingIds.has(record.id));
+    if (records.length > 0) {
+      db.run('BEGIN TRANSACTION');
+      try {
+        for (const record of records) insertRecord(db, record);
+        db.run('COMMIT');
+      } catch (error) {
+        db.run('ROLLBACK');
+        throw error;
+      }
+    }
+
+    saveDb(db, dbPath);
+    const totalRows = db.exec('SELECT COUNT(*) FROM feed')[0]?.values[0]?.[0] as number;
+    return { dbPath, recordCount: totalRows, newRecords: newRecords.length };
+  } finally {
+    db.close();
+  }
+}
+
+export async function listFeed(filters: FeedTimelineFilters = {}): Promise<FeedTimelineItem[]> {
+  const db = await openDb(twitterFeedIndexPath());
+  const limit = filters.limit ?? 30;
+  const offset = filters.offset ?? 0;
+
+  try {
+    const rows = db.exec(
+      `
+        SELECT
+          f.id,
+          f.tweet_id,
+          f.url,
+          f.text,
+          f.author_handle,
+          f.author_name,
+          f.author_profile_image_url,
+          f.posted_at,
+          f.synced_at,
+          f.sort_index,
+          f.fetch_page,
+          f.fetch_position,
+          f.links_json,
+          f.media_count,
+          f.link_count,
+          f.like_count,
+          f.repost_count,
+          f.reply_count,
+          f.quote_count,
+          f.bookmark_count,
+          f.view_count
+        FROM feed f
+        ${feedSortClause()}
+        LIMIT ?
+        OFFSET ?
+      `,
+      [limit, offset],
+    );
+    if (!rows.length) return [];
+    return rows[0].values.map((row) => mapTimelineRow(row));
+  } finally {
+    db.close();
+  }
+}
+
+export async function countFeed(): Promise<number> {
+  const db = await openDb(twitterFeedIndexPath());
+  try {
+    const rows = db.exec('SELECT COUNT(*) FROM feed');
+    return Number(rows[0]?.values?.[0]?.[0] ?? 0);
+  } finally {
+    db.close();
+  }
+}
+
+export async function getFeedById(id: string): Promise<FeedTimelineItem | null> {
+  const db = await openDb(twitterFeedIndexPath());
+  try {
+    const rows = db.exec(
+      `SELECT
+        f.id,
+        f.tweet_id,
+        f.url,
+        f.text,
+        f.author_handle,
+        f.author_name,
+        f.author_profile_image_url,
+        f.posted_at,
+        f.synced_at,
+        f.sort_index,
+        f.fetch_page,
+        f.fetch_position,
+        f.links_json,
+        f.media_count,
+        f.link_count,
+        f.like_count,
+        f.repost_count,
+        f.reply_count,
+        f.quote_count,
+        f.bookmark_count,
+        f.view_count
+      FROM feed f
+      WHERE f.id = ?
+      LIMIT 1`,
+      [id],
+    );
+    const row = rows[0]?.values?.[0];
+    return row ? mapTimelineRow(row) : null;
+  } finally {
+    db.close();
+  }
+}

--- a/src/feed-service.ts
+++ b/src/feed-service.ts
@@ -1,0 +1,31 @@
+import { getTwitterFeedStatus, latestFeedSyncAt } from './feed.js';
+
+export interface FeedStatusView {
+  itemCount: number;
+  skippedEntries: number;
+  lastUpdated: string | null;
+  mode: string;
+  cachePath: string;
+}
+
+export async function getFeedStatusView(): Promise<FeedStatusView> {
+  const status = await getTwitterFeedStatus();
+  return {
+    itemCount: status.totalItems,
+    skippedEntries: status.totalSkippedEntries,
+    lastUpdated: latestFeedSyncAt(status),
+    mode: 'Read-only Home timeline sync via browser session',
+    cachePath: status.cachePath,
+  };
+}
+
+export function formatFeedStatus(view: FeedStatusView): string {
+  return [
+    'Feed',
+    `  items: ${view.itemCount}`,
+    `  skipped entries: ${view.skippedEntries}`,
+    `  last updated: ${view.lastUpdated ?? 'never'}`,
+    `  sync mode: ${view.mode}`,
+    `  cache: ${view.cachePath}`,
+  ].join('\n');
+}

--- a/src/feed.ts
+++ b/src/feed.ts
@@ -1,0 +1,46 @@
+import { pathExists, readJson, readJsonLines } from './fs.js';
+import { twitterFeedCachePath, twitterFeedMetaPath, twitterFeedStatePath } from './paths.js';
+import type { FeedBackfillState, FeedCacheMeta, FeedRecord } from './types.js';
+
+export function latestFeedSyncAt(meta?: Pick<FeedCacheMeta, 'lastSyncAt'> | null): string | null {
+  return meta?.lastSyncAt ?? null;
+}
+
+export async function getTwitterFeedStatus(): Promise<FeedCacheMeta & { cachePath: string; metaPath: string }> {
+  const cachePath = twitterFeedCachePath();
+  const metaPath = twitterFeedMetaPath();
+  const statePath = twitterFeedStatePath();
+  const meta = (await pathExists(metaPath))
+    ? await readJson<FeedCacheMeta>(metaPath)
+    : undefined;
+  const state = (await pathExists(statePath))
+    ? await readJson<FeedBackfillState>(statePath)
+    : undefined;
+  const metaUpdatedAt = latestFeedSyncAt(meta);
+  const graphQlStatusIsNewer = Boolean(
+    state?.lastRunAt && (!metaUpdatedAt || Date.parse(state.lastRunAt) > Date.parse(metaUpdatedAt))
+  );
+
+  if (graphQlStatusIsNewer) {
+    const cache = await readJsonLines<FeedRecord>(cachePath);
+    return {
+      provider: 'twitter',
+      schemaVersion: 1,
+      lastSyncAt: state?.lastRunAt,
+      totalItems: cache.length,
+      totalSkippedEntries: state?.totalSkippedEntries ?? meta?.totalSkippedEntries ?? 0,
+      cachePath,
+      metaPath,
+    };
+  }
+
+  return {
+    provider: 'twitter',
+    schemaVersion: 1,
+    lastSyncAt: meta?.lastSyncAt,
+    totalItems: meta?.totalItems ?? 0,
+    totalSkippedEntries: meta?.totalSkippedEntries ?? 0,
+    cachePath,
+    metaPath,
+  };
+}

--- a/src/graphql-actions.ts
+++ b/src/graphql-actions.ts
@@ -1,0 +1,94 @@
+import { buildGraphqlUrl, buildXGraphqlHeaders, resolveXSessionAuth, type XSessionOptions } from './x-graphql.js';
+
+interface MutationSpec {
+  queryId: string;
+  operationName: string;
+  responseKey: string;
+  failureLabel: string;
+}
+
+export class RemoteTweetActionError extends Error {
+  status?: number;
+
+  constructor(message: string, options: { status?: number } = {}) {
+    super(message);
+    this.name = 'RemoteTweetActionError';
+    this.status = options.status;
+  }
+}
+
+export interface RemoteTweetActionResult {
+  tweetId: string;
+  operation: 'unlike' | 'unbookmark';
+  responseKey: string;
+}
+
+const UNLIKE_MUTATION: MutationSpec = {
+  queryId: 'ZYKSe-w7KEslx3JhSIk5LA',
+  operationName: 'UnfavoriteTweet',
+  responseKey: 'unfavorite_tweet',
+  failureLabel: 'Failed to unlike tweet',
+};
+
+const UNBOOKMARK_MUTATION: MutationSpec = {
+  queryId: 'Wlmlj2-xzyS1GN3a6cj-mQ',
+  operationName: 'DeleteBookmark',
+  responseKey: 'tweet_bookmark_delete',
+  failureLabel: 'Failed to delete bookmark',
+};
+
+async function runMutation(
+  spec: MutationSpec,
+  tweetId: string,
+  options: XSessionOptions = {},
+): Promise<RemoteTweetActionResult> {
+  const session = resolveXSessionAuth(options);
+  const response = await fetch(buildGraphqlUrl(spec.queryId, spec.operationName), {
+    method: 'POST',
+    headers: buildXGraphqlHeaders(session),
+    body: JSON.stringify({
+      variables: { tweet_id: tweetId },
+      queryId: spec.queryId,
+    }),
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new RemoteTweetActionError(
+      `${spec.failureLabel} (${response.status}).\n` +
+      `Response: ${text.slice(0, 300)}\n\n` +
+      (response.status === 401 || response.status === 403
+        ? 'Fix: Your X session may have expired. Open your browser, go to https://x.com, and make sure you are logged in. Then retry.'
+        : 'This may be a temporary X issue. Try again in a few minutes.'),
+      { status: response.status },
+    );
+  }
+
+  const json = await response.json() as Record<string, any>;
+  if (json?.data?.[spec.responseKey] !== 'Done') {
+    throw new RemoteTweetActionError(
+      `${spec.failureLabel}.\n` +
+      `Response: ${JSON.stringify(json).slice(0, 300)}`,
+    );
+  }
+
+  return {
+    tweetId,
+    operation: spec === UNLIKE_MUTATION ? 'unlike' : 'unbookmark',
+    responseKey: spec.responseKey,
+  };
+}
+
+export async function unlikeTweet(
+  tweetId: string,
+  options: XSessionOptions = {},
+): Promise<RemoteTweetActionResult> {
+  return runMutation(UNLIKE_MUTATION, tweetId, options);
+}
+
+export async function unbookmarkTweet(
+  tweetId: string,
+  options: XSessionOptions = {},
+): Promise<RemoteTweetActionResult> {
+  return runMutation(UNBOOKMARK_MUTATION, tweetId, options);
+}

--- a/src/graphql-actions.ts
+++ b/src/graphql-actions.ts
@@ -1,4 +1,4 @@
-import { buildGraphqlUrl, buildXGraphqlHeaders, resolveXSessionAuth, type XSessionOptions } from './x-graphql.js';
+import { buildGraphqlUrl, buildXGraphqlHeaders, fetchXResource, resolveXSessionAuth, type XSessionOptions } from './x-graphql.js';
 
 interface MutationSpec {
   queryId: string;
@@ -43,7 +43,7 @@ async function runMutation(
   options: XSessionOptions = {},
 ): Promise<RemoteTweetActionResult> {
   const session = resolveXSessionAuth(options);
-  const response = await fetch(buildGraphqlUrl(spec.queryId, spec.operationName), {
+  const response = await fetchXResource(buildGraphqlUrl(spec.queryId, spec.operationName), {
     method: 'POST',
     headers: buildXGraphqlHeaders(session),
     body: JSON.stringify({

--- a/src/graphql-bookmarks.ts
+++ b/src/graphql-bookmarks.ts
@@ -4,6 +4,7 @@ import { loadChromeSessionConfig } from './config.js';
 import { extractChromeXCookies } from './chrome-cookies.js';
 import { extractFirefoxXCookies } from './firefox-cookies.js';
 import { parseTimestampMs } from './date-utils.js';
+import { fetchXResource } from './x-graphql.js';
 import type { BookmarkBackfillState, BookmarkCacheMeta, BookmarkRecord, QuotedTweetSnapshot } from './types.js';
 import { exportBookmarksForSyncSeed, updateQuotedTweets, updateBookmarkText } from './bookmarks-db.js';
 
@@ -375,7 +376,7 @@ async function fetchPageWithRetry(csrfToken: string, cursor?: string, cookieHead
   let lastError: Error | undefined;
 
   for (let attempt = 0; attempt < 4; attempt++) {
-    const response = await fetch(buildUrl(cursor, pageSize), { headers: buildHeaders(csrfToken, cookieHeader) });
+    const response = await fetchXResource(buildUrl(cursor, pageSize), { headers: buildHeaders(csrfToken, cookieHeader) });
 
     if (response.status === 429) {
       const waitSec = Math.min(15 * Math.pow(2, attempt), 120);

--- a/src/graphql-feed.ts
+++ b/src/graphql-feed.ts
@@ -1,0 +1,553 @@
+import { pathExists, readJson, readJsonLines, writeJson, writeJsonLines } from './fs.js';
+import { ensureDataDir, twitterFeedCachePath, twitterFeedIndexPath, twitterFeedMetaPath, twitterFeedStatePath } from './paths.js';
+import { resolveXSessionAuth, buildGraphqlUrl, buildXGraphqlHeaders, fetchXResource, type XSessionOptions } from './x-graphql.js';
+import type { FeedBackfillState, FeedCacheMeta, FeedRecord } from './types.js';
+import { buildFeedIndex } from './feed-db.js';
+
+const HOME_TIMELINE_QUERY_ID = 'Fb7fyZ9MMCzvf_bNtwNdXA';
+const HOME_TIMELINE_OPERATION = 'HomeTimeline';
+
+const HOME_TIMELINE_FEATURES = {
+  rweb_video_screen_enabled: false,
+  profile_label_improvements_pcf_label_in_post_enabled: true,
+  responsive_web_profile_redirect_enabled: false,
+  rweb_tipjar_consumption_enabled: false,
+  verified_phone_label_enabled: false,
+  creator_subscriptions_tweet_preview_api_enabled: true,
+  responsive_web_graphql_timeline_navigation_enabled: true,
+  responsive_web_graphql_skip_user_profile_image_extensions_enabled: false,
+  premium_content_api_read_enabled: false,
+  communities_web_enable_tweet_community_results_fetch: true,
+  c9s_tweet_anatomy_moderator_badge_enabled: true,
+  responsive_web_grok_analyze_button_fetch_trends_enabled: false,
+  responsive_web_grok_analyze_post_followups_enabled: true,
+  responsive_web_jetfuel_frame: true,
+  responsive_web_grok_share_attachment_enabled: true,
+  responsive_web_grok_annotations_enabled: true,
+  articles_preview_enabled: true,
+  responsive_web_edit_tweet_api_enabled: true,
+  graphql_is_translatable_rweb_tweet_is_translatable_enabled: true,
+  view_counts_everywhere_api_enabled: true,
+  longform_notetweets_consumption_enabled: true,
+  responsive_web_twitter_article_tweet_consumption_enabled: true,
+  content_disclosure_indicator_enabled: true,
+  content_disclosure_ai_generated_indicator_enabled: true,
+  responsive_web_grok_show_grok_translated_post: true,
+  responsive_web_grok_analysis_button_from_backend: true,
+  post_ctas_fetch_enabled: true,
+  freedom_of_speech_not_reach_fetch_enabled: true,
+  standardized_nudges_misinfo: true,
+  tweet_with_visibility_results_prefer_gql_limited_actions_policy_enabled: true,
+  longform_notetweets_rich_text_read_enabled: true,
+  longform_notetweets_inline_media_enabled: false,
+  responsive_web_grok_image_annotation_enabled: true,
+  responsive_web_grok_imagine_annotation_enabled: true,
+  responsive_web_grok_community_note_auto_translation_is_enabled: true,
+  responsive_web_enhance_cards_enabled: false,
+};
+
+interface FeedPageResult {
+  records: FeedRecord[];
+  nextCursor?: string;
+  skippedEntries: number;
+  seenTweetIds: string[];
+}
+
+export interface FeedSyncOptions extends XSessionOptions {
+  maxPages?: number;
+  delayMs?: number;
+  maxMinutes?: number;
+  pageSize?: number;
+  onProgress?: (status: FeedSyncProgress) => void;
+}
+
+export interface FeedSyncProgress {
+  page: number;
+  totalFetched: number;
+  newAdded: number;
+  skippedEntries: number;
+  running: boolean;
+  done: boolean;
+  stopReason?: string;
+}
+
+export interface FeedSyncResult {
+  added: number;
+  totalItems: number;
+  skippedEntries: number;
+  pages: number;
+  stopReason: string;
+  cachePath: string;
+  statePath: string;
+  dbPath: string;
+}
+
+function buildFirstPageUrl(count = 20): string {
+  const variables = {
+    count,
+    includePromotedContent: true,
+    requestContext: 'launch',
+    withCommunity: true,
+  };
+  const params = new URLSearchParams({
+    variables: JSON.stringify(variables),
+    features: JSON.stringify(HOME_TIMELINE_FEATURES),
+  });
+  return `${buildGraphqlUrl(HOME_TIMELINE_QUERY_ID, HOME_TIMELINE_OPERATION)}?${params}`;
+}
+
+function buildPageBody(cursor: string, count = 20, seenTweetIds: string[] = []): string {
+  return JSON.stringify({
+    variables: {
+      count,
+      cursor,
+      includePromotedContent: true,
+      withCommunity: true,
+      seenTweetIds,
+    },
+    features: HOME_TIMELINE_FEATURES,
+    queryId: HOME_TIMELINE_QUERY_ID,
+  });
+}
+
+function parseSnowflake(value?: string | null): bigint | null {
+  if (!value || !/^\d+$/.test(value)) return null;
+  try {
+    return BigInt(value);
+  } catch {
+    return null;
+  }
+}
+
+function scoreRecord(record: FeedRecord): number {
+  let score = 0;
+  if (record.postedAt) score += 2;
+  if (record.authorProfileImageUrl) score += 2;
+  if (record.author) score += 3;
+  if (record.engagement) score += 3;
+  if ((record.mediaObjects?.length ?? 0) > 0) score += 3;
+  if ((record.links?.length ?? 0) > 0) score += 2;
+  return score;
+}
+
+export function mergeFeedRecord(existing: FeedRecord | undefined, incoming: FeedRecord): FeedRecord {
+  if (!existing) return incoming;
+  const richer = scoreRecord(incoming) >= scoreRecord(existing)
+    ? { ...existing, ...incoming }
+    : { ...incoming, ...existing };
+  return {
+    ...richer,
+    syncedAt: incoming.syncedAt,
+    sortIndex: incoming.sortIndex ?? richer.sortIndex ?? null,
+    fetchPage: incoming.fetchPage ?? richer.fetchPage ?? null,
+    fetchPosition: incoming.fetchPosition ?? richer.fetchPosition ?? null,
+  };
+}
+
+function compareFeedOrderDesc(a: FeedRecord, b: FeedRecord): number {
+  const syncA = Date.parse(a.syncedAt);
+  const syncB = Date.parse(b.syncedAt);
+  if (Number.isFinite(syncA) && Number.isFinite(syncB) && syncA !== syncB) return syncB - syncA;
+
+  const sortA = parseSnowflake(a.sortIndex);
+  const sortB = parseSnowflake(b.sortIndex);
+  if (sortA != null && sortB != null && sortA !== sortB) return sortA > sortB ? -1 : 1;
+
+  const pageA = a.fetchPage ?? Number.MAX_SAFE_INTEGER;
+  const pageB = b.fetchPage ?? Number.MAX_SAFE_INTEGER;
+  if (pageA !== pageB) return pageA - pageB;
+
+  const posA = a.fetchPosition ?? Number.MAX_SAFE_INTEGER;
+  const posB = b.fetchPosition ?? Number.MAX_SAFE_INTEGER;
+  if (posA !== posB) return posA - posB;
+
+  const idA = parseSnowflake(a.tweetId ?? a.id);
+  const idB = parseSnowflake(b.tweetId ?? b.id);
+  if (idA != null && idB != null && idA !== idB) return idA > idB ? -1 : 1;
+
+  return String(a.id).localeCompare(String(b.id));
+}
+
+export function mergeFeedRecords(existing: FeedRecord[], incoming: FeedRecord[]): { merged: FeedRecord[]; added: number } {
+  const byId = new Map(existing.map((r) => [r.id, r]));
+  let added = 0;
+  for (const record of incoming) {
+    const prev = byId.get(record.id);
+    if (!prev) added += 1;
+    byId.set(record.id, mergeFeedRecord(prev, record));
+  }
+  const merged = Array.from(byId.values());
+  merged.sort(compareFeedOrderDesc);
+  return { merged, added };
+}
+
+function extractAuthor(userResult: any, now: string) {
+  if (!userResult) return undefined;
+  const authorHandle = userResult?.core?.screen_name ?? userResult?.legacy?.screen_name;
+  const authorName = userResult?.core?.name ?? userResult?.legacy?.name;
+  const authorProfileImageUrl =
+    userResult?.avatar?.image_url ??
+    userResult?.legacy?.profile_image_url_https ??
+    userResult?.legacy?.profile_image_url;
+
+  return {
+    id: userResult.rest_id,
+    handle: authorHandle,
+    name: authorName,
+    profileImageUrl: authorProfileImageUrl,
+    bio: userResult?.legacy?.description,
+    followerCount: userResult?.legacy?.followers_count,
+    followingCount: userResult?.legacy?.friends_count,
+    isVerified: Boolean(userResult?.is_blue_verified ?? userResult?.legacy?.verified),
+    location:
+      typeof userResult?.location === 'object'
+        ? userResult.location.location
+        : userResult?.legacy?.location,
+    snapshotAt: now,
+  };
+}
+
+function extractQuotedTweet(quotedResult: any): FeedRecord['quotedTweet'] | undefined {
+  const quotedTweet = quotedResult?.tweet ?? quotedResult;
+  const quotedLegacy = quotedTweet?.legacy;
+  if (!quotedLegacy) return undefined;
+  const quotedTweetId = quotedLegacy.id_str ?? quotedTweet?.rest_id;
+  if (!quotedTweetId) return undefined;
+  const quotedUser = quotedTweet?.core?.user_results?.result;
+  const authorHandle = quotedUser?.core?.screen_name ?? quotedUser?.legacy?.screen_name;
+  const authorName = quotedUser?.core?.name ?? quotedUser?.legacy?.name;
+  const authorProfileImageUrl =
+    quotedUser?.avatar?.image_url ??
+    quotedUser?.legacy?.profile_image_url_https ??
+    quotedUser?.legacy?.profile_image_url;
+  const mediaEntities = quotedLegacy?.extended_entities?.media ?? quotedLegacy?.entities?.media ?? [];
+
+  return {
+    id: quotedTweetId,
+    text: quotedTweet?.note_tweet?.note_tweet_results?.result?.text ?? quotedLegacy.full_text ?? quotedLegacy.text ?? '',
+    authorHandle,
+    authorName,
+    authorProfileImageUrl,
+    postedAt: quotedLegacy.created_at ?? null,
+    media: mediaEntities.map((m: any) => m.media_url_https ?? m.media_url).filter(Boolean),
+    mediaObjects: mediaEntities.map((m: any) => ({
+      type: m.type,
+      url: m.media_url_https ?? m.media_url,
+      expandedUrl: m.expanded_url,
+      width: m.original_info?.width,
+      height: m.original_info?.height,
+      altText: m.ext_alt_text,
+    })),
+    url: `https://x.com/${authorHandle ?? '_'}/status/${quotedTweetId}`,
+  };
+}
+
+export function convertHomeTimelineTweetToRecord(tweetResult: any, now: string, ordering: { sortIndex?: string | null; fetchPage: number; fetchPosition: number }): FeedRecord | null {
+  const tweet = tweetResult?.tweet ?? tweetResult;
+  const legacy = tweet?.legacy;
+  if (!legacy) return null;
+
+  const tweetId = legacy.id_str ?? tweet?.rest_id;
+  if (!tweetId) return null;
+
+  const userResult = tweet?.core?.user_results?.result;
+  const authorHandle = userResult?.core?.screen_name ?? userResult?.legacy?.screen_name;
+  const authorName = userResult?.core?.name ?? userResult?.legacy?.name;
+  const authorProfileImageUrl =
+    userResult?.avatar?.image_url ??
+    userResult?.legacy?.profile_image_url_https ??
+    userResult?.legacy?.profile_image_url;
+
+  const mediaEntities = legacy?.extended_entities?.media ?? legacy?.entities?.media ?? [];
+  const media: string[] = mediaEntities
+    .map((m: any) => m.media_url_https ?? m.media_url)
+    .filter(Boolean);
+  const mediaObjects = mediaEntities.map((m: any) => ({
+    type: m.type,
+    url: m.media_url_https ?? m.media_url,
+    expandedUrl: m.expanded_url,
+    width: m.original_info?.width,
+    height: m.original_info?.height,
+    altText: m.ext_alt_text,
+    videoVariants: Array.isArray(m.video_info?.variants)
+      ? m.video_info.variants
+          .filter((v: any) => v.content_type === 'video/mp4')
+          .map((v: any) => ({
+            url: v.url,
+            contentType: v.content_type,
+            bitrate: v.bitrate,
+          }))
+      : undefined,
+  }));
+  const links: string[] = (legacy?.entities?.urls ?? [])
+    .map((u: any) => u.expanded_url ?? u.url)
+    .filter((u: string | undefined) => u && !u.includes('t.co'));
+  const quotedTweet = extractQuotedTweet(tweet?.quoted_status_result?.result);
+
+  return {
+    id: tweetId,
+    tweetId,
+    url: `https://x.com/${authorHandle ?? '_'}/status/${tweetId}`,
+    text: tweet?.note_tweet?.note_tweet_results?.result?.text ?? legacy.full_text ?? legacy.text ?? '',
+    authorHandle,
+    authorName,
+    authorProfileImageUrl,
+    author: extractAuthor(userResult, now),
+    postedAt: legacy.created_at ?? null,
+    syncedAt: now,
+    sortIndex: ordering.sortIndex ?? null,
+    fetchPage: ordering.fetchPage,
+    fetchPosition: ordering.fetchPosition,
+    conversationId: legacy.conversation_id_str,
+    inReplyToStatusId: legacy.in_reply_to_status_id_str,
+    inReplyToUserId: legacy.in_reply_to_user_id_str,
+    quotedStatusId: legacy.quoted_status_id_str,
+    quotedTweet,
+    language: legacy.lang,
+    sourceApp: legacy.source,
+    possiblySensitive: legacy.possibly_sensitive,
+    engagement: {
+      likeCount: legacy.favorite_count,
+      repostCount: legacy.retweet_count,
+      replyCount: legacy.reply_count,
+      quoteCount: legacy.quote_count,
+      bookmarkCount: legacy.bookmark_count,
+      viewCount: tweet?.views?.count ? Number(tweet.views.count) : undefined,
+    },
+    media,
+    mediaObjects,
+    links,
+    tags: [],
+    ingestedVia: 'graphql',
+  };
+}
+
+export function parseHomeTimelineResponse(json: any, options: { now?: string; fetchPage?: number } = {}): FeedPageResult {
+  const ts = options.now ?? new Date().toISOString();
+  const fetchPage = options.fetchPage ?? 1;
+  const instructions = json?.data?.home?.home_timeline_urt?.instructions;
+  if (!Array.isArray(instructions)) {
+    throw new Error('Home timeline response did not include data.home.home_timeline_urt.instructions.');
+  }
+
+  const entries: any[] = [];
+  for (const instruction of instructions) {
+    if (instruction?.type === 'TimelineAddEntries' && Array.isArray(instruction.entries)) {
+      entries.push(...instruction.entries);
+    }
+  }
+
+  const records: FeedRecord[] = [];
+  const seenTweetIds: string[] = [];
+  let skippedEntries = 0;
+  let nextCursor: string | undefined;
+
+  for (const [index, entry] of entries.entries()) {
+    if (entry?.content?.cursorType === 'Bottom') {
+      nextCursor = entry.content.value;
+      continue;
+    }
+
+    const itemType = entry?.content?.itemContent?.itemType;
+    if (itemType !== 'TimelineTweet') {
+      skippedEntries += 1;
+      continue;
+    }
+
+    if (typeof entry?.entryId === 'string' && entry.entryId.startsWith('promoted-')) {
+      skippedEntries += 1;
+      continue;
+    }
+
+    const tweetResult = entry?.content?.itemContent?.tweet_results?.result;
+    const record = convertHomeTimelineTweetToRecord(tweetResult, ts, {
+      sortIndex: typeof entry?.sortIndex === 'string' ? entry.sortIndex : null,
+      fetchPage,
+      fetchPosition: index,
+    });
+    if (!record) {
+      skippedEntries += 1;
+      continue;
+    }
+    records.push(record);
+    seenTweetIds.push(record.tweetId);
+  }
+
+  return { records, nextCursor, skippedEntries, seenTweetIds };
+}
+
+async function fetchPageWithRetry(
+  headers: Record<string, string>,
+  cursor?: string,
+  pageSize = 20,
+  seenTweetIds: string[] = [],
+): Promise<FeedPageResult> {
+  let lastError: Error | undefined;
+
+  for (let attempt = 0; attempt < 4; attempt++) {
+    const response = cursor
+      ? await fetchXResource(buildGraphqlUrl(HOME_TIMELINE_QUERY_ID, HOME_TIMELINE_OPERATION), {
+          method: 'POST',
+          headers,
+          body: buildPageBody(cursor, pageSize, seenTweetIds),
+        })
+      : await fetchXResource(buildFirstPageUrl(pageSize), { headers });
+
+    if (response.status === 429) {
+      const waitSec = Math.min(15 * Math.pow(2, attempt), 120);
+      lastError = new Error(`Rate limited (429) on attempt ${attempt + 1}`);
+      await new Promise((r) => setTimeout(r, waitSec * 1000));
+      continue;
+    }
+
+    if (response.status >= 500) {
+      lastError = new Error(`Server error (${response.status}) on attempt ${attempt + 1}`);
+      await new Promise((r) => setTimeout(r, 5000 * (attempt + 1)));
+      continue;
+    }
+
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(
+        `Home timeline API returned ${response.status}.\n` +
+        `Response: ${text.slice(0, 300)}\n\n` +
+        (response.status === 401 || response.status === 403
+          ? 'Fix: Your X session may have expired. Open your browser, go to https://x.com, and make sure you are logged in. Then retry.'
+          : 'This may be a temporary issue. Try again in a few minutes.')
+      );
+    }
+
+    const json = await response.json();
+    return parseHomeTimelineResponse(json);
+  }
+
+  throw lastError ?? new Error('Home timeline API: all retry attempts failed. Try again later.');
+}
+
+function updateState(
+  prev: FeedBackfillState,
+  input: { fetched: number; stored: number; skippedEntries: number; seenIds: string[]; stopReason: string; lastCursor?: string; lastRunAt?: string },
+): FeedBackfillState {
+  return {
+    provider: 'twitter',
+    lastRunAt: input.lastRunAt ?? new Date().toISOString(),
+    totalRuns: prev.totalRuns + 1,
+    totalFetched: prev.totalFetched + input.fetched,
+    totalStored: input.stored,
+    totalSkippedEntries: input.skippedEntries,
+    lastSeenIds: input.seenIds.slice(-20),
+    stopReason: input.stopReason,
+    lastCursor: input.lastCursor,
+  };
+}
+
+export async function syncFeedGraphQL(options: FeedSyncOptions = {}): Promise<FeedSyncResult> {
+  const maxPages = options.maxPages ?? 5;
+  const delayMs = options.delayMs ?? 600;
+  const maxMinutes = options.maxMinutes ?? 5;
+  const pageSize = options.pageSize ?? 20;
+
+  const session = resolveXSessionAuth(options);
+  const headers = buildXGraphqlHeaders(session);
+  ensureDataDir();
+
+  const cachePath = twitterFeedCachePath();
+  const metaPath = twitterFeedMetaPath();
+  const statePath = twitterFeedStatePath();
+  const existing = await readJsonLines<FeedRecord>(cachePath);
+  const previousMeta = (await pathExists(metaPath))
+    ? await readJson<FeedCacheMeta>(metaPath)
+    : undefined;
+  const prevState: FeedBackfillState = (await pathExists(statePath))
+    ? await readJson<FeedBackfillState>(statePath)
+    : { provider: 'twitter', totalRuns: 0, totalFetched: 0, totalStored: 0, totalSkippedEntries: 0, lastSeenIds: [] };
+
+  const started = Date.now();
+  let page = 0;
+  let totalAdded = 0;
+  let totalFetched = 0;
+  let totalSkipped = 0;
+  let cursor: string | undefined;
+  let merged = existing;
+  let stopReason = 'unknown';
+  let seenTweetIds: string[] = prevState.lastSeenIds.slice(-5);
+
+  while (page < maxPages) {
+    if (Date.now() - started > maxMinutes * 60_000) {
+      stopReason = 'max runtime reached';
+      break;
+    }
+
+    const result = await fetchPageWithRetry(headers, cursor, pageSize, seenTweetIds);
+    page += 1;
+
+    const pageNow = new Date().toISOString();
+    const recordsWithPage = result.records.map((record) => ({ ...record, syncedAt: pageNow, fetchPage: page }));
+    const mergeResult = mergeFeedRecords(merged, recordsWithPage);
+    merged = mergeResult.merged;
+    totalAdded += mergeResult.added;
+    totalFetched += recordsWithPage.length;
+    totalSkipped += result.skippedEntries;
+    seenTweetIds = result.seenTweetIds.slice(-5);
+
+    options.onProgress?.({
+      page,
+      totalFetched,
+      newAdded: totalAdded,
+      skippedEntries: totalSkipped,
+      running: true,
+      done: false,
+    });
+
+    if (!result.nextCursor) {
+      stopReason = recordsWithPage.length === 0 ? 'no tweet entries found' : 'end of feed';
+      break;
+    }
+
+    cursor = result.nextCursor;
+    if (page < maxPages) await new Promise((r) => setTimeout(r, delayMs));
+  }
+
+  if (stopReason === 'unknown') stopReason = page >= maxPages ? 'max pages reached' : 'unknown';
+
+  const syncedAt = new Date().toISOString();
+  await writeJsonLines(cachePath, merged);
+  await writeJson(metaPath, {
+    provider: 'twitter',
+    schemaVersion: 1,
+    lastSyncAt: syncedAt,
+    totalItems: merged.length,
+    totalSkippedEntries: totalSkipped,
+  } satisfies FeedCacheMeta);
+  await writeJson(statePath, updateState(prevState, {
+    fetched: totalFetched,
+    stored: merged.length,
+    skippedEntries: totalSkipped,
+    seenIds: seenTweetIds,
+    stopReason,
+    lastCursor: cursor,
+    lastRunAt: syncedAt,
+  }));
+  const indexResult = await buildFeedIndex({ force: true });
+
+  options.onProgress?.({
+    page,
+    totalFetched,
+    newAdded: totalAdded,
+    skippedEntries: totalSkipped,
+    running: false,
+    done: true,
+    stopReason,
+  });
+
+  return {
+    added: totalAdded,
+    totalItems: merged.length,
+    skippedEntries: totalSkipped,
+    pages: page,
+    stopReason,
+    cachePath,
+    statePath,
+    dbPath: indexResult.dbPath ?? twitterFeedIndexPath(),
+  };
+}

--- a/src/graphql-likes.ts
+++ b/src/graphql-likes.ts
@@ -1,0 +1,554 @@
+import { readJsonLines, writeJsonLines, readJson, writeJson, pathExists } from './fs.js';
+import { ensureDataDir, twitterLikesBackfillStatePath, twitterLikesCachePath, twitterLikesMetaPath } from './paths.js';
+import { loadChromeSessionConfig } from './config.js';
+import { extractChromeXCookies } from './chrome-cookies.js';
+import { extractFirefoxXCookies } from './firefox-cookies.js';
+import type { LikeRecord, LikesBackfillState, LikesCacheMeta } from './types.js';
+
+const CHROME_UA = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.0.0 Safari/537.36';
+
+const X_PUBLIC_BEARER =
+  'AAAAAAAAAAAAAAAAAAAAANRILgAAAAAAnNwIzUejRCOuH5E6I8xnZz4puTs%3D1Zv7ttfk8LF81IUq16cHjhLTvJu4FA33AGWWjCpTnA';
+
+const LIKES_QUERY_ID = 'KPuet6dGbC8LB2sOLx7tZQ';
+const LIKES_OPERATION = 'Likes';
+const VIEWER_QUERY_ID = '_8ClT24oZ8tpylf_OSuNdg';
+const VIEWER_OPERATION = 'Viewer';
+
+const LIKES_GRAPHQL_FEATURES = {
+  rweb_video_screen_enabled: true,
+  profile_label_improvements_pcf_label_in_post_enabled: true,
+  responsive_web_profile_redirect_enabled: false,
+  rweb_tipjar_consumption_enabled: true,
+  verified_phone_label_enabled: false,
+  creator_subscriptions_tweet_preview_api_enabled: true,
+  responsive_web_graphql_timeline_navigation_enabled: true,
+  responsive_web_graphql_skip_user_profile_image_extensions_enabled: false,
+  premium_content_api_read_enabled: false,
+  communities_web_enable_tweet_community_results_fetch: true,
+  c9s_tweet_anatomy_moderator_badge_enabled: true,
+  responsive_web_grok_analyze_button_fetch_trends_enabled: false,
+  responsive_web_grok_analyze_post_followups_enabled: true,
+  responsive_web_jetfuel_frame: false,
+  responsive_web_grok_share_attachment_enabled: true,
+  responsive_web_grok_annotations_enabled: true,
+  articles_preview_enabled: true,
+  responsive_web_edit_tweet_api_enabled: true,
+  graphql_is_translatable_rweb_tweet_is_translatable_enabled: true,
+  view_counts_everywhere_api_enabled: true,
+  longform_notetweets_consumption_enabled: true,
+  responsive_web_twitter_article_tweet_consumption_enabled: true,
+  content_disclosure_indicator_enabled: true,
+  content_disclosure_ai_generated_indicator_enabled: true,
+  responsive_web_grok_show_grok_translated_post: false,
+  responsive_web_grok_analysis_button_from_backend: true,
+  post_ctas_fetch_enabled: true,
+  freedom_of_speech_not_reach_fetch_enabled: true,
+  standardized_nudges_misinfo: true,
+  tweet_with_visibility_results_prefer_gql_limited_actions_policy_enabled: true,
+  longform_notetweets_rich_text_read_enabled: true,
+  longform_notetweets_inline_media_enabled: true,
+  responsive_web_grok_image_annotation_enabled: true,
+  responsive_web_grok_imagine_annotation_enabled: true,
+  responsive_web_grok_community_note_auto_translation_is_enabled: false,
+  responsive_web_enhance_cards_enabled: false,
+};
+
+const LIKES_GRAPHQL_FIELD_TOGGLES = {
+  withPayments: false,
+  withAuxiliaryUserLabels: false,
+  withArticleRichContentState: true,
+  withArticlePlainText: false,
+  withArticleSummaryText: true,
+  withArticleVoiceOver: false,
+  withGrokAnalyze: false,
+  withDisallowedReplyControls: false,
+};
+
+const VIEWER_GRAPHQL_FEATURES = {
+  subscriptions_upsells_api_enabled: true,
+  profile_label_improvements_pcf_label_in_post_enabled: true,
+  responsive_web_profile_redirect_enabled: false,
+  rweb_tipjar_consumption_enabled: true,
+  verified_phone_label_enabled: false,
+  creator_subscriptions_tweet_preview_api_enabled: true,
+  responsive_web_graphql_skip_user_profile_image_extensions_enabled: false,
+  responsive_web_graphql_timeline_navigation_enabled: true,
+};
+
+const VIEWER_GRAPHQL_FIELD_TOGGLES = {
+  isDelegate: false,
+  withPayments: false,
+  withAuxiliaryUserLabels: false,
+};
+
+export interface LikesSyncOptions {
+  maxPages?: number;
+  delayMs?: number;
+  maxMinutes?: number;
+  stalePageLimit?: number;
+  browser?: string;
+  chromeUserDataDir?: string;
+  chromeProfileDirectory?: string;
+  firefoxProfileDir?: string;
+  csrfToken?: string;
+  cookieHeader?: string;
+  onProgress?: (status: LikesSyncProgress) => void;
+  checkpointEvery?: number;
+}
+
+export interface LikesSyncProgress {
+  page: number;
+  totalFetched: number;
+  newAdded: number;
+  running: boolean;
+  done: boolean;
+  stopReason?: string;
+}
+
+export interface LikesSyncResult {
+  added: number;
+  totalLikes: number;
+  pages: number;
+  stopReason: string;
+  cachePath: string;
+  statePath: string;
+}
+
+interface LikesPageResult {
+  records: LikeRecord[];
+  nextCursor?: string;
+}
+
+type FavoriteTweet = Record<string, any>;
+
+function parseSnowflake(value?: string | null): bigint | null {
+  if (!value || !/^\d+$/.test(value)) return null;
+  try {
+    return BigInt(value);
+  } catch {
+    return null;
+  }
+}
+
+function decrementSnowflake(value?: string | null): string | undefined {
+  const parsed = parseSnowflake(value);
+  if (parsed == null || parsed <= 0n) return undefined;
+  return String(parsed - 1n);
+}
+
+function parseLikeTimestamp(record: LikeRecord): number | null {
+  const candidates = [record.likedAt, record.postedAt, record.syncedAt];
+  for (const candidate of candidates) {
+    if (!candidate) continue;
+    const parsed = Date.parse(candidate);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return null;
+}
+
+function compareLikeChronology(a: LikeRecord, b: LikeRecord): number {
+  const aTimestamp = parseLikeTimestamp(a);
+  const bTimestamp = parseLikeTimestamp(b);
+  if (aTimestamp != null && bTimestamp != null && aTimestamp !== bTimestamp) {
+    return aTimestamp > bTimestamp ? 1 : -1;
+  }
+
+  const aId = parseSnowflake(a.tweetId ?? a.id);
+  const bId = parseSnowflake(b.tweetId ?? b.id);
+  if (aId != null && bId != null && aId !== bId) {
+    return aId > bId ? 1 : -1;
+  }
+
+  const aStamp = String(a.likedAt ?? a.postedAt ?? a.syncedAt ?? '');
+  const bStamp = String(b.likedAt ?? b.postedAt ?? b.syncedAt ?? '');
+  return aStamp.localeCompare(bStamp);
+}
+
+async function loadExistingLikes(): Promise<LikeRecord[]> {
+  return readJsonLines<LikeRecord>(twitterLikesCachePath());
+}
+
+function buildViewerUrl(): string {
+  const params = new URLSearchParams({
+    variables: JSON.stringify({}),
+    features: JSON.stringify(VIEWER_GRAPHQL_FEATURES),
+    fieldToggles: JSON.stringify(VIEWER_GRAPHQL_FIELD_TOGGLES),
+  });
+  return `https://x.com/i/api/graphql/${VIEWER_QUERY_ID}/${VIEWER_OPERATION}?${params}`;
+}
+
+function buildUrl(userId: string, cursor?: string): string {
+  const variables: Record<string, unknown> = {
+    userId,
+    count: 20,
+    includePromotedContent: false,
+  };
+  if (cursor) variables.cursor = cursor;
+  const params = new URLSearchParams({
+    variables: JSON.stringify(variables),
+    features: JSON.stringify(LIKES_GRAPHQL_FEATURES),
+    fieldToggles: JSON.stringify(LIKES_GRAPHQL_FIELD_TOGGLES),
+  });
+  return `https://x.com/i/api/graphql/${LIKES_QUERY_ID}/${LIKES_OPERATION}?${params}`;
+}
+
+function buildHeaders(csrfToken: string, cookieHeader?: string): Record<string, string> {
+  return {
+    authorization: `Bearer ${X_PUBLIC_BEARER}`,
+    'x-csrf-token': csrfToken,
+    'x-twitter-auth-type': 'OAuth2Session',
+    'x-twitter-active-user': 'yes',
+    'content-type': 'application/json',
+    'user-agent': CHROME_UA,
+    cookie: cookieHeader ?? `ct0=${csrfToken}`,
+  };
+}
+
+function snowflakeToIso(value?: string | null): string | null {
+  const parsed = parseSnowflake(value);
+  if (parsed == null) return null;
+  const ms = Number(parsed >> 22n) + 1288834974657;
+  return new Date(ms).toISOString();
+}
+
+export function convertLikedTweetToRecord(tweet: FavoriteTweet, now: string): LikeRecord | null {
+  const graphTweet = tweet?.tweet ?? tweet;
+  const legacy = graphTweet?.legacy;
+  const tweetId = legacy?.id_str ?? graphTweet?.rest_id ?? tweet?.id_str ?? tweet?.id?.toString();
+  if (!tweetId) return null;
+
+  const user = legacy
+    ? graphTweet?.core?.user_results?.result
+    : tweet?.user;
+  const authorHandle = legacy
+    ? user?.core?.screen_name ?? user?.legacy?.screen_name
+    : user?.screen_name;
+  const authorName = legacy
+    ? user?.core?.name ?? user?.legacy?.name
+    : user?.name;
+  const authorProfileImageUrl = legacy
+    ? user?.avatar?.image_url ?? user?.legacy?.profile_image_url_https ?? user?.legacy?.profile_image_url
+    : user?.profile_image_url_https ?? user?.profile_image_url;
+
+  const sourceTweet = legacy ?? tweet;
+  const mediaEntities = sourceTweet?.extended_entities?.media ?? sourceTweet?.entities?.media ?? [];
+  const media: string[] = mediaEntities
+    .map((m: any) => m.media_url_https ?? m.media_url)
+    .filter(Boolean);
+  const mediaObjects = mediaEntities.map((m: any) => ({
+    type: m.type,
+    mediaUrl: m.media_url_https ?? m.media_url,
+    previewUrl: m.media_url_https ?? m.media_url,
+    width: m.sizes?.large?.w ?? m.original_info?.width,
+    height: m.sizes?.large?.h ?? m.original_info?.height,
+    extAltText: m.ext_alt_text,
+    variants: Array.isArray(m.video_info?.variants)
+      ? m.video_info.variants.map((v: any) => ({
+          url: v.url,
+          contentType: v.content_type,
+          bitrate: v.bitrate,
+        }))
+      : undefined,
+  }));
+
+  const links: string[] = (sourceTweet?.entities?.urls ?? [])
+    .map((u: any) => u.expanded_url ?? u.url)
+    .filter((u: string | undefined) => u && !u.includes('t.co'));
+
+  return {
+    id: tweetId,
+    tweetId,
+    url: `https://x.com/${authorHandle ?? '_'}/status/${tweetId}`,
+    text:
+      graphTweet?.note_tweet?.note_tweet_results?.result?.text ??
+      sourceTweet?.full_text ??
+      sourceTweet?.text ??
+      '',
+    authorHandle,
+    authorName,
+    authorProfileImageUrl,
+    author: user ? {
+      handle: authorHandle,
+      name: authorName,
+      profileImageUrl: authorProfileImageUrl,
+      description: legacy ? user?.legacy?.description : user?.description,
+      location: legacy ? user?.legacy?.location : user?.location,
+      url: legacy ? user?.legacy?.url : user?.url,
+      verified: Boolean(legacy ? (user?.is_blue_verified ?? user?.legacy?.verified) : user?.verified),
+      followersCount: legacy ? user?.legacy?.followers_count : user?.followers_count,
+      followingCount: legacy ? user?.legacy?.friends_count : user?.friends_count,
+      statusesCount: legacy ? user?.legacy?.statuses_count : user?.statuses_count,
+    } : undefined,
+    postedAt: sourceTweet?.created_at ?? null,
+    likedAt: null,
+    syncedAt: now,
+    conversationId: sourceTweet?.conversation_id_str,
+    inReplyToStatusId: sourceTweet?.in_reply_to_status_id_str,
+    inReplyToUserId: sourceTweet?.in_reply_to_user_id_str,
+    quotedStatusId: sourceTweet?.quoted_status_id_str,
+    language: sourceTweet?.lang,
+    sourceApp: sourceTweet?.source,
+    possiblySensitive: sourceTweet?.possibly_sensitive,
+    engagement: {
+      likeCount: sourceTweet?.favorite_count,
+      repostCount: sourceTweet?.retweet_count,
+      replyCount: sourceTweet?.reply_count,
+      quoteCount: sourceTweet?.quote_count,
+      bookmarkCount: sourceTweet?.bookmark_count,
+      viewCount: graphTweet?.views?.count ? Number(graphTweet.views.count) : undefined,
+    },
+    media,
+    mediaObjects,
+    links,
+    tags: [],
+    ingestedVia: 'browser',
+  };
+}
+
+export function parseLikesResponse(json: unknown, now?: string): LikesPageResult {
+  const ts = now ?? new Date().toISOString();
+  const instructions = Array.isArray(json)
+    ? []
+    : (json as any)?.data?.user?.result?.timeline?.timeline?.instructions ?? [];
+  const timelineEntries = instructions.flatMap((instruction: any) => instruction?.entries ?? []);
+  const timelineRecords = timelineEntries
+    .map((entry: any) => {
+      const tweetResult = entry?.content?.itemContent?.tweet_results?.result;
+      const record = convertLikedTweetToRecord(tweetResult, ts);
+      if (record && entry?.sortIndex) {
+        record.likedAt = snowflakeToIso(entry.sortIndex) ?? record.likedAt;
+      }
+      return record;
+    })
+    .filter((record: LikeRecord | null): record is LikeRecord => Boolean(record));
+
+  const arrayRecords = Array.isArray(json)
+    ? json
+        .map((tweet) => convertLikedTweetToRecord(tweet, ts))
+        .filter((record): record is LikeRecord => Boolean(record))
+    : [];
+
+  const records = timelineRecords.length > 0 ? timelineRecords : arrayRecords;
+  const nextCursor = timelineEntries
+    .find((entry: any) => entry?.content?.cursorType === 'Bottom')
+    ?.content?.value ?? decrementSnowflake(records[records.length - 1]?.tweetId);
+  return { records, nextCursor };
+}
+
+function scoreRecord(record: LikeRecord): number {
+  let score = 0;
+  if (record.postedAt) score += 2;
+  if (record.authorProfileImageUrl) score += 2;
+  if (record.author) score += 3;
+  if (record.engagement) score += 3;
+  if ((record.mediaObjects?.length ?? 0) > 0) score += 3;
+  if ((record.links?.length ?? 0) > 0) score += 2;
+  return score;
+}
+
+export function mergeLikeRecord(existing: LikeRecord | undefined, incoming: LikeRecord): LikeRecord {
+  if (!existing) return incoming;
+  return scoreRecord(incoming) >= scoreRecord(existing)
+    ? { ...existing, ...incoming, likedAt: existing.likedAt ?? incoming.likedAt ?? null }
+    : { ...incoming, ...existing, likedAt: existing.likedAt ?? incoming.likedAt ?? null };
+}
+
+export function mergeLikes(
+  existing: LikeRecord[],
+  incoming: LikeRecord[],
+): { merged: LikeRecord[]; added: number } {
+  const byId = new Map(existing.map((r) => [r.id, r]));
+  let added = 0;
+  for (const record of incoming) {
+    const prev = byId.get(record.id);
+    if (!prev) added += 1;
+    byId.set(record.id, mergeLikeRecord(prev, record));
+  }
+  const merged = Array.from(byId.values());
+  merged.sort((a, b) => compareLikeChronology(b, a));
+  return { merged, added };
+}
+
+function updateState(
+  prev: LikesBackfillState,
+  input: { added: number; seenIds: string[]; stopReason: string; lastRunAt?: string },
+): LikesBackfillState {
+  return {
+    provider: 'twitter',
+    lastRunAt: input.lastRunAt ?? new Date().toISOString(),
+    totalRuns: prev.totalRuns + 1,
+    totalAdded: prev.totalAdded + input.added,
+    lastAdded: input.added,
+    lastSeenIds: input.seenIds.slice(-20),
+    stopReason: input.stopReason,
+  };
+}
+
+async function fetchViewerId(csrfToken: string, cookieHeader?: string): Promise<string> {
+  const response = await fetch(buildViewerUrl(), { headers: buildHeaders(csrfToken, cookieHeader) });
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`Viewer lookup failed (${response.status}).\nResponse: ${text.slice(0, 300)}`);
+  }
+  const json = await response.json();
+  const userId = json?.data?.viewer?.user_results?.result?.rest_id;
+  if (!userId) {
+    throw new Error('Viewer lookup did not return a user id for the logged-in X session.');
+  }
+  return String(userId);
+}
+
+async function fetchPageWithRetry(csrfToken: string, userId: string, cursor?: string, cookieHeader?: string): Promise<LikesPageResult> {
+  let lastError: Error | undefined;
+
+  for (let attempt = 0; attempt < 4; attempt++) {
+    const response = await fetch(buildUrl(userId, cursor), { headers: buildHeaders(csrfToken, cookieHeader) });
+    if (response.status === 429) {
+      const waitSec = Math.min(15 * Math.pow(2, attempt), 120);
+      lastError = new Error(`Rate limited (429) on attempt ${attempt + 1}`);
+      await new Promise((r) => setTimeout(r, waitSec * 1000));
+      continue;
+    }
+    if (response.status >= 500) {
+      lastError = new Error(`Server error (${response.status}) on attempt ${attempt + 1}`);
+      await new Promise((r) => setTimeout(r, 5000 * (attempt + 1)));
+      continue;
+    }
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(
+        `Likes API returned ${response.status}.\n` +
+          `Response: ${text.slice(0, 300)}\n\n` +
+          (response.status === 401 || response.status === 403
+            ? 'Fix: Your X session may have expired. Open your browser, go to https://x.com, and make sure you are logged in. Then retry.'
+            : 'This may be a temporary issue. Try again in a few minutes.')
+      );
+    }
+    const json = await response.json();
+    return parseLikesResponse(json);
+  }
+
+  throw lastError ?? new Error('Likes API: all retry attempts failed. Try again later.');
+}
+
+export async function syncLikesGraphQL(options: LikesSyncOptions = {}): Promise<LikesSyncResult> {
+  const maxPages = options.maxPages ?? 500;
+  const delayMs = options.delayMs ?? 600;
+  const maxMinutes = options.maxMinutes ?? 30;
+  const stalePageLimit = options.stalePageLimit ?? 3;
+  const checkpointEvery = options.checkpointEvery ?? 25;
+
+  let csrfToken: string;
+  let cookieHeader: string | undefined;
+
+  if (options.csrfToken) {
+    csrfToken = options.csrfToken;
+    cookieHeader = options.cookieHeader;
+  } else {
+    const config = loadChromeSessionConfig({ browserId: options.browser });
+    if (config.browser.cookieBackend === 'firefox') {
+      const cookies = extractFirefoxXCookies(options.firefoxProfileDir);
+      csrfToken = cookies.csrfToken;
+      cookieHeader = cookies.cookieHeader;
+    } else {
+      const chromeDir = options.chromeUserDataDir ?? config.chromeUserDataDir;
+      const chromeProfile = options.chromeProfileDirectory ?? config.chromeProfileDirectory;
+      const cookies = extractChromeXCookies(chromeDir, chromeProfile, config.browser);
+      csrfToken = cookies.csrfToken;
+      cookieHeader = cookies.cookieHeader;
+    }
+  }
+
+  ensureDataDir();
+  const cachePath = twitterLikesCachePath();
+  const metaPath = twitterLikesMetaPath();
+  const statePath = twitterLikesBackfillStatePath();
+  let existing = await loadExistingLikes();
+  const previousMeta = (await pathExists(metaPath))
+    ? await readJson<LikesCacheMeta>(metaPath)
+    : undefined;
+  const prevState: LikesBackfillState = (await pathExists(statePath))
+    ? await readJson<LikesBackfillState>(statePath)
+    : { provider: 'twitter', totalRuns: 0, totalAdded: 0, lastAdded: 0, lastSeenIds: [] };
+
+  const started = Date.now();
+  let page = 0;
+  let totalAdded = 0;
+  let stalePages = 0;
+  let cursor: string | undefined;
+  const allSeenIds: string[] = [];
+  let stopReason = 'unknown';
+  const userId = await fetchViewerId(csrfToken, cookieHeader);
+
+  while (page < maxPages) {
+    if (Date.now() - started > maxMinutes * 60_000) {
+      stopReason = 'max runtime reached';
+      break;
+    }
+
+    const result = await fetchPageWithRetry(csrfToken, userId, cursor, cookieHeader);
+    page += 1;
+
+    if (result.records.length === 0) {
+      stopReason = 'end of likes';
+      break;
+    }
+
+    const mergedResult = mergeLikes(existing, result.records);
+    existing = mergedResult.merged;
+    totalAdded += mergedResult.added;
+    result.records.forEach((r) => allSeenIds.push(r.id));
+    stalePages = mergedResult.added === 0 ? stalePages + 1 : 0;
+
+    options.onProgress?.({
+      page,
+      totalFetched: allSeenIds.length,
+      newAdded: totalAdded,
+      running: true,
+      done: false,
+    });
+
+    if (stalePages >= stalePageLimit) {
+      stopReason = 'no new likes (stale)';
+      break;
+    }
+    if (!result.nextCursor) {
+      stopReason = 'end of likes';
+      break;
+    }
+
+    if (page % checkpointEvery === 0) await writeJsonLines(cachePath, existing);
+    cursor = result.nextCursor;
+    if (page < maxPages) await new Promise((r) => setTimeout(r, delayMs));
+  }
+
+  if (stopReason === 'unknown') stopReason = page >= maxPages ? 'max pages reached' : 'unknown';
+
+  const syncedAt = new Date().toISOString();
+  await writeJsonLines(cachePath, existing);
+  await writeJson(metaPath, {
+    provider: 'twitter',
+    schemaVersion: 1,
+    lastFullSyncAt: syncedAt,
+    lastIncrementalSyncAt: previousMeta?.lastIncrementalSyncAt,
+    totalLikes: existing.length,
+  } satisfies LikesCacheMeta);
+  await writeJson(statePath, updateState(prevState, {
+    added: totalAdded,
+    seenIds: allSeenIds.slice(-20),
+    stopReason,
+    lastRunAt: syncedAt,
+  }));
+
+  options.onProgress?.({
+    page,
+    totalFetched: allSeenIds.length,
+    newAdded: totalAdded,
+    running: false,
+    done: true,
+    stopReason,
+  });
+
+  return { added: totalAdded, totalLikes: existing.length, pages: page, stopReason, cachePath, statePath };
+}

--- a/src/graphql-likes.ts
+++ b/src/graphql-likes.ts
@@ -3,6 +3,7 @@ import { ensureDataDir, twitterLikesBackfillStatePath, twitterLikesCachePath, tw
 import { loadChromeSessionConfig } from './config.js';
 import { extractChromeXCookies } from './chrome-cookies.js';
 import { extractFirefoxXCookies } from './firefox-cookies.js';
+import { fetchXResource } from './x-graphql.js';
 import type { LikeRecord, LikesBackfillState, LikesCacheMeta } from './types.js';
 
 const CHROME_UA = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.0.0 Safari/537.36';
@@ -386,7 +387,7 @@ function updateState(
 }
 
 async function fetchViewerId(csrfToken: string, cookieHeader?: string): Promise<string> {
-  const response = await fetch(buildViewerUrl(), { headers: buildHeaders(csrfToken, cookieHeader) });
+  const response = await fetchXResource(buildViewerUrl(), { headers: buildHeaders(csrfToken, cookieHeader) });
   if (!response.ok) {
     const text = await response.text();
     throw new Error(`Viewer lookup failed (${response.status}).\nResponse: ${text.slice(0, 300)}`);
@@ -403,7 +404,7 @@ async function fetchPageWithRetry(csrfToken: string, userId: string, cursor?: st
   let lastError: Error | undefined;
 
   for (let attempt = 0; attempt < 4; attempt++) {
-    const response = await fetch(buildUrl(userId, cursor), { headers: buildHeaders(csrfToken, cookieHeader) });
+    const response = await fetchXResource(buildUrl(userId, cursor), { headers: buildHeaders(csrfToken, cookieHeader) });
     if (response.status === 429) {
       const waitSec = Math.min(15 * Math.pow(2, attempt), 120);
       lastError = new Error(`Rate limited (429) on attempt ${attempt + 1}`);

--- a/src/likes-db.ts
+++ b/src/likes-db.ts
@@ -1,0 +1,420 @@
+import type { Database } from 'sql.js';
+import { openDb, saveDb } from './db.js';
+import { readJsonLines } from './fs.js';
+import { twitterLikesCachePath, twitterLikesIndexPath } from './paths.js';
+import type { LikeRecord } from './types.js';
+
+export interface LikeSearchResult {
+  id: string;
+  url: string;
+  text: string;
+  authorHandle?: string;
+  authorName?: string;
+  likedAt?: string | null;
+  postedAt?: string | null;
+  score: number;
+}
+
+export interface LikeSearchOptions {
+  query: string;
+  author?: string;
+  limit?: number;
+  before?: string;
+  after?: string;
+}
+
+export interface LikeTimelineItem {
+  id: string;
+  tweetId: string;
+  url: string;
+  text: string;
+  authorHandle?: string;
+  authorName?: string;
+  authorProfileImageUrl?: string;
+  postedAt?: string | null;
+  likedAt?: string | null;
+  links: string[];
+  mediaCount: number;
+  linkCount: number;
+  likeCount?: number | null;
+  repostCount?: number | null;
+  replyCount?: number | null;
+  quoteCount?: number | null;
+  bookmarkCount?: number | null;
+  viewCount?: number | null;
+}
+
+export interface LikeTimelineFilters {
+  query?: string;
+  author?: string;
+  after?: string;
+  before?: string;
+  sort?: 'asc' | 'desc';
+  limit?: number;
+  offset?: number;
+}
+
+const SCHEMA_VERSION = 1;
+
+function parseJsonArray(value: unknown): string[] {
+  if (typeof value !== 'string' || !value.trim()) return [];
+  try {
+    const parsed = JSON.parse(value);
+    return Array.isArray(parsed) ? parsed.filter((entry): entry is string => typeof entry === 'string') : [];
+  } catch {
+    return [];
+  }
+}
+
+function mapTimelineRow(row: unknown[]): LikeTimelineItem {
+  return {
+    id: row[0] as string,
+    tweetId: row[1] as string,
+    url: row[2] as string,
+    text: row[3] as string,
+    authorHandle: (row[4] as string) ?? undefined,
+    authorName: (row[5] as string) ?? undefined,
+    authorProfileImageUrl: (row[6] as string) ?? undefined,
+    postedAt: (row[7] as string) ?? null,
+    likedAt: (row[8] as string) ?? null,
+    links: parseJsonArray(row[9]),
+    mediaCount: Number(row[10] ?? 0),
+    linkCount: Number(row[11] ?? 0),
+    likeCount: row[12] as number | null,
+    repostCount: row[13] as number | null,
+    replyCount: row[14] as number | null,
+    quoteCount: row[15] as number | null,
+    bookmarkCount: row[16] as number | null,
+    viewCount: row[17] as number | null,
+  };
+}
+
+function buildLikeWhereClause(filters: LikeTimelineFilters): { where: string; params: Array<string | number> } {
+  const conditions: string[] = [];
+  const params: Array<string | number> = [];
+
+  if (filters.query) {
+    conditions.push(`l.rowid IN (SELECT rowid FROM likes_fts WHERE likes_fts MATCH ?)`);
+    params.push(filters.query);
+  }
+  if (filters.author) {
+    conditions.push(`l.author_handle = ? COLLATE NOCASE`);
+    params.push(filters.author);
+  }
+  if (filters.after) {
+    conditions.push(`COALESCE(l.liked_at, l.posted_at) >= ?`);
+    params.push(filters.after);
+  }
+  if (filters.before) {
+    conditions.push(`COALESCE(l.liked_at, l.posted_at) <= ?`);
+    params.push(filters.before);
+  }
+
+  return {
+    where: conditions.length ? `WHERE ${conditions.join(' AND ')}` : '',
+    params,
+  };
+}
+
+function likeSortClause(direction: 'asc' | 'desc' = 'desc'): string {
+  const normalized = direction === 'asc' ? 'ASC' : 'DESC';
+  return `
+    ORDER BY
+      COALESCE(NULLIF(l.liked_at, ''), NULLIF(l.posted_at, ''), '') ${normalized},
+      CAST(l.tweet_id AS INTEGER) ${normalized}
+  `;
+}
+
+function initSchema(db: Database): void {
+  db.run(`CREATE TABLE IF NOT EXISTS meta (key TEXT PRIMARY KEY, value TEXT)`);
+  db.run(`CREATE TABLE IF NOT EXISTS likes (
+    id TEXT PRIMARY KEY,
+    tweet_id TEXT NOT NULL,
+    url TEXT NOT NULL,
+    text TEXT NOT NULL,
+    author_handle TEXT,
+    author_name TEXT,
+    author_profile_image_url TEXT,
+    posted_at TEXT,
+    liked_at TEXT,
+    synced_at TEXT NOT NULL,
+    conversation_id TEXT,
+    in_reply_to_status_id TEXT,
+    quoted_status_id TEXT,
+    language TEXT,
+    like_count INTEGER,
+    repost_count INTEGER,
+    reply_count INTEGER,
+    quote_count INTEGER,
+    bookmark_count INTEGER,
+    view_count INTEGER,
+    media_count INTEGER DEFAULT 0,
+    link_count INTEGER DEFAULT 0,
+    links_json TEXT,
+    tags_json TEXT,
+    ingested_via TEXT
+  )`);
+  db.run(`CREATE INDEX IF NOT EXISTS idx_likes_author ON likes(author_handle)`);
+  db.run(`CREATE INDEX IF NOT EXISTS idx_likes_posted ON likes(posted_at)`);
+  db.run(`CREATE INDEX IF NOT EXISTS idx_likes_liked ON likes(liked_at)`);
+  db.run(`CREATE VIRTUAL TABLE IF NOT EXISTS likes_fts USING fts5(
+    text,
+    author_handle,
+    author_name,
+    content=likes,
+    content_rowid=rowid,
+    tokenize='porter unicode61'
+  )`);
+  db.run(`REPLACE INTO meta VALUES ('schema_version', '${SCHEMA_VERSION}')`);
+}
+
+function insertRecord(db: Database, record: LikeRecord): void {
+  db.run(
+    `INSERT OR REPLACE INTO likes VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+    [
+      record.id,
+      record.tweetId,
+      record.url,
+      record.text,
+      record.authorHandle ?? null,
+      record.authorName ?? null,
+      record.authorProfileImageUrl ?? null,
+      record.postedAt ?? null,
+      record.likedAt ?? null,
+      record.syncedAt,
+      record.conversationId ?? null,
+      record.inReplyToStatusId ?? null,
+      record.quotedStatusId ?? null,
+      record.language ?? null,
+      record.engagement?.likeCount ?? null,
+      record.engagement?.repostCount ?? null,
+      record.engagement?.replyCount ?? null,
+      record.engagement?.quoteCount ?? null,
+      record.engagement?.bookmarkCount ?? null,
+      record.engagement?.viewCount ?? null,
+      record.media?.length ?? 0,
+      record.links?.length ?? 0,
+      record.links?.length ? JSON.stringify(record.links) : null,
+      record.tags?.length ? JSON.stringify(record.tags) : null,
+      record.ingestedVia ?? null,
+    ],
+  );
+}
+
+export async function buildLikesIndex(options?: { force?: boolean }): Promise<{ dbPath: string; recordCount: number; newRecords: number }> {
+  const cachePath = twitterLikesCachePath();
+  const dbPath = twitterLikesIndexPath();
+  const records = await readJsonLines<LikeRecord>(cachePath);
+  const db = await openDb(dbPath);
+
+  try {
+    if (options?.force) {
+      db.run('DROP TABLE IF EXISTS likes_fts');
+      db.run('DROP TABLE IF EXISTS likes');
+      db.run('DROP TABLE IF EXISTS meta');
+    }
+
+    initSchema(db);
+
+    const existingIds = new Set<string>();
+    try {
+      const rows = db.exec('SELECT id FROM likes');
+      for (const row of (rows[0]?.values ?? [])) existingIds.add(row[0] as string);
+    } catch {}
+
+    const newRecords = records.filter((record) => !existingIds.has(record.id));
+    if (records.length > 0) {
+      db.run('BEGIN TRANSACTION');
+      try {
+        for (const record of records) insertRecord(db, record);
+        db.run('COMMIT');
+      } catch (error) {
+        db.run('ROLLBACK');
+        throw error;
+      }
+    }
+
+    db.run(`INSERT INTO likes_fts(likes_fts) VALUES('rebuild')`);
+    saveDb(db, dbPath);
+    const totalRows = db.exec('SELECT COUNT(*) FROM likes')[0]?.values[0]?.[0] as number;
+    return { dbPath, recordCount: totalRows, newRecords: newRecords.length };
+  } finally {
+    db.close();
+  }
+}
+
+export async function searchLikes(options: LikeSearchOptions): Promise<LikeSearchResult[]> {
+  const db = await openDb(twitterLikesIndexPath());
+  const limit = options.limit ?? 20;
+
+  try {
+    const conditions: string[] = [];
+    const params: Array<string | number> = [];
+
+    if (options.query) {
+      conditions.push(`l.rowid IN (SELECT rowid FROM likes_fts WHERE likes_fts MATCH ?)`);
+      params.push(options.query);
+    }
+    if (options.author) {
+      conditions.push(`l.author_handle = ? COLLATE NOCASE`);
+      params.push(options.author);
+    }
+    if (options.after) {
+      conditions.push(`COALESCE(l.liked_at, l.posted_at) >= ?`);
+      params.push(options.after);
+    }
+    if (options.before) {
+      conditions.push(`COALESCE(l.liked_at, l.posted_at) <= ?`);
+      params.push(options.before);
+    }
+
+    const where = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
+    const orderBy = options.query
+      ? `ORDER BY bm25(likes_fts, 5.0, 1.0, 1.0) ASC`
+      : `ORDER BY COALESCE(l.liked_at, l.posted_at) DESC`;
+
+    const sql = options.query
+      ? `
+        SELECT l.id, l.url, l.text, l.author_handle, l.author_name, l.liked_at, l.posted_at,
+               bm25(likes_fts, 5.0, 1.0, 1.0) as score
+        FROM likes l
+        JOIN likes_fts ON likes_fts.rowid = l.rowid
+        ${where}
+        ${orderBy}
+        LIMIT ?
+      `
+      : `
+        SELECT l.id, l.url, l.text, l.author_handle, l.author_name, l.liked_at, l.posted_at, 0 as score
+        FROM likes l
+        ${where}
+        ${orderBy}
+        LIMIT ?
+      `;
+
+    params.push(limit);
+    const rows = db.exec(sql, params);
+    if (!rows.length) return [];
+
+    return rows[0].values.map((row) => ({
+      id: row[0] as string,
+      url: row[1] as string,
+      text: row[2] as string,
+      authorHandle: row[3] as string | undefined,
+      authorName: row[4] as string | undefined,
+      likedAt: row[5] as string | null,
+      postedAt: row[6] as string | null,
+      score: row[7] as number,
+    }));
+  } finally {
+    db.close();
+  }
+}
+
+export async function listLikes(filters: LikeTimelineFilters = {}): Promise<LikeTimelineItem[]> {
+  const db = await openDb(twitterLikesIndexPath());
+  const limit = filters.limit ?? 30;
+  const offset = filters.offset ?? 0;
+
+  try {
+    const { where, params } = buildLikeWhereClause(filters);
+    const sql = `
+      SELECT
+        l.id,
+        l.tweet_id,
+        l.url,
+        l.text,
+        l.author_handle,
+        l.author_name,
+        l.author_profile_image_url,
+        l.posted_at,
+        l.liked_at,
+        l.links_json,
+        l.media_count,
+        l.link_count,
+        l.like_count,
+        l.repost_count,
+        l.reply_count,
+        l.quote_count,
+        l.bookmark_count,
+        l.view_count
+      FROM likes l
+      ${where}
+      ${likeSortClause(filters.sort)}
+      LIMIT ?
+      OFFSET ?
+    `;
+    params.push(limit, offset);
+    const rows = db.exec(sql, params);
+    if (!rows.length) return [];
+    return rows[0].values.map((row) => mapTimelineRow(row));
+  } finally {
+    db.close();
+  }
+}
+
+export async function countLikes(filters: LikeTimelineFilters = {}): Promise<number> {
+  const db = await openDb(twitterLikesIndexPath());
+
+  try {
+    const { where, params } = buildLikeWhereClause(filters);
+    const rows = db.exec(
+      `
+        SELECT COUNT(*)
+        FROM likes l
+        ${where}
+      `,
+      params,
+    );
+    return Number(rows[0]?.values?.[0]?.[0] ?? 0);
+  } finally {
+    db.close();
+  }
+}
+
+export async function getLikeById(id: string): Promise<LikeTimelineItem | null> {
+  const db = await openDb(twitterLikesIndexPath());
+  try {
+    const rows = db.exec(
+      `SELECT
+        l.id,
+        l.tweet_id,
+        l.url,
+        l.text,
+        l.author_handle,
+        l.author_name,
+        l.author_profile_image_url,
+        l.posted_at,
+        l.liked_at,
+        l.links_json,
+        l.media_count,
+        l.link_count,
+        l.like_count,
+        l.repost_count,
+        l.reply_count,
+        l.quote_count,
+        l.bookmark_count,
+        l.view_count
+      FROM likes l
+      WHERE l.id = ?
+      LIMIT 1`,
+      [id],
+    );
+    const row = rows[0]?.values?.[0];
+    return row ? mapTimelineRow(row) : null;
+  } finally {
+    db.close();
+  }
+}
+
+export function formatLikeSearchResults(results: LikeSearchResult[]): string {
+  if (results.length === 0) return 'No results found.';
+
+  return results
+    .map((result, index) => {
+      const author = result.authorHandle ? `@${result.authorHandle}` : 'unknown';
+      const date = (result.likedAt ?? result.postedAt)?.slice(0, 10) ?? '?';
+      const text = result.text.length > 140 ? result.text.slice(0, 140) + '...' : result.text;
+      return `${index + 1}. [${date}] ${author}\n   ${text}\n   ${result.url}`;
+    })
+    .join('\n\n');
+}

--- a/src/likes-service.ts
+++ b/src/likes-service.ts
@@ -1,0 +1,28 @@
+import { getTwitterLikesStatus, latestLikeSyncAt } from './likes.js';
+
+export interface LikesStatusView {
+  likeCount: number;
+  lastUpdated: string | null;
+  mode: string;
+  cachePath: string;
+}
+
+export async function getLikesStatusView(): Promise<LikesStatusView> {
+  const status = await getTwitterLikesStatus();
+  return {
+    likeCount: status.totalLikes,
+    lastUpdated: latestLikeSyncAt(status),
+    mode: 'Full archive sync via browser session',
+    cachePath: status.cachePath,
+  };
+}
+
+export function formatLikesStatus(view: LikesStatusView): string {
+  return [
+    'Likes',
+    `  likes: ${view.likeCount}`,
+    `  last updated: ${view.lastUpdated ?? 'never'}`,
+    `  sync mode: ${view.mode}`,
+    `  cache: ${view.cachePath}`,
+  ].join('\n');
+}

--- a/src/likes-trim.ts
+++ b/src/likes-trim.ts
@@ -1,0 +1,212 @@
+import { removeLikesFromArchive } from './archive-actions.js';
+import { readJsonLines } from './fs.js';
+import { RemoteTweetActionError, unlikeTweet } from './graphql-actions.js';
+import { twitterLikesCachePath } from './paths.js';
+import type { LikeRecord } from './types.js';
+import type { XSessionOptions } from './x-graphql.js';
+
+export interface LikesTrimPlan {
+  totalLikes: number;
+  keepCount: number;
+  removeCount: number;
+  keepBoundaryId?: string;
+  firstRemoveId?: string;
+  removalIds: string[];
+}
+
+export interface LikesTrimProgress {
+  batchNumber: number;
+  batchTotal: number;
+  completed: number;
+  totalToRemove: number;
+  currentTweetId?: string;
+  pausedSeconds?: number;
+}
+
+export interface TrimLikesOptions extends XSessionOptions {
+  keep: number;
+  batchSize: number;
+  pauseSeconds: number;
+  rateLimitBackoffSeconds?: number;
+  maxRateLimitRetries?: number;
+  onProgress?: (progress: LikesTrimProgress) => void;
+  sleep?: (ms: number) => Promise<void>;
+}
+
+export interface TrimLikesResult {
+  totalBefore: number;
+  totalAfter: number;
+  kept: number;
+  removed: number;
+  batchesCompleted: number;
+  keepBoundaryId?: string;
+  firstRemovedId?: string;
+  cachePath?: string;
+  dbPath?: string;
+}
+
+export class LikesTrimRateLimitError extends Error {
+  retryAfterSeconds: number;
+
+  constructor(message: string, retryAfterSeconds: number) {
+    super(message);
+    this.name = 'LikesTrimRateLimitError';
+    this.retryAfterSeconds = retryAfterSeconds;
+  }
+}
+
+function likeTimestamp(record: LikeRecord): number {
+  const raw = record.likedAt ?? record.postedAt ?? '';
+  const value = Date.parse(raw);
+  return Number.isFinite(value) ? value : 0;
+}
+
+function compareLikesByRecency(a: LikeRecord, b: LikeRecord): number {
+  const delta = likeTimestamp(b) - likeTimestamp(a);
+  if (delta !== 0) return delta;
+  return String(b.id).localeCompare(String(a.id));
+}
+
+export async function planLikesTrim(keep: number): Promise<LikesTrimPlan> {
+  const existing = await readJsonLines<LikeRecord>(twitterLikesCachePath());
+  const sorted = [...existing].sort(compareLikesByRecency);
+  const keepCount = Math.max(0, Math.min(keep, sorted.length));
+  const keepBoundary = keepCount > 0 ? sorted[keepCount - 1] : undefined;
+  const removable = sorted.slice(keepCount);
+
+  return {
+    totalLikes: sorted.length,
+    keepCount,
+    removeCount: removable.length,
+    keepBoundaryId: keepBoundary?.id,
+    firstRemoveId: removable[0]?.id,
+    removalIds: removable.map((record) => record.id),
+  };
+}
+
+function chunk<T>(items: T[], size: number): T[][] {
+  const width = Math.max(1, size);
+  const batches: T[][] = [];
+  for (let i = 0; i < items.length; i += width) {
+    batches.push(items.slice(i, i + width));
+  }
+  return batches;
+}
+
+function defaultSleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export async function trimLikes(options: TrimLikesOptions): Promise<TrimLikesResult> {
+  const keep = Math.max(0, Math.trunc(options.keep));
+  const batchSize = Math.max(1, Math.trunc(options.batchSize));
+  const pauseSeconds = Math.max(0, options.pauseSeconds);
+  const rateLimitBackoffSeconds = Math.max(
+    1,
+    Math.trunc(options.rateLimitBackoffSeconds ?? Math.max(pauseSeconds, 300)),
+  );
+  const maxRateLimitRetries = Math.max(0, Math.trunc(options.maxRateLimitRetries ?? 3));
+  const plan = await planLikesTrim(keep);
+
+  if (plan.removeCount === 0) {
+    return {
+      totalBefore: plan.totalLikes,
+      totalAfter: plan.totalLikes,
+      kept: plan.keepCount,
+      removed: 0,
+      batchesCompleted: 0,
+      keepBoundaryId: plan.keepBoundaryId,
+    };
+  }
+
+  const batches = chunk(plan.removalIds, batchSize);
+  const sleep = options.sleep ?? defaultSleep;
+  let completed = 0;
+  let lastArchiveState: Awaited<ReturnType<typeof removeLikesFromArchive>> | undefined;
+
+  for (let index = 0; index < batches.length; index += 1) {
+    const batch = batches[index]!;
+    const succeededIds: string[] = [];
+
+    for (const tweetId of batch) {
+      let attempts = 0;
+
+      while (true) {
+        options.onProgress?.({
+          batchNumber: index + 1,
+          batchTotal: batches.length,
+          completed,
+          totalToRemove: plan.removeCount,
+          currentTweetId: tweetId,
+        });
+
+        try {
+          await unlikeTweet(tweetId, options);
+          succeededIds.push(tweetId);
+          completed += 1;
+          break;
+        } catch (error) {
+          const isRateLimited = error instanceof RemoteTweetActionError && error.status === 429;
+          if (isRateLimited && attempts < maxRateLimitRetries) {
+            attempts += 1;
+            options.onProgress?.({
+              batchNumber: index + 1,
+              batchTotal: batches.length,
+              completed,
+              totalToRemove: plan.removeCount,
+              currentTweetId: tweetId,
+              pausedSeconds: rateLimitBackoffSeconds,
+            });
+            await sleep(rateLimitBackoffSeconds * 1000);
+            continue;
+          }
+
+          if (succeededIds.length > 0) {
+            lastArchiveState = await removeLikesFromArchive(succeededIds);
+          }
+
+          if (isRateLimited) {
+            throw new LikesTrimRateLimitError(
+              `Rate limited after ${completed}/${plan.removeCount} removals.\n` +
+              `Retry after ${rateLimitBackoffSeconds}s or rerun the command later.\n` +
+              `${(error as Error).message}`,
+              rateLimitBackoffSeconds,
+            );
+          }
+
+          const prefix = succeededIds.length > 0
+            ? `Processed ${completed}/${plan.removeCount} likes before stopping.\n`
+            : '';
+          throw new Error(`${prefix}${(error as Error).message}`);
+        }
+      }
+    }
+
+    if (succeededIds.length > 0) {
+      lastArchiveState = await removeLikesFromArchive(succeededIds);
+    }
+
+    if (pauseSeconds > 0 && index < batches.length - 1) {
+      options.onProgress?.({
+        batchNumber: index + 1,
+        batchTotal: batches.length,
+        completed,
+        totalToRemove: plan.removeCount,
+        pausedSeconds: pauseSeconds,
+      });
+      await sleep(pauseSeconds * 1000);
+    }
+  }
+
+  return {
+    totalBefore: plan.totalLikes,
+    totalAfter: lastArchiveState?.totalRemaining ?? plan.keepCount,
+    kept: keep,
+    removed: completed,
+    batchesCompleted: batches.length,
+    keepBoundaryId: plan.keepBoundaryId,
+    firstRemovedId: plan.firstRemoveId,
+    cachePath: lastArchiveState?.cachePath,
+    dbPath: lastArchiveState?.dbPath,
+  };
+}

--- a/src/likes.ts
+++ b/src/likes.ts
@@ -1,0 +1,59 @@
+import { pathExists, readJson, readJsonLines } from './fs.js';
+import { twitterLikesBackfillStatePath, twitterLikesCachePath, twitterLikesMetaPath } from './paths.js';
+import type { LikeRecord, LikesBackfillState, LikesCacheMeta } from './types.js';
+
+export function latestLikeSyncAt(
+  meta?: Pick<LikesCacheMeta, 'lastIncrementalSyncAt' | 'lastFullSyncAt'> | null,
+): string | null {
+  let latestValue: string | null = null;
+  let latestTs = Number.NEGATIVE_INFINITY;
+
+  for (const candidate of [meta?.lastIncrementalSyncAt, meta?.lastFullSyncAt]) {
+    if (!candidate) continue;
+    const parsed = Date.parse(candidate);
+    if (!Number.isFinite(parsed) || parsed <= latestTs) continue;
+    latestTs = parsed;
+    latestValue = candidate;
+  }
+
+  return latestValue;
+}
+
+export async function getTwitterLikesStatus(): Promise<LikesCacheMeta & { cachePath: string; metaPath: string }> {
+  const cachePath = twitterLikesCachePath();
+  const metaPath = twitterLikesMetaPath();
+  const statePath = twitterLikesBackfillStatePath();
+  const meta = (await pathExists(metaPath))
+    ? await readJson<LikesCacheMeta>(metaPath)
+    : undefined;
+  const state = (await pathExists(statePath))
+    ? await readJson<LikesBackfillState>(statePath)
+    : undefined;
+  const metaUpdatedAt = latestLikeSyncAt(meta);
+  const graphQlStatusIsNewer = Boolean(
+    state?.lastRunAt && (!metaUpdatedAt || Date.parse(state.lastRunAt) > Date.parse(metaUpdatedAt))
+  );
+
+  if (graphQlStatusIsNewer) {
+    const cache = await readJsonLines<LikeRecord>(cachePath);
+    return {
+      provider: 'twitter',
+      schemaVersion: 1,
+      lastFullSyncAt: meta?.lastFullSyncAt,
+      lastIncrementalSyncAt: state?.lastRunAt,
+      totalLikes: cache.length,
+      cachePath,
+      metaPath,
+    };
+  }
+
+  return {
+    provider: 'twitter',
+    schemaVersion: 1,
+    lastFullSyncAt: meta?.lastFullSyncAt,
+    lastIncrementalSyncAt: meta?.lastIncrementalSyncAt,
+    totalLikes: meta?.totalLikes ?? 0,
+    cachePath,
+    metaPath,
+  };
+}

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -48,6 +48,26 @@ export function twitterBookmarksIndexPath(): string {
   return path.join(dataDir(), 'bookmarks.db');
 }
 
+export function twitterLikesCachePath(): string {
+  return path.join(dataDir(), 'likes.jsonl');
+}
+
+export function twitterLikesMetaPath(): string {
+  return path.join(dataDir(), 'likes-meta.json');
+}
+
+export function twitterLikesBackfillStatePath(): string {
+  return path.join(dataDir(), 'likes-backfill-state.json');
+}
+
+export function twitterLikesIndexPath(): string {
+  return path.join(dataDir(), 'likes.db');
+}
+
+export function isLikesFirstRun(): boolean {
+  return !fs.existsSync(twitterLikesCachePath());
+}
+
 export function preferencesPath(): string {
   return path.join(dataDir(), '.preferences');
 }

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -68,6 +68,26 @@ export function isLikesFirstRun(): boolean {
   return !fs.existsSync(twitterLikesCachePath());
 }
 
+export function twitterFeedCachePath(): string {
+  return path.join(dataDir(), 'feed.jsonl');
+}
+
+export function twitterFeedMetaPath(): string {
+  return path.join(dataDir(), 'feed-meta.json');
+}
+
+export function twitterFeedStatePath(): string {
+  return path.join(dataDir(), 'feed-state.json');
+}
+
+export function twitterFeedIndexPath(): string {
+  return path.join(dataDir(), 'feed.db');
+}
+
+export function isFeedFirstRun(): boolean {
+  return !fs.existsSync(twitterFeedCachePath());
+}
+
 export function preferencesPath(): string {
   return path.join(dataDir(), '.preferences');
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -110,6 +110,36 @@ export interface LikeRecord {
   ingestedVia?: 'browser' | 'graphql';
 }
 
+export interface FeedRecord {
+  id: string;
+  tweetId: string;
+  authorHandle?: string;
+  authorName?: string;
+  authorProfileImageUrl?: string;
+  author?: BookmarkAuthorSnapshot;
+  url: string;
+  text: string;
+  postedAt?: string | null;
+  syncedAt: string;
+  sortIndex?: string | null;
+  fetchPage?: number | null;
+  fetchPosition?: number | null;
+  conversationId?: string;
+  inReplyToStatusId?: string;
+  inReplyToUserId?: string;
+  quotedStatusId?: string;
+  quotedTweet?: QuotedTweetSnapshot;
+  language?: string;
+  sourceApp?: string;
+  possiblySensitive?: boolean;
+  engagement?: BookmarkEngagementSnapshot;
+  media?: string[];
+  mediaObjects?: BookmarkMediaObject[];
+  links?: string[];
+  tags?: string[];
+  ingestedVia?: 'graphql';
+}
+
 export interface BookmarkCacheMeta {
   provider: 'twitter';
   schemaVersion: number;
@@ -124,6 +154,14 @@ export interface LikesCacheMeta {
   lastFullSyncAt?: string;
   lastIncrementalSyncAt?: string;
   totalLikes: number;
+}
+
+export interface FeedCacheMeta {
+  provider: 'twitter';
+  schemaVersion: number;
+  lastSyncAt?: string;
+  totalItems: number;
+  totalSkippedEntries: number;
 }
 
 export interface XOAuthTokenSet {
@@ -155,4 +193,16 @@ export interface LikesBackfillState {
   lastAdded: number;
   lastSeenIds: string[];
   stopReason?: string;
+}
+
+export interface FeedBackfillState {
+  provider: 'twitter';
+  lastRunAt?: string;
+  totalRuns: number;
+  totalFetched: number;
+  totalStored: number;
+  totalSkippedEntries: number;
+  lastSeenIds: string[];
+  stopReason?: string;
+  lastCursor?: string;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -76,12 +76,48 @@ export interface BookmarkRecord {
   ingestedVia?: 'api' | 'browser' | 'graphql';
 }
 
+export interface LikeRecord {
+  id: string;
+  tweetId: string;
+  authorHandle?: string;
+  authorName?: string;
+  authorProfileImageUrl?: string;
+  author?: BookmarkAuthorSnapshot;
+  url: string;
+  text: string;
+  postedAt?: string | null;
+  likedAt?: string | null;
+  syncedAt: string;
+  conversationId?: string;
+  inReplyToStatusId?: string;
+  inReplyToUserId?: string;
+  quotedStatusId?: string;
+  quotedTweet?: QuotedTweetSnapshot;
+  language?: string;
+  sourceApp?: string;
+  possiblySensitive?: boolean;
+  engagement?: BookmarkEngagementSnapshot;
+  media?: string[];
+  mediaObjects?: BookmarkMediaObject[];
+  links?: string[];
+  tags?: string[];
+  ingestedVia?: 'browser' | 'graphql';
+}
+
 export interface BookmarkCacheMeta {
   provider: 'twitter';
   schemaVersion: number;
   lastFullSyncAt?: string;
   lastIncrementalSyncAt?: string;
   totalBookmarks: number;
+}
+
+export interface LikesCacheMeta {
+  provider: 'twitter';
+  schemaVersion: number;
+  lastFullSyncAt?: string;
+  lastIncrementalSyncAt?: string;
+  totalLikes: number;
 }
 
 export interface XOAuthTokenSet {
@@ -94,6 +130,16 @@ export interface XOAuthTokenSet {
 }
 
 export interface BookmarkBackfillState {
+  provider: 'twitter';
+  lastRunAt?: string;
+  totalRuns: number;
+  totalAdded: number;
+  lastAdded: number;
+  lastSeenIds: string[];
+  stopReason?: string;
+}
+
+export interface LikesBackfillState {
   provider: 'twitter';
   lastRunAt?: string;
   totalRuns: number;

--- a/src/web-server.ts
+++ b/src/web-server.ts
@@ -1,0 +1,266 @@
+import { serve } from '@hono/node-server';
+import { serveStatic } from '@hono/node-server/serve-static';
+import { Hono } from 'hono';
+import { readFile } from 'node:fs/promises';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { countBookmarks, getBookmarkById, listBookmarks, type BookmarkTimelineFilters } from './bookmarks-db.js';
+import { countLikes, getLikeById, listLikes, type LikeTimelineFilters } from './likes-db.js';
+import {
+  dataDir,
+  twitterBookmarksCachePath,
+  twitterBookmarksIndexPath,
+  twitterLikesCachePath,
+  twitterLikesIndexPath,
+} from './paths.js';
+import type { ApiListResponse, ApiStatusResponse } from './web-types.js';
+
+export interface WebServerOptions {
+  host?: string;
+  port?: number;
+  staticDir?: string;
+}
+
+export interface RunningWebServer {
+  host: string;
+  port: number;
+  url: string;
+  close: () => Promise<void>;
+}
+
+function parseInteger(value: string | undefined, fallback: number, min = 0): number {
+  if (!value) return fallback;
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed < min) return fallback;
+  return parsed;
+}
+
+function isMissingTableError(error: unknown): boolean {
+  return error instanceof Error && /no such table/i.test(error.message);
+}
+
+function repoRootFromModule(): string {
+  const moduleDir = path.dirname(fileURLToPath(import.meta.url));
+  return path.resolve(moduleDir, '..');
+}
+
+export function resolveWebBuildDir(override?: string): string {
+  if (override) return override;
+  if (process.env.FT_WEB_DIST_DIR) return process.env.FT_WEB_DIST_DIR;
+
+  const repoRoot = repoRootFromModule();
+  const candidates = [
+    path.join(repoRoot, 'dist', 'web'),
+    path.join(repoRoot, 'web', 'dist'),
+  ];
+
+  const found = candidates.find((candidate) => fs.existsSync(path.join(candidate, 'index.html')));
+  return found ?? candidates[0];
+}
+
+async function loadIndexHtml(staticDir: string): Promise<string> {
+  const indexPath = path.join(staticDir, 'index.html');
+  try {
+    return await readFile(indexPath, 'utf8');
+  } catch {
+    throw new Error(`Web assets not found at ${staticDir}. Run npm run build first.`);
+  }
+}
+
+export async function createWebApp(options: WebServerOptions = {}): Promise<Hono> {
+  const staticDir = resolveWebBuildDir(options.staticDir);
+  const indexHtml = await loadIndexHtml(staticDir);
+  const app = new Hono();
+
+  app.onError((error) => {
+    const message = error instanceof Error ? error.message : 'Unexpected server error';
+    const status = /Invalid search query/i.test(message) ? 400 : 500;
+    return Response.json({ error: message }, { status });
+  });
+
+  app.get('/api/status', async (c) => {
+    const response: ApiStatusResponse = {
+      dataDir: dataDir(),
+      bookmarks: {
+        total: fs.existsSync(twitterBookmarksIndexPath()) ? await countBookmarks() : 0,
+        hasCache: fs.existsSync(twitterBookmarksCachePath()),
+        hasIndex: fs.existsSync(twitterBookmarksIndexPath()),
+      },
+      likes: {
+        total: fs.existsSync(twitterLikesIndexPath()) ? await countLikes() : 0,
+        hasCache: fs.existsSync(twitterLikesCachePath()),
+        hasIndex: fs.existsSync(twitterLikesIndexPath()),
+      },
+    };
+    return c.json(response);
+  });
+
+  app.get('/api/bookmarks', async (c) => {
+    const limit = parseInteger(c.req.query('limit'), 30, 1);
+    const offset = parseInteger(c.req.query('offset'), 0, 0);
+    const sort: 'asc' | 'desc' = c.req.query('sort') === 'asc' ? 'asc' : 'desc';
+    if (!fs.existsSync(twitterBookmarksIndexPath())) {
+      const response: ApiListResponse<never> = {
+        source: 'bookmarks',
+        total: 0,
+        limit,
+        offset,
+        items: [],
+      };
+      return c.json(response);
+    }
+    const filters: BookmarkTimelineFilters = {
+      query: c.req.query('query'),
+      author: c.req.query('author'),
+      after: c.req.query('after'),
+      before: c.req.query('before'),
+      category: c.req.query('category'),
+      domain: c.req.query('domain'),
+      sort,
+      limit,
+      offset,
+    };
+    let items: Awaited<ReturnType<typeof listBookmarks>> = [];
+    let total = 0;
+    try {
+      [items, total] = await Promise.all([
+        listBookmarks(filters),
+        countBookmarks(filters),
+      ]);
+    } catch (error) {
+      if (!isMissingTableError(error)) throw error;
+    }
+
+    const response: ApiListResponse<(typeof items)[number]> = {
+      source: 'bookmarks',
+      total,
+      limit,
+      offset,
+      items,
+    };
+    return c.json(response);
+  });
+
+  app.get('/api/bookmarks/:id', async (c) => {
+    if (!fs.existsSync(twitterBookmarksIndexPath())) {
+      return c.json({ error: 'Bookmark not found' }, 404);
+    }
+    let item = null;
+    try {
+      item = await getBookmarkById(c.req.param('id'));
+    } catch (error) {
+      if (!isMissingTableError(error)) throw error;
+    }
+    if (!item) return c.json({ error: 'Bookmark not found' }, 404);
+    return c.json(item);
+  });
+
+  app.get('/api/likes', async (c) => {
+    const limit = parseInteger(c.req.query('limit'), 30, 1);
+    const offset = parseInteger(c.req.query('offset'), 0, 0);
+    const sort: 'asc' | 'desc' = c.req.query('sort') === 'asc' ? 'asc' : 'desc';
+    if (!fs.existsSync(twitterLikesIndexPath())) {
+      const response: ApiListResponse<never> = {
+        source: 'likes',
+        total: 0,
+        limit,
+        offset,
+        items: [],
+      };
+      return c.json(response);
+    }
+    const filters: LikeTimelineFilters = {
+      query: c.req.query('query'),
+      author: c.req.query('author'),
+      after: c.req.query('after'),
+      before: c.req.query('before'),
+      sort,
+      limit,
+      offset,
+    };
+    let items: Awaited<ReturnType<typeof listLikes>> = [];
+    let total = 0;
+    try {
+      [items, total] = await Promise.all([
+        listLikes(filters),
+        countLikes(filters),
+      ]);
+    } catch (error) {
+      if (!isMissingTableError(error)) throw error;
+    }
+
+    const response: ApiListResponse<(typeof items)[number]> = {
+      source: 'likes',
+      total,
+      limit,
+      offset,
+      items,
+    };
+    return c.json(response);
+  });
+
+  app.get('/api/likes/:id', async (c) => {
+    if (!fs.existsSync(twitterLikesIndexPath())) {
+      return c.json({ error: 'Like not found' }, 404);
+    }
+    let item = null;
+    try {
+      item = await getLikeById(c.req.param('id'));
+    } catch (error) {
+      if (!isMissingTableError(error)) throw error;
+    }
+    if (!item) return c.json({ error: 'Like not found' }, 404);
+    return c.json(item);
+  });
+
+  app.get('/assets/*', serveStatic({ root: staticDir }));
+  app.get('/favicon.ico', (c) => c.body(null, 204));
+  app.get('*', (c) => c.html(indexHtml));
+
+  return app;
+}
+
+export async function startWebServer(options: WebServerOptions = {}): Promise<RunningWebServer> {
+  const host = options.host ?? '127.0.0.1';
+  const port = options.port ?? 4310;
+  const app = await createWebApp(options);
+
+  const server = serve({
+    fetch: app.fetch,
+    hostname: host,
+    port,
+  });
+
+  if (!server.listening) {
+    await new Promise<void>((resolve, reject) => {
+      const onListening = () => {
+        server.off('error', onError);
+        resolve();
+      };
+      const onError = (error: Error) => {
+        server.off('listening', onListening);
+        reject(error);
+      };
+      server.once('listening', onListening);
+      server.once('error', onError);
+    });
+  }
+
+  const address = server.address();
+  const actualPort = typeof address === 'object' && address ? address.port : port;
+
+  return {
+    host,
+    port: actualPort,
+    url: `http://${host}:${actualPort}`,
+    close: async () => {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error?: Error) => {
+          if (error) reject(error);
+          else resolve();
+        });
+      });
+    },
+  };
+}

--- a/src/web-types.ts
+++ b/src/web-types.ts
@@ -1,0 +1,21 @@
+export type ArchiveSource = 'bookmarks' | 'likes';
+
+export interface ApiStatusBucket {
+  total: number;
+  hasCache: boolean;
+  hasIndex: boolean;
+}
+
+export interface ApiStatusResponse {
+  dataDir: string;
+  bookmarks: ApiStatusBucket;
+  likes: ApiStatusBucket;
+}
+
+export interface ApiListResponse<T> {
+  source: ArchiveSource;
+  total: number;
+  limit: number;
+  offset: number;
+  items: T[];
+}

--- a/src/web.ts
+++ b/src/web.ts
@@ -1,0 +1,43 @@
+import fs from 'node:fs';
+import { spawn } from 'node:child_process';
+import { resolveWebBuildDir, startWebServer as startServer, type RunningWebServer, type WebServerOptions } from './web-server.js';
+
+export interface WebCommandOptions extends WebServerOptions {
+  open?: boolean;
+}
+
+export function assertWebAssetsBuilt(): void {
+  const buildDir = resolveWebBuildDir();
+  const indexPath = `${buildDir}/index.html`;
+  if (!fs.existsSync(indexPath)) {
+    throw new Error(`Web assets not found at ${buildDir}. Run npm run build first.`);
+  }
+}
+
+function tryOpenBrowser(url: string): void {
+  const platform = process.platform;
+  const command = platform === 'darwin'
+    ? ['open', url]
+    : platform === 'win32'
+      ? ['cmd', '/c', 'start', '', url]
+      : ['xdg-open', url];
+
+  try {
+    const child = spawn(command[0], command.slice(1), {
+      detached: true,
+      stdio: 'ignore',
+    });
+    child.on('error', () => {
+      // Browser launch is a convenience only.
+    });
+    child.unref();
+  } catch {
+    // Browser launch is a convenience only.
+  }
+}
+
+export async function startWebServer(options: WebCommandOptions = {}): Promise<RunningWebServer> {
+  const server = await startServer(options);
+  if (options.open) tryOpenBrowser(server.url);
+  return server;
+}

--- a/src/x-graphql.ts
+++ b/src/x-graphql.ts
@@ -1,0 +1,61 @@
+import { loadChromeSessionConfig } from './config.js';
+import { extractChromeXCookies } from './chrome-cookies.js';
+import { extractFirefoxXCookies } from './firefox-cookies.js';
+
+export const CHROME_UA =
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.0.0 Safari/537.36';
+
+export const X_PUBLIC_BEARER =
+  'AAAAAAAAAAAAAAAAAAAAANRILgAAAAAAnNwIzUejRCOuH5E6I8xnZz4puTs%3D1Zv7ttfk8LF81IUq16cHjhLTvJu4FA33AGWWjCpTnA';
+
+export interface XSessionOptions {
+  browser?: string;
+  chromeUserDataDir?: string;
+  chromeProfileDirectory?: string;
+  firefoxProfileDir?: string;
+  csrfToken?: string;
+  cookieHeader?: string;
+}
+
+export interface XSessionAuth {
+  csrfToken: string;
+  cookieHeader?: string;
+}
+
+export function xGraphqlOrigin(): string {
+  return (process.env.FT_X_API_ORIGIN ?? 'https://x.com').replace(/\/+$/, '');
+}
+
+export function buildGraphqlUrl(queryId: string, operationName: string): string {
+  return `${xGraphqlOrigin()}/i/api/graphql/${queryId}/${operationName}`;
+}
+
+export function buildXGraphqlHeaders(session: XSessionAuth): Record<string, string> {
+  return {
+    authorization: `Bearer ${X_PUBLIC_BEARER}`,
+    'x-csrf-token': session.csrfToken,
+    'x-twitter-auth-type': 'OAuth2Session',
+    'x-twitter-active-user': 'yes',
+    'content-type': 'application/json',
+    'user-agent': CHROME_UA,
+    cookie: session.cookieHeader ?? `ct0=${session.csrfToken}`,
+  };
+}
+
+export function resolveXSessionAuth(options: XSessionOptions = {}): XSessionAuth {
+  if (options.csrfToken) {
+    return {
+      csrfToken: options.csrfToken,
+      cookieHeader: options.cookieHeader,
+    };
+  }
+
+  const config = loadChromeSessionConfig({ browserId: options.browser });
+  if (config.browser.cookieBackend === 'firefox') {
+    return extractFirefoxXCookies(options.firefoxProfileDir);
+  }
+
+  const chromeDir = options.chromeUserDataDir ?? config.chromeUserDataDir;
+  const chromeProfile = options.chromeProfileDirectory ?? config.chromeProfileDirectory;
+  return extractChromeXCookies(chromeDir, chromeProfile, config.browser);
+}

--- a/src/x-graphql.ts
+++ b/src/x-graphql.ts
@@ -1,6 +1,11 @@
 import { loadChromeSessionConfig } from './config.js';
 import { extractChromeXCookies } from './chrome-cookies.js';
 import { extractFirefoxXCookies } from './firefox-cookies.js';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
 
 export const CHROME_UA =
   'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.0.0 Safari/537.36';
@@ -22,6 +27,8 @@ export interface XSessionAuth {
   cookieHeader?: string;
 }
 
+const execFileAsync = promisify(execFile);
+
 export function xGraphqlOrigin(): string {
   return (process.env.FT_X_API_ORIGIN ?? 'https://x.com').replace(/\/+$/, '');
 }
@@ -40,6 +47,90 @@ export function buildXGraphqlHeaders(session: XSessionAuth): Record<string, stri
     'user-agent': CHROME_UA,
     cookie: session.cookieHeader ?? `ct0=${session.csrfToken}`,
   };
+}
+
+function shouldFallbackToCurl(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  const codes = [
+    (error as any)?.code,
+    (error as any)?.cause?.code,
+    (error as any)?.errno,
+    (error as any)?.cause?.errno,
+  ].filter((value): value is string => typeof value === 'string');
+
+  return codes.some((code) =>
+    [
+      'UND_ERR_CONNECT_TIMEOUT',
+      'UND_ERR_CONNECT_ERROR',
+      'ECONNRESET',
+      'ECONNREFUSED',
+      'ETIMEDOUT',
+      'EHOSTUNREACH',
+      'ENETUNREACH',
+    ].includes(code),
+  );
+}
+
+function parseCurlHeaders(raw: string): Headers {
+  const normalized = raw.replace(/\r\n/g, '\n');
+  const blocks = normalized
+    .split('\n\n')
+    .map((block) => block.trim())
+    .filter((block) => block.startsWith('HTTP/'));
+  const last = blocks[blocks.length - 1] ?? '';
+  const headers = new Headers();
+  for (const line of last.split('\n').slice(1)) {
+    const idx = line.indexOf(':');
+    if (idx <= 0) continue;
+    const key = line.slice(0, idx).trim();
+    const value = line.slice(idx + 1).trim();
+    headers.append(key, value);
+  }
+  return headers;
+}
+
+async function fetchViaCurl(input: string, init?: RequestInit): Promise<Response> {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), 'ft-x-curl-'));
+  const headerPath = path.join(tmpDir, 'headers.txt');
+  const bodyPath = path.join(tmpDir, 'body.txt');
+  const method = init?.method ?? 'GET';
+  const args = ['-sS', '-L', '-X', method, input, '-D', headerPath, '-o', bodyPath];
+
+  try {
+    for (const [key, value] of Object.entries(init?.headers as Record<string, string> ?? {})) {
+      args.push('-H', `${key}: ${value}`);
+    }
+    if (init?.body != null) {
+      const bodyFile = path.join(tmpDir, 'request-body.txt');
+      await writeFile(bodyFile, String(init.body));
+      args.push('--data-binary', `@${bodyFile}`);
+    }
+
+    await execFileAsync('curl', args, { maxBuffer: 10 * 1024 * 1024 });
+    const headerRaw = await readFile(headerPath, 'utf8');
+    const body = await readFile(bodyPath, 'utf8');
+    const statusLine = headerRaw
+      .replace(/\r\n/g, '\n')
+      .split('\n')
+      .filter((line) => line.startsWith('HTTP/'))
+      .pop();
+    const status = Number(statusLine?.split(/\s+/)[1] ?? 0) || 0;
+    return new Response(body, {
+      status,
+      headers: parseCurlHeaders(headerRaw),
+    });
+  } finally {
+    await rm(tmpDir, { recursive: true, force: true });
+  }
+}
+
+export async function fetchXResource(input: string, init?: RequestInit): Promise<Response> {
+  try {
+    return await fetch(input, init);
+  } catch (error) {
+    if (!shouldFallbackToCurl(error)) throw error;
+    return fetchViaCurl(input, init);
+  }
 }
 
 export function resolveXSessionAuth(options: XSessionOptions = {}): XSessionAuth {

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,0 +1,36 @@
+# fieldtheory-cli likes trim command
+
+## Plan
+
+- [x] Unit 1: stop the old ad hoc bulk unlike process and snapshot current likes state
+- [x] Unit 2: add throttled bulk likes trim primitives and efficient per-batch local reconciliation
+- [x] Unit 3: expose `ft likes trim`, update docs, and keep help text aligned
+- [x] Verification: run targeted tests and build, then validate the real archive count before execution
+- [x] Execution: run the formal trim command until only the latest 200 likes remain
+- [x] Review: record implementation and live execution results
+
+## Notes
+
+- Target branch: `feat/likes-archive`
+- Origin plan: `docs/plans/2026-04-09-003-feat-likes-trim-command-plan.md`
+- Scope boundary: likes-only bulk trim, with batch throttling and resumable execution from current local state
+
+## Review
+- Added `src/likes-trim.ts` to formalize bulk likes trimming, including trim planning by recency, per-batch remote unlike execution, and one local archive/index reconciliation per batch.
+- Added `removeLikesFromArchive()` in `src/archive-actions.ts` so bulk removals rewrite `likes.jsonl`, update `likes-meta.json`, and rebuild `likes.db` once per batch instead of once per item.
+- Added `ft likes trim` in `src/cli.ts` with `--keep`, `--batch-size`, `--pause-seconds`, `--rate-limit-backoff-seconds`, and `--max-rate-limit-retries`.
+- Added 429-aware retry handling by introducing `RemoteTweetActionError` in `src/graphql-actions.ts` and automatic backoff/retry inside `src/likes-trim.ts`.
+- Updated `README.md` and `docs/README.md` for the new formal bulk-trim command and plan entry.
+- Verification passed:
+  - `npm test -- tests/archive-actions.test.ts`
+  - `npm test -- tests/cli-actions.test.ts`
+  - `npm run build`
+- Live execution results:
+  - Current likes before formal run: `530`
+  - Real command executed: `node dist/cli.js likes trim --keep 200 --batch-size 20 --pause-seconds 30 --rate-limit-backoff-seconds 300 --max-rate-limit-retries 5`
+  - Initial first attempt hit `429` immediately; command was enhanced with automatic rate-limit backoff and retry.
+  - Final live run removed `330` older likes successfully.
+  - Final local verification:
+    - `likes.jsonl` count: `200`
+    - `node dist/cli.js likes status` reports `likes: 200`
+    - oldest kept like id: `2020906224792027164`

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -29,8 +29,49 @@
   - Current likes before formal run: `530`
   - Real command executed: `node dist/cli.js likes trim --keep 200 --batch-size 20 --pause-seconds 30 --rate-limit-backoff-seconds 300 --max-rate-limit-retries 5`
   - Initial first attempt hit `429` immediately; command was enhanced with automatic rate-limit backoff and retry.
-  - Final live run removed `330` older likes successfully.
+- Final live run removed `330` older likes successfully.
   - Final local verification:
     - `likes.jsonl` count: `200`
     - `node dist/cli.js likes status` reports `likes: 200`
     - oldest kept like id: `2020906224792027164`
+
+# fieldtheory-cli X home timeline viewer
+
+## Plan
+
+- [x] Unit 1: capture and validate the Home timeline GraphQL contract, then add feed cache/meta/state primitives
+- [x] Unit 2: add feed SQLite index, list/show/status read models, and local paging
+- [x] Unit 3: expose `ft feed sync|status|list|show` as the CLI-first read-only viewer
+- [x] Unit 4: update docs and record phase-1 operator boundaries
+- [x] Verification: prove mocked-X sync, index build, and CLI browsing behavior with targeted tests
+- [x] Review: record implementation and validation results
+
+## Notes
+
+- Origin requirements: `docs/brainstorms/2026-04-12-x-feed-requirements.md`
+- Origin plan: `docs/plans/2026-04-12-004-feat-x-feed-cli-viewer-plan.md`
+- Scope boundary: CLI-first, read-only, tweet-only Home timeline viewing with local cache and local paging; no web surface or feed actions in phase 1
+
+## Review
+
+- Added a dedicated feed archive path with `feed.jsonl`, `feed-meta.json`, `feed-state.json`, and `feed.db`, plus separate feed record typing and ordering metadata in `src/types.ts` and `src/paths.ts`.
+- Added Home timeline GraphQL ingestion in `src/graphql-feed.ts`, including first-page and cursor-page request handling, tweet-only normalization, promoted/non-tweet entry skipping, and stable local ordering via `sortIndex`, `fetchPage`, and `fetchPosition`.
+- Added feed read models in `src/feed-db.ts`, `src/feed-service.ts`, and `src/feed.ts` to support local paging, item lookup, and feed status formatting without coupling feed storage to likes or bookmarks.
+- Exposed `ft feed sync`, `ft feed status`, `ft feed list`, and `ft feed show` in `src/cli.ts`.
+- Updated `README.md` and `docs/README.md` for the new read-only feed viewer workflow and linked planning artifacts under `docs/`.
+- Hardened X network access by extending `src/x-graphql.ts` with broader `curl` fallback coverage for Node fetch failures such as `UND_ERR_CONNECT_TIMEOUT`, `UND_ERR_CONNECT_ERROR`, and `ECONNRESET`, then routed feed, likes, bookmarks, and remote mutation GraphQL calls through the shared helper.
+- Verification passed:
+  - `npm test -- tests/graphql-feed.test.ts tests/feed-db.test.ts tests/feed-service.test.ts tests/cli-feed.test.ts`
+  - `npm run build`
+- Real validation passed against the live logged-in X session:
+  - `node dist/cli.js feed sync --max-pages 2`
+  - result: `56` new feed items synced, `16` skipped non-tweet entries
+  - `node dist/cli.js feed status`
+  - result: `items: 56`, `skipped entries: 16`, `last updated: 2026-04-12T14:51:04.458Z`
+  - `node dist/cli.js feed list --limit 5`
+  - result: returned live cached feed items, including `2043320548776681627 @mattpocockuk`
+  - `node dist/cli.js feed show 2043320548776681627`
+  - result: returned full tweet detail with author, text, URL, and ordering metadata
+- Shared-network regression check also passed:
+  - `node dist/cli.js likes sync --max-pages 1`
+  - result: `15` new likes synced, `215` total

--- a/tests/archive-actions.test.ts
+++ b/tests/archive-actions.test.ts
@@ -1,0 +1,143 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import os from 'node:os';
+import path from 'node:path';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { removeBookmarkFromArchive, removeLikeFromArchive, removeLikesFromArchive } from '../src/archive-actions.js';
+import { buildIndex, getBookmarkById } from '../src/bookmarks-db.js';
+import { buildLikesIndex, getLikeById } from '../src/likes-db.js';
+import { writeJson } from '../src/fs.js';
+
+const BOOKMARK_FIXTURE = {
+  id: 'b1',
+  tweetId: 'b1',
+  url: 'https://x.com/alice/status/b1',
+  text: 'Saved bookmark',
+  authorHandle: 'alice',
+  authorName: 'Alice',
+  postedAt: '2026-03-01T00:00:00Z',
+  bookmarkedAt: '2026-03-02T00:00:00Z',
+  syncedAt: '2026-03-02T00:00:00Z',
+  links: [],
+  mediaObjects: [],
+  tags: [],
+  ingestedVia: 'graphql',
+};
+
+const LIKE_FIXTURE = {
+  id: 'l1',
+  tweetId: 'l1',
+  url: 'https://x.com/bob/status/l1',
+  text: 'Saved like',
+  authorHandle: 'bob',
+  authorName: 'Bob',
+  postedAt: '2026-03-01T00:00:00Z',
+  likedAt: '2026-03-03T00:00:00Z',
+  syncedAt: '2026-03-03T00:00:00Z',
+  links: [],
+  mediaObjects: [],
+  tags: [],
+  ingestedVia: 'graphql',
+};
+
+async function withArchiveData(fn: (dir: string) => Promise<void>): Promise<void> {
+  const dir = await mkdtemp(path.join(os.tmpdir(), 'ft-archive-actions-'));
+  process.env.FT_DATA_DIR = dir;
+  try {
+    await writeFile(path.join(dir, 'bookmarks.jsonl'), `${JSON.stringify(BOOKMARK_FIXTURE)}\n`);
+    await writeFile(path.join(dir, 'likes.jsonl'), `${JSON.stringify(LIKE_FIXTURE)}\n`);
+    await writeJson(path.join(dir, 'bookmarks-meta.json'), {
+      provider: 'twitter',
+      schemaVersion: 1,
+      totalBookmarks: 1,
+    });
+    await writeJson(path.join(dir, 'likes-meta.json'), {
+      provider: 'twitter',
+      schemaVersion: 1,
+      totalLikes: 1,
+    });
+    await buildIndex({ force: true });
+    await buildLikesIndex({ force: true });
+    await fn(dir);
+  } finally {
+    delete process.env.FT_DATA_DIR;
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+test('removeLikeFromArchive deletes the cached like and rebuilds the likes index', async () => {
+  await withArchiveData(async () => {
+    const result = await removeLikeFromArchive('l1');
+    assert.equal(result.removed, true);
+    assert.equal(result.totalRemaining, 0);
+    assert.equal(await getLikeById('l1'), null);
+  });
+});
+
+test('removeBookmarkFromArchive deletes the cached bookmark and rebuilds the bookmarks index', async () => {
+  await withArchiveData(async () => {
+    const result = await removeBookmarkFromArchive('b1');
+    assert.equal(result.removed, true);
+    assert.equal(result.totalRemaining, 0);
+    assert.equal(await getBookmarkById('b1'), null);
+  });
+});
+
+test('removeBookmarkFromArchive reports a missing local record without corrupting the archive', async () => {
+  await withArchiveData(async () => {
+    const result = await removeBookmarkFromArchive('missing');
+    assert.equal(result.removed, false);
+    assert.equal(result.totalRemaining, 1);
+    assert.ok(await getBookmarkById('b1'));
+  });
+});
+
+test('removeLikesFromArchive deletes multiple cached likes and rebuilds the index once', async () => {
+  await withArchiveData(async (dir) => {
+    const extra = {
+      ...LIKE_FIXTURE,
+      id: 'l2',
+      tweetId: 'l2',
+      url: 'https://x.com/bob/status/l2',
+      text: 'Second saved like',
+    };
+
+    await writeFile(path.join(dir, 'likes.jsonl'), `${JSON.stringify(LIKE_FIXTURE)}\n${JSON.stringify(extra)}\n`);
+    await writeJson(path.join(dir, 'likes-meta.json'), {
+      provider: 'twitter',
+      schemaVersion: 1,
+      totalLikes: 2,
+    });
+    await buildLikesIndex({ force: true });
+
+    const result = await removeLikesFromArchive(['l1', 'l2']);
+    assert.deepEqual(result.removedIds.sort(), ['l1', 'l2']);
+    assert.equal(result.totalRemaining, 0);
+    assert.equal(await getLikeById('l1'), null);
+    assert.equal(await getLikeById('l2'), null);
+  });
+});
+
+test('removeLikesFromArchive treats tweetId matches as removed instead of missing', async () => {
+  await withArchiveData(async (dir) => {
+    const remapped = {
+      ...LIKE_FIXTURE,
+      id: 'internal-like-row',
+      tweetId: 'tweet-123',
+      url: 'https://x.com/bob/status/tweet-123',
+    };
+
+    await writeFile(path.join(dir, 'likes.jsonl'), `${JSON.stringify(remapped)}\n`);
+    await writeJson(path.join(dir, 'likes-meta.json'), {
+      provider: 'twitter',
+      schemaVersion: 1,
+      totalLikes: 1,
+    });
+    await buildLikesIndex({ force: true });
+
+    const result = await removeLikesFromArchive(['tweet-123']);
+    assert.deepEqual(result.removedIds, ['internal-like-row']);
+    assert.deepEqual(result.missingIds, []);
+    assert.equal(result.totalRemaining, 0);
+  });
+});

--- a/tests/cli-actions.test.ts
+++ b/tests/cli-actions.test.ts
@@ -1,0 +1,336 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import os from 'node:os';
+import path from 'node:path';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { buildIndex, getBookmarkById } from '../src/bookmarks-db.js';
+import { buildLikesIndex, getLikeById } from '../src/likes-db.js';
+import { writeJson } from '../src/fs.js';
+
+const execFileAsync = promisify(execFile);
+
+const BOOKMARK_FIXTURE = {
+  id: 'b1',
+  tweetId: 'b1',
+  url: 'https://x.com/alice/status/b1',
+  text: 'Saved bookmark',
+  authorHandle: 'alice',
+  authorName: 'Alice',
+  postedAt: '2026-03-01T00:00:00Z',
+  bookmarkedAt: '2026-03-02T00:00:00Z',
+  syncedAt: '2026-03-02T00:00:00Z',
+  links: [],
+  mediaObjects: [],
+  tags: [],
+  ingestedVia: 'graphql',
+};
+
+const LIKE_FIXTURE = {
+  id: 'l1',
+  tweetId: 'l1',
+  url: 'https://x.com/bob/status/l1',
+  text: 'Saved like',
+  authorHandle: 'bob',
+  authorName: 'Bob',
+  postedAt: '2026-03-01T00:00:00Z',
+  likedAt: '2026-03-03T00:00:00Z',
+  syncedAt: '2026-03-03T00:00:00Z',
+  links: [],
+  mediaObjects: [],
+  tags: [],
+  ingestedVia: 'graphql',
+};
+
+async function startMockXServer(options: { unlikeStatus?: number; unbookmarkStatus?: number } = {}) {
+  const server = http.createServer(async (req, res) => {
+    const body = await new Promise<string>((resolve) => {
+      let data = '';
+      req.on('data', (chunk) => { data += chunk; });
+      req.on('end', () => resolve(data));
+    });
+
+    if (req.method !== 'POST') {
+      res.writeHead(404).end('not found');
+      return;
+    }
+
+    const parsed = body ? JSON.parse(body) : {};
+    if (req.url?.includes('/ZYKSe-w7KEslx3JhSIk5LA/UnfavoriteTweet')) {
+      assert.equal(parsed.variables?.tweet_id, 'l1');
+      const status = options.unlikeStatus ?? 200;
+      res.writeHead(status, { 'content-type': 'application/json' });
+      res.end(status === 200 ? JSON.stringify({ data: { unfavorite_tweet: 'Done' } }) : 'upstream failure');
+      return;
+    }
+
+    if (req.url?.includes('/Wlmlj2-xzyS1GN3a6cj-mQ/DeleteBookmark')) {
+      assert.equal(parsed.variables?.tweet_id, 'b1');
+      const status = options.unbookmarkStatus ?? 200;
+      res.writeHead(status, { 'content-type': 'application/json' });
+      res.end(status === 200 ? JSON.stringify({ data: { tweet_bookmark_delete: 'Done' } }) : 'upstream failure');
+      return;
+    }
+
+    res.writeHead(404).end('not found');
+  });
+
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', () => resolve()));
+  const address = server.address();
+  if (!address || typeof address === 'string') throw new Error('Failed to bind mock X server.');
+
+  return {
+    origin: `http://127.0.0.1:${address.port}`,
+    close: () => new Promise<void>((resolve, reject) => server.close((error) => error ? reject(error) : resolve())),
+  };
+}
+
+async function withCliDataDir(fn: (dir: string) => Promise<void>): Promise<void> {
+  const dir = await mkdtemp(path.join(os.tmpdir(), 'ft-cli-actions-'));
+  process.env.FT_DATA_DIR = dir;
+  try {
+    await writeFile(path.join(dir, 'bookmarks.jsonl'), `${JSON.stringify(BOOKMARK_FIXTURE)}\n`);
+    await writeFile(path.join(dir, 'likes.jsonl'), `${JSON.stringify(LIKE_FIXTURE)}\n`);
+    await writeJson(path.join(dir, 'bookmarks-meta.json'), {
+      provider: 'twitter',
+      schemaVersion: 1,
+      totalBookmarks: 1,
+    });
+    await writeJson(path.join(dir, 'likes-meta.json'), {
+      provider: 'twitter',
+      schemaVersion: 1,
+      totalLikes: 1,
+    });
+    await buildIndex({ force: true });
+    await buildLikesIndex({ force: true });
+    await fn(dir);
+  } finally {
+    delete process.env.FT_DATA_DIR;
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+test('ft likes unlike removes the item remotely and from the local archive', async () => {
+  await withCliDataDir(async (dir) => {
+    const mockX = await startMockXServer();
+    const tsx = path.join(process.cwd(), 'node_modules', '.bin', 'tsx');
+
+    try {
+      const { stdout } = await execFileAsync(tsx, ['src/cli.ts', 'likes', 'unlike', 'l1', '--cookies', 'ct0-token', 'auth'], {
+        cwd: process.cwd(),
+        env: { ...process.env, FT_DATA_DIR: dir, FT_X_API_ORIGIN: mockX.origin },
+      });
+
+      assert.match(stdout, /Unliked on X: l1/);
+      assert.equal(await getLikeById('l1'), null);
+      const likesCache = await readFile(path.join(dir, 'likes.jsonl'), 'utf8');
+      assert.equal(likesCache.trim(), '');
+    } finally {
+      await mockX.close();
+    }
+  });
+});
+
+test('ft unbookmark removes the item remotely and from the local archive', async () => {
+  await withCliDataDir(async (dir) => {
+    const mockX = await startMockXServer();
+    const tsx = path.join(process.cwd(), 'node_modules', '.bin', 'tsx');
+
+    try {
+      const { stdout } = await execFileAsync(tsx, ['src/cli.ts', 'unbookmark', 'b1', '--cookies', 'ct0-token', 'auth'], {
+        cwd: process.cwd(),
+        env: { ...process.env, FT_DATA_DIR: dir, FT_X_API_ORIGIN: mockX.origin },
+      });
+
+      assert.match(stdout, /Removed bookmark on X: b1/);
+      assert.equal(await getBookmarkById('b1'), null);
+      const bookmarksCache = await readFile(path.join(dir, 'bookmarks.jsonl'), 'utf8');
+      assert.equal(bookmarksCache.trim(), '');
+    } finally {
+      await mockX.close();
+    }
+  });
+});
+
+test('ft likes unlike does not mutate local cache when the remote mutation fails', async () => {
+  await withCliDataDir(async (dir) => {
+    const mockX = await startMockXServer({ unlikeStatus: 500 });
+    const tsx = path.join(process.cwd(), 'node_modules', '.bin', 'tsx');
+
+    try {
+      await assert.rejects(
+        execFileAsync(tsx, ['src/cli.ts', 'likes', 'unlike', 'l1', '--cookies', 'ct0-token', 'auth'], {
+          cwd: process.cwd(),
+          env: { ...process.env, FT_DATA_DIR: dir, FT_X_API_ORIGIN: mockX.origin },
+        }),
+      );
+
+      assert.ok(await getLikeById('l1'));
+      const likesCache = await readFile(path.join(dir, 'likes.jsonl'), 'utf8');
+      assert.match(likesCache, /Saved like/);
+    } finally {
+      await mockX.close();
+    }
+  });
+});
+
+test('ft likes trim keeps the newest likes and removes older ones in batches', async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), 'ft-cli-trim-'));
+  process.env.FT_DATA_DIR = dir;
+
+  const likes = [
+    {
+      ...LIKE_FIXTURE,
+      id: 'l3',
+      tweetId: 'l3',
+      likedAt: '2026-03-05T00:00:00Z',
+      url: 'https://x.com/bob/status/l3',
+      text: 'Newest like',
+    },
+    {
+      ...LIKE_FIXTURE,
+      id: 'l2',
+      tweetId: 'l2',
+      likedAt: '2026-03-04T00:00:00Z',
+      url: 'https://x.com/bob/status/l2',
+      text: 'Middle like',
+    },
+    {
+      ...LIKE_FIXTURE,
+      id: 'l1',
+      tweetId: 'l1',
+      likedAt: '2026-03-03T00:00:00Z',
+      url: 'https://x.com/bob/status/l1',
+      text: 'Oldest like',
+    },
+  ];
+
+  const requests: string[] = [];
+  const server = http.createServer(async (req, res) => {
+    const body = await new Promise<string>((resolve) => {
+      let data = '';
+      req.on('data', (chunk) => { data += chunk; });
+      req.on('end', () => resolve(data));
+    });
+    const parsed = body ? JSON.parse(body) : {};
+    requests.push(parsed.variables?.tweet_id);
+    res.writeHead(200, { 'content-type': 'application/json' });
+    res.end(JSON.stringify({ data: { unfavorite_tweet: 'Done' } }));
+  });
+
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', () => resolve()));
+  const address = server.address();
+  if (!address || typeof address === 'string') throw new Error('Failed to bind mock trim server.');
+
+  try {
+    await writeFile(path.join(dir, 'likes.jsonl'), likes.map((row) => JSON.stringify(row)).join('\n') + '\n');
+    await writeJson(path.join(dir, 'likes-meta.json'), {
+      provider: 'twitter',
+      schemaVersion: 1,
+      totalLikes: 3,
+    });
+    await buildLikesIndex({ force: true });
+
+    const tsx = path.join(process.cwd(), 'node_modules', '.bin', 'tsx');
+    const { stdout } = await execFileAsync(
+      tsx,
+      ['src/cli.ts', 'likes', 'trim', '--keep', '1', '--batch-size', '2', '--pause-seconds', '0', '--cookies', 'ct0-token', 'auth'],
+      {
+        cwd: process.cwd(),
+        env: { ...process.env, FT_DATA_DIR: dir, FT_X_API_ORIGIN: `http://127.0.0.1:${address.port}` },
+      },
+    );
+
+    assert.match(stdout, /Removed 2 old likes on X/);
+    assert.deepEqual(requests.sort(), ['l1', 'l2']);
+    assert.ok(await getLikeById('l3'));
+    assert.equal(await getLikeById('l2'), null);
+    assert.equal(await getLikeById('l1'), null);
+  } finally {
+    delete process.env.FT_DATA_DIR;
+    await new Promise<void>((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('ft likes trim retries a 429 before succeeding', async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), 'ft-cli-trim-429-'));
+  process.env.FT_DATA_DIR = dir;
+
+  const likes = [
+    {
+      ...LIKE_FIXTURE,
+      id: 'l2',
+      tweetId: 'l2',
+      likedAt: '2026-03-04T00:00:00Z',
+      url: 'https://x.com/bob/status/l2',
+      text: 'Newest like',
+    },
+    {
+      ...LIKE_FIXTURE,
+      id: 'l1',
+      tweetId: 'l1',
+      likedAt: '2026-03-03T00:00:00Z',
+      url: 'https://x.com/bob/status/l1',
+      text: 'Oldest like',
+    },
+  ];
+
+  let requests = 0;
+  const server = http.createServer(async (_req, res) => {
+    requests += 1;
+    if (requests === 1) {
+      res.writeHead(429, { 'content-type': 'text/plain' });
+      res.end('Rate limit exceeded');
+      return;
+    }
+
+    res.writeHead(200, { 'content-type': 'application/json' });
+    res.end(JSON.stringify({ data: { unfavorite_tweet: 'Done' } }));
+  });
+
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', () => resolve()));
+  const address = server.address();
+  if (!address || typeof address === 'string') throw new Error('Failed to bind mock trim server.');
+
+  try {
+    await writeFile(path.join(dir, 'likes.jsonl'), likes.map((row) => JSON.stringify(row)).join('\n') + '\n');
+    await writeJson(path.join(dir, 'likes-meta.json'), {
+      provider: 'twitter',
+      schemaVersion: 1,
+      totalLikes: 2,
+    });
+    await buildLikesIndex({ force: true });
+
+    const tsx = path.join(process.cwd(), 'node_modules', '.bin', 'tsx');
+    const { stdout } = await execFileAsync(
+      tsx,
+      [
+        'src/cli.ts',
+        'likes',
+        'trim',
+        '--keep', '1',
+        '--batch-size', '1',
+        '--pause-seconds', '0',
+        '--rate-limit-backoff-seconds', '1',
+        '--max-rate-limit-retries', '1',
+        '--cookies', 'ct0-token', 'auth',
+      ],
+      {
+        cwd: process.cwd(),
+        env: { ...process.env, FT_DATA_DIR: dir, FT_X_API_ORIGIN: `http://127.0.0.1:${address.port}` },
+      },
+    );
+
+    assert.match(stdout, /Removed 1 old likes on X/);
+    assert.equal(requests, 2);
+    assert.ok(await getLikeById('l2'));
+    assert.equal(await getLikeById('l1'), null);
+  } finally {
+    delete process.env.FT_DATA_DIR;
+    await new Promise<void>((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/tests/cli-feed.test.ts
+++ b/tests/cli-feed.test.ts
@@ -1,0 +1,97 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import os from 'node:os';
+import path from 'node:path';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { buildFeedIndex } from '../src/feed-db.js';
+import { writeJson } from '../src/fs.js';
+import { buildCli } from '../src/cli.js';
+
+const execFileAsync = promisify(execFile);
+
+const FIXTURES = [
+  {
+    id: '1',
+    tweetId: '1',
+    url: 'https://x.com/alice/status/1',
+    text: 'Machine learning agents are getting better',
+    authorHandle: 'alice',
+    authorName: 'Alice Smith',
+    syncedAt: '2026-04-12T14:00:00Z',
+    postedAt: '2026-04-12T13:00:00Z',
+    sortIndex: '2000',
+    fetchPage: 1,
+    fetchPosition: 0,
+    links: ['https://example.com'],
+    tags: [],
+    ingestedVia: 'graphql',
+  },
+];
+
+async function withFeedDataDir(fn: (dir: string) => Promise<void>): Promise<void> {
+  const dir = await mkdtemp(path.join(os.tmpdir(), 'ft-cli-feed-'));
+  process.env.FT_DATA_DIR = dir;
+  try {
+    await writeFile(path.join(dir, 'feed.jsonl'), FIXTURES.map((r) => JSON.stringify(r)).join('\n') + '\n');
+    await writeJson(path.join(dir, 'feed-meta.json'), {
+      provider: 'twitter',
+      schemaVersion: 1,
+      lastSyncAt: '2026-04-12T14:00:00Z',
+      totalItems: 1,
+      totalSkippedEntries: 2,
+    });
+    await buildFeedIndex();
+    await fn(dir);
+  } finally {
+    delete process.env.FT_DATA_DIR;
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+test('buildCli help includes feed command group', () => {
+  const help = buildCli().helpInformation();
+  assert.match(help, /\bfeed\b/);
+});
+
+test('ft feed status prints feed-specific summary', async () => {
+  await withFeedDataDir(async (dir) => {
+    const tsx = path.join(process.cwd(), 'node_modules', '.bin', 'tsx');
+    const { stdout } = await execFileAsync(tsx, ['src/cli.ts', 'feed', 'status'], {
+      cwd: process.cwd(),
+      env: { ...process.env, FT_DATA_DIR: dir },
+    });
+
+    assert.match(stdout, /Feed/);
+    assert.match(stdout, /items: 1/);
+    assert.match(stdout, /skipped entries: 2/);
+    assert.match(stdout, /cache: .*feed\.jsonl/);
+  });
+});
+
+test('ft feed list lists cached feed items', async () => {
+  await withFeedDataDir(async (dir) => {
+    const tsx = path.join(process.cwd(), 'node_modules', '.bin', 'tsx');
+    const { stdout } = await execFileAsync(tsx, ['src/cli.ts', 'feed', 'list', '--limit', '1'], {
+      cwd: process.cwd(),
+      env: { ...process.env, FT_DATA_DIR: dir },
+    });
+
+    assert.match(stdout, /@alice/);
+    assert.match(stdout, /https:\/\/x\.com\/alice\/status\/1/);
+  });
+});
+
+test('ft feed show prints details for one feed item', async () => {
+  await withFeedDataDir(async (dir) => {
+    const tsx = path.join(process.cwd(), 'node_modules', '.bin', 'tsx');
+    const { stdout } = await execFileAsync(tsx, ['src/cli.ts', 'feed', 'show', '1'], {
+      cwd: process.cwd(),
+      env: { ...process.env, FT_DATA_DIR: dir },
+    });
+
+    assert.match(stdout, /Alice Smith/);
+    assert.match(stdout, /Machine learning agents are getting better/);
+  });
+});

--- a/tests/cli-likes.test.ts
+++ b/tests/cli-likes.test.ts
@@ -1,0 +1,82 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import os from 'node:os';
+import path from 'node:path';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { buildLikesIndex } from '../src/likes-db.js';
+import { writeJson } from '../src/fs.js';
+import { buildCli } from '../src/cli.js';
+
+const execFileAsync = promisify(execFile);
+
+const FIXTURES = [
+  {
+    id: '1',
+    tweetId: '1',
+    url: 'https://x.com/alice/status/1',
+    text: 'Machine learning is transforming healthcare',
+    authorHandle: 'alice',
+    authorName: 'Alice Smith',
+    syncedAt: '2026-01-01T00:00:00Z',
+    postedAt: '2026-01-01T12:00:00Z',
+    likedAt: '2026-03-05T12:00:00Z',
+    engagement: { likeCount: 100, repostCount: 10 },
+    mediaObjects: [],
+    links: ['https://example.com'],
+    tags: [],
+    ingestedVia: 'browser',
+  },
+];
+
+async function withLikesDataDir(fn: (dir: string) => Promise<void>): Promise<void> {
+  const dir = await mkdtemp(path.join(os.tmpdir(), 'ft-cli-likes-'));
+  process.env.FT_DATA_DIR = dir;
+  try {
+    await writeFile(path.join(dir, 'likes.jsonl'), FIXTURES.map((r) => JSON.stringify(r)).join('\n') + '\n');
+    await writeJson(path.join(dir, 'likes-meta.json'), {
+      provider: 'twitter',
+      schemaVersion: 1,
+      lastFullSyncAt: '2026-04-05T12:34:56Z',
+      totalLikes: 1,
+    });
+    await buildLikesIndex();
+    await fn(dir);
+  } finally {
+    delete process.env.FT_DATA_DIR;
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+test('buildCli help includes likes command group', () => {
+  const help = buildCli().helpInformation();
+  assert.match(help, /\blikes\b/);
+});
+
+test('ft likes status prints likes-specific summary', async () => {
+  await withLikesDataDir(async (dir) => {
+    const tsx = path.join(process.cwd(), 'node_modules', '.bin', 'tsx');
+    const { stdout } = await execFileAsync(tsx, ['src/cli.ts', 'likes', 'status'], {
+      cwd: process.cwd(),
+      env: { ...process.env, FT_DATA_DIR: dir },
+    });
+
+    assert.match(stdout, /Likes/);
+    assert.match(stdout, /likes: 1/);
+    assert.match(stdout, /cache: .*likes\.jsonl/);
+  });
+});
+
+test('ft likes list lists liked items', async () => {
+  await withLikesDataDir(async (dir) => {
+    const tsx = path.join(process.cwd(), 'node_modules', '.bin', 'tsx');
+    const { stdout } = await execFileAsync(tsx, ['src/cli.ts', 'likes', 'list', '--limit', '1'], {
+      cwd: process.cwd(),
+      env: { ...process.env, FT_DATA_DIR: dir },
+    });
+
+    assert.match(stdout, /@alice/);
+    assert.match(stdout, /https:\/\/x\.com\/alice\/status\/1/);
+  });
+});

--- a/tests/cli-web.test.ts
+++ b/tests/cli-web.test.ts
@@ -1,0 +1,54 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import os from 'node:os';
+import path from 'node:path';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { spawn } from 'node:child_process';
+
+test('ft web starts the local server and prints a URL', async () => {
+  const staticDir = await mkdtemp(path.join(os.tmpdir(), 'ft-web-dist-'));
+  await writeFile(
+    path.join(staticDir, 'index.html'),
+    '<!doctype html><html><body><div id="root">ok</div></body></html>',
+    'utf8',
+  );
+
+  const tsx = path.join(process.cwd(), 'node_modules', '.bin', 'tsx');
+  const child = spawn(tsx, ['src/cli.ts', 'web', '--port', '0'], {
+    cwd: process.cwd(),
+    env: { ...process.env, FT_WEB_DIST_DIR: staticDir },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+
+  let stdout = '';
+
+  try {
+    const url = await new Promise<string>((resolve, reject) => {
+      const timeout = setTimeout(() => reject(new Error('Timed out waiting for web server output')), 5000);
+
+      child.stdout.on('data', (chunk) => {
+        stdout += chunk.toString();
+        const match = stdout.match(/URL:\s+(http:\/\/[^\s]+)/);
+        if (match) {
+          clearTimeout(timeout);
+          resolve(match[1]);
+        }
+      });
+
+      child.once('error', reject);
+      child.once('exit', (code) => {
+        clearTimeout(timeout);
+        reject(new Error(`web command exited early with code ${code}\n${stdout}`));
+      });
+    });
+
+    const response = await fetch(url);
+    const html = await response.text();
+    assert.equal(response.status, 200);
+    assert.match(html, /<div id="root">ok<\/div>/);
+  } finally {
+    child.kill('SIGINT');
+    await new Promise((resolve) => child.once('exit', resolve));
+    await rm(staticDir, { recursive: true, force: true });
+  }
+});

--- a/tests/feed-db.test.ts
+++ b/tests/feed-db.test.ts
@@ -1,0 +1,85 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import os from 'node:os';
+import path from 'node:path';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { buildFeedIndex, countFeed, getFeedById, listFeed } from '../src/feed-db.js';
+
+const FIXTURES = [
+  {
+    id: '2',
+    tweetId: '2',
+    url: 'https://x.com/alice/status/2',
+    text: 'newer',
+    authorHandle: 'alice',
+    authorName: 'Alice',
+    syncedAt: '2026-04-12T12:00:00Z',
+    postedAt: '2026-04-12T11:00:00Z',
+    sortIndex: '2000',
+    fetchPage: 1,
+    fetchPosition: 0,
+    links: ['https://example.com'],
+    tags: [],
+    ingestedVia: 'graphql',
+  },
+  {
+    id: '1',
+    tweetId: '1',
+    url: 'https://x.com/bob/status/1',
+    text: 'older refreshed',
+    authorHandle: 'bob',
+    authorName: 'Bob',
+    syncedAt: '2026-04-11T12:00:00Z',
+    postedAt: '2026-04-11T11:00:00Z',
+    sortIndex: '1000',
+    fetchPage: 2,
+    fetchPosition: 5,
+    links: [],
+    tags: [],
+    ingestedVia: 'graphql',
+  },
+];
+
+async function withFeedDataDir(fn: (dir: string) => Promise<void>): Promise<void> {
+  const dir = await mkdtemp(path.join(os.tmpdir(), 'ft-feed-db-'));
+  process.env.FT_DATA_DIR = dir;
+  try {
+    await writeFile(path.join(dir, 'feed.jsonl'), FIXTURES.map((r) => JSON.stringify(r)).join('\n') + '\n');
+    await fn(dir);
+  } finally {
+    delete process.env.FT_DATA_DIR;
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+test('buildFeedIndex and listFeed preserve feed ordering', async () => {
+  await withFeedDataDir(async () => {
+    const idx = await buildFeedIndex();
+    assert.equal(idx.recordCount, 2);
+
+    const items = await listFeed({ limit: 10, offset: 0 });
+    assert.deepEqual(items.map((item) => item.id), ['2', '1']);
+  });
+});
+
+test('listFeed paginates with limit and offset', async () => {
+  await withFeedDataDir(async () => {
+    await buildFeedIndex();
+    const first = await listFeed({ limit: 1, offset: 0 });
+    const second = await listFeed({ limit: 1, offset: 1 });
+    assert.equal(first.length, 1);
+    assert.equal(second.length, 1);
+    assert.notEqual(first[0].id, second[0].id);
+  });
+});
+
+test('countFeed and getFeedById read from the indexed feed archive', async () => {
+  await withFeedDataDir(async () => {
+    await buildFeedIndex();
+    assert.equal(await countFeed(), 2);
+    const item = await getFeedById('2');
+    assert.ok(item);
+    assert.equal(item?.authorHandle, 'alice');
+    assert.equal(item?.sortIndex, '2000');
+  });
+});

--- a/tests/feed-service.test.ts
+++ b/tests/feed-service.test.ts
@@ -1,0 +1,45 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import os from 'node:os';
+import path from 'node:path';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { writeJson } from '../src/fs.js';
+import { formatFeedStatus, getFeedStatusView } from '../src/feed-service.js';
+
+test('formatFeedStatus produces human-readable summary', () => {
+  const text = formatFeedStatus({
+    itemCount: 42,
+    skippedEntries: 7,
+    lastUpdated: '2026-04-12T14:00:00Z',
+    mode: 'Read-only Home timeline sync via browser session',
+    cachePath: '/tmp/feed.jsonl',
+  });
+
+  assert.match(text, /^Feed/);
+  assert.match(text, /items: 42/);
+  assert.match(text, /skipped entries: 7/);
+  assert.match(text, /last updated: 2026-04-12T14:00:00Z/);
+  assert.match(text, /cache: \/tmp\/feed\.jsonl/);
+});
+
+test('getFeedStatusView uses feed metadata', async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), 'ft-feed-status-view-'));
+  process.env.FT_DATA_DIR = tmpDir;
+  try {
+    await writeJson(path.join(tmpDir, 'feed-meta.json'), {
+      provider: 'twitter',
+      schemaVersion: 1,
+      lastSyncAt: '2026-04-12T14:00:00Z',
+      totalItems: 3,
+      totalSkippedEntries: 5,
+    });
+
+    const view = await getFeedStatusView();
+    assert.equal(view.itemCount, 3);
+    assert.equal(view.skippedEntries, 5);
+    assert.equal(view.lastUpdated, '2026-04-12T14:00:00Z');
+  } finally {
+    delete process.env.FT_DATA_DIR;
+    await rm(tmpDir, { recursive: true, force: true });
+  }
+});

--- a/tests/graphql-actions.test.ts
+++ b/tests/graphql-actions.test.ts
@@ -1,0 +1,58 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { unlikeTweet, unbookmarkTweet } from '../src/graphql-actions.js';
+
+test('unlikeTweet posts the current X web mutation with tweet_id variables', async () => {
+  const originalFetch = globalThis.fetch;
+  let requestUrl = '';
+  let requestBody = '';
+  let requestHeaders: Headers | undefined;
+
+  globalThis.fetch = (async (input, init) => {
+    requestUrl = String(input);
+    requestBody = String(init?.body ?? '');
+    requestHeaders = new Headers(init?.headers as HeadersInit | undefined);
+    return new Response(JSON.stringify({ data: { unfavorite_tweet: 'Done' } }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
+  }) as typeof fetch;
+
+  process.env.FT_X_API_ORIGIN = 'https://x.test';
+
+  try {
+    const result = await unlikeTweet('123', {
+      csrfToken: 'ct0-token',
+      cookieHeader: 'ct0=ct0-token; auth_token=auth',
+    });
+
+    assert.equal(result.operation, 'unlike');
+    assert.match(requestUrl, /https:\/\/x\.test\/i\/api\/graphql\/ZYKSe-w7KEslx3JhSIk5LA\/UnfavoriteTweet$/);
+    assert.deepEqual(JSON.parse(requestBody), {
+      variables: { tweet_id: '123' },
+      queryId: 'ZYKSe-w7KEslx3JhSIk5LA',
+    });
+    assert.equal(requestHeaders?.get('x-csrf-token'), 'ct0-token');
+    assert.match(requestHeaders?.get('cookie') ?? '', /auth_token=auth/);
+  } finally {
+    delete process.env.FT_X_API_ORIGIN;
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('unbookmarkTweet maps auth failures to re-login guidance', async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (async () => new Response('forbidden', { status: 403 })) as typeof fetch;
+
+  try {
+    await assert.rejects(
+      unbookmarkTweet('456', {
+        csrfToken: 'ct0-token',
+        cookieHeader: 'ct0=ct0-token',
+      }),
+      /make sure you are logged in/i,
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});

--- a/tests/graphql-feed.test.ts
+++ b/tests/graphql-feed.test.ts
@@ -1,0 +1,246 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import os from 'node:os';
+import path from 'node:path';
+import { mkdtemp, rm } from 'node:fs/promises';
+import {
+  convertHomeTimelineTweetToRecord,
+  parseHomeTimelineResponse,
+  mergeFeedRecord,
+  mergeFeedRecords,
+  syncFeedGraphQL,
+} from '../src/graphql-feed.js';
+import type { FeedRecord } from '../src/types.js';
+import { readJson, readJsonLines } from '../src/fs.js';
+
+const NOW = '2026-04-12T14:00:00.000Z';
+
+function makeTweetResult(overrides: Record<string, any> = {}) {
+  return {
+    rest_id: '2043312514902171702',
+    core: {
+      user_results: {
+        result: {
+          rest_id: '296593919',
+          core: { screen_name: 'vikingmute', name: 'Viking' },
+          avatar: { image_url: 'https://pbs.twimg.com/profile_images/725179208528322560/TPjU7qop_normal.jpg' },
+          legacy: {
+            description: 'builder',
+            followers_count: 64701,
+            friends_count: 279,
+            location: 'Shanghai',
+            verified: false,
+          },
+          is_blue_verified: true,
+        },
+      },
+    },
+    legacy: {
+      id_str: '2043312514902171702',
+      full_text: 'hello from the home timeline',
+      created_at: 'Sun Apr 12 12:57:21 +0000 2026',
+      favorite_count: 25,
+      retweet_count: 7,
+      reply_count: 0,
+      quote_count: 0,
+      bookmark_count: 31,
+      conversation_id_str: '2043312514902171702',
+      lang: 'zh',
+      entities: {
+        urls: [
+          { expanded_url: 'https://example.com/post', url: 'https://t.co/abc' },
+        ],
+      },
+      extended_entities: {
+        media: [
+          {
+            type: 'photo',
+            media_url_https: 'https://pbs.twimg.com/media/example.jpg',
+            expanded_url: 'https://x.com/vikingmute/status/2043312514902171702/photo/1',
+            original_info: { width: 1200, height: 800 },
+            ext_alt_text: 'A test image',
+          },
+        ],
+      },
+    },
+    views: { count: '1829' },
+    ...overrides,
+  };
+}
+
+function makeEntry(tweet: any, overrides: Record<string, any> = {}) {
+  return {
+    entryId: `tweet-${tweet.rest_id}`,
+    sortIndex: '2043330774450569216',
+    content: {
+      __typename: 'TimelineTimelineItem',
+      itemContent: {
+        __typename: 'TimelineTweet',
+        itemType: 'TimelineTweet',
+        tweet_results: { result: tweet },
+      },
+    },
+    ...overrides,
+  };
+}
+
+function makeResponse(entries: any[]) {
+  return {
+    data: {
+      home: {
+        home_timeline_urt: {
+          instructions: [
+            {
+              type: 'TimelineAddEntries',
+              entries,
+            },
+          ],
+        },
+      },
+    },
+  };
+}
+
+function makeRecord(overrides: Partial<FeedRecord> = {}): FeedRecord {
+  return {
+    id: '100',
+    tweetId: '100',
+    url: 'https://x.com/user/status/100',
+    text: 'Test',
+    syncedAt: NOW,
+    sortIndex: '1000',
+    fetchPage: 1,
+    fetchPosition: 0,
+    tags: [],
+    ingestedVia: 'graphql',
+    ...overrides,
+  };
+}
+
+test('convertHomeTimelineTweetToRecord builds a feed record with ordering fields', () => {
+  const result = convertHomeTimelineTweetToRecord(makeTweetResult(), NOW, {
+    sortIndex: '2043330774450569216',
+    fetchPage: 1,
+    fetchPosition: 0,
+  });
+  assert.ok(result);
+  assert.equal(result.id, '2043312514902171702');
+  assert.equal(result.authorHandle, 'vikingmute');
+  assert.equal(result.sortIndex, '2043330774450569216');
+  assert.equal(result.fetchPage, 1);
+  assert.equal(result.fetchPosition, 0);
+  assert.equal(result.engagement?.viewCount, 1829);
+});
+
+test('parseHomeTimelineResponse keeps tweet entries, skips promoted and non-tweet entries, and extracts cursor', () => {
+  const response = makeResponse([
+    makeEntry(makeTweetResult()),
+    makeEntry(makeTweetResult({ rest_id: '2042253137759588807', legacy: { ...makeTweetResult().legacy, id_str: '2042253137759588807' } }), {
+      entryId: 'promoted-tweet-2042253137759588807-abc',
+      sortIndex: '2043330774450569215',
+    }),
+    {
+      entryId: 'module-1',
+      content: {
+        __typename: 'TimelineTimelineModule',
+      },
+    },
+    {
+      entryId: 'cursor-bottom-1',
+      sortIndex: '2043330774450569181',
+      content: {
+        cursorType: 'Bottom',
+        value: 'cursor-next',
+      },
+    },
+  ]);
+
+  const result = parseHomeTimelineResponse(response, { now: NOW, fetchPage: 2 });
+  assert.equal(result.records.length, 1);
+  assert.equal(result.skippedEntries, 2);
+  assert.equal(result.nextCursor, 'cursor-next');
+  assert.deepEqual(result.seenTweetIds, ['2043312514902171702']);
+  assert.equal(result.records[0].fetchPage, 2);
+});
+
+test('mergeFeedRecord keeps richer content and refreshes latest feed order metadata', () => {
+  const existing = makeRecord({
+    text: 'old',
+    syncedAt: '2026-04-11T00:00:00.000Z',
+    sortIndex: '1000',
+    fetchPage: 3,
+    fetchPosition: 9,
+  });
+  const incoming = makeRecord({
+    text: 'new',
+    authorHandle: 'alice',
+    syncedAt: '2026-04-12T00:00:00.000Z',
+    sortIndex: '2000',
+    fetchPage: 1,
+    fetchPosition: 0,
+  });
+  const merged = mergeFeedRecord(existing, incoming);
+  assert.equal(merged.text, 'new');
+  assert.equal(merged.authorHandle, 'alice');
+  assert.equal(merged.sortIndex, '2000');
+  assert.equal(merged.fetchPage, 1);
+});
+
+test('mergeFeedRecords sorts by latest sync then feed order metadata', () => {
+  const older = makeRecord({ id: '1', tweetId: '1', syncedAt: '2026-04-11T00:00:00.000Z', sortIndex: '1000', fetchPage: 1, fetchPosition: 0 });
+  const newer = makeRecord({ id: '2', tweetId: '2', syncedAt: '2026-04-12T00:00:00.000Z', sortIndex: '999', fetchPage: 1, fetchPosition: 0 });
+  const refreshed = makeRecord({ id: '1', tweetId: '1', syncedAt: '2026-04-13T00:00:00.000Z', sortIndex: '3000', fetchPage: 1, fetchPosition: 0 });
+  const result = mergeFeedRecords([older, newer], [refreshed]);
+  assert.deepEqual(result.merged.map((record) => record.id), ['1', '2']);
+});
+
+test('syncFeedGraphQL writes cache, meta, state, and index from mocked Home timeline pages', async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), 'ft-sync-feed-'));
+  process.env.FT_DATA_DIR = tmpDir;
+
+  const originalFetch = globalThis.fetch;
+  let calls = 0;
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    calls += 1;
+    if (calls === 1) {
+      assert.equal(init?.method, undefined);
+      return new Response(JSON.stringify(makeResponse([
+        makeEntry(makeTweetResult()),
+        {
+          entryId: 'cursor-bottom-1',
+          sortIndex: '2043330774450569181',
+          content: { cursorType: 'Bottom', value: 'cursor-next' },
+        },
+      ])), { status: 200, headers: { 'content-type': 'application/json' } });
+    }
+    assert.equal(init?.method, 'POST');
+    return new Response(JSON.stringify(makeResponse([
+      makeEntry(makeTweetResult({
+        rest_id: '2043144280731259110',
+        legacy: { ...makeTweetResult().legacy, id_str: '2043144280731259110', full_text: 'page two tweet' },
+      }), { sortIndex: '2043330774450569214' }),
+    ])), { status: 200, headers: { 'content-type': 'application/json' } });
+  }) as typeof fetch;
+
+  try {
+    const result = await syncFeedGraphQL({
+      csrfToken: 'ct0-token',
+      cookieHeader: 'ct0=ct0-token; auth_token=auth',
+      maxPages: 2,
+      delayMs: 0,
+    });
+
+    assert.equal(result.added, 2);
+    assert.equal(result.totalItems, 2);
+    const cache = await readJsonLines<FeedRecord>(path.join(tmpDir, 'feed.jsonl'));
+    assert.equal(cache.length, 2);
+    const meta = await readJson<any>(path.join(tmpDir, 'feed-meta.json'));
+    assert.equal(meta.totalItems, 2);
+    const state = await readJson<any>(path.join(tmpDir, 'feed-state.json'));
+    assert.equal(state.totalStored, 2);
+  } finally {
+    globalThis.fetch = originalFetch;
+    delete process.env.FT_DATA_DIR;
+    await rm(tmpDir, { recursive: true, force: true });
+  }
+});

--- a/tests/graphql-likes.test.ts
+++ b/tests/graphql-likes.test.ts
@@ -1,0 +1,241 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import os from 'node:os';
+import path from 'node:path';
+import { mkdtemp, rm } from 'node:fs/promises';
+import {
+  convertLikedTweetToRecord,
+  parseLikesResponse,
+  mergeLikeRecord,
+  mergeLikes,
+  syncLikesGraphQL,
+} from '../src/graphql-likes.js';
+import type { LikeRecord } from '../src/types.js';
+import { writeJsonLines } from '../src/fs.js';
+
+const NOW = '2026-03-28T00:00:00.000Z';
+
+function makeLikedTweet(overrides: Record<string, any> = {}) {
+  return {
+    id_str: '1234567890',
+    full_text: 'Hello world, this is a liked tweet!',
+    created_at: 'Tue Mar 10 12:00:00 +0000 2026',
+    favorite_count: 42,
+    retweet_count: 5,
+    reply_count: 3,
+    quote_count: 1,
+    bookmark_count: 7,
+    conversation_id_str: '1234567890',
+    lang: 'en',
+    entities: {
+      urls: [
+        { expanded_url: 'https://example.com/article', url: 'https://t.co/abc' },
+        { expanded_url: 'https://t.co/internal', url: 'https://t.co/def' },
+      ],
+      ...overrides.entities,
+    },
+    extended_entities: {
+      media: [
+        {
+          type: 'photo',
+          media_url_https: 'https://pbs.twimg.com/media/example.jpg',
+          sizes: { large: { w: 1200, h: 800 } },
+          ext_alt_text: 'A test image',
+        },
+      ],
+      ...overrides.extended_entities,
+    },
+    user: {
+      screen_name: 'testuser',
+      name: 'Test User',
+      profile_image_url_https: 'https://pbs.twimg.com/profile_images/9876/photo.jpg',
+      description: 'I test things',
+      followers_count: 1000,
+      friends_count: 200,
+      statuses_count: 300,
+      location: 'San Francisco',
+      verified: true,
+      ...overrides.user,
+    },
+    ...overrides,
+  };
+}
+
+function makeRecord(overrides: Partial<LikeRecord> = {}): LikeRecord {
+  return {
+    id: '100',
+    tweetId: '100',
+    url: 'https://x.com/user/status/100',
+    text: 'Test',
+    syncedAt: NOW,
+    tags: [],
+    ingestedVia: 'browser',
+    ...overrides,
+  };
+}
+
+function makeViewerResponse(userId = 'u1') {
+  return {
+    data: {
+      viewer: {
+        user_results: {
+          result: {
+            rest_id: userId,
+          },
+        },
+      },
+    },
+  };
+}
+
+function makeLikesTimelineResponse(tweets: Array<Record<string, any>>, cursor = 'next-cursor') {
+  return {
+    data: {
+      user: {
+        result: {
+          timeline: {
+            timeline: {
+              instructions: [
+                {
+                  entries: [
+                    ...tweets.map((tweet, index) => ({
+                      entryId: `tweet-${tweet.id_str ?? index}`,
+                      sortIndex: String(2041895058709413888n - BigInt(index)),
+                      content: {
+                        itemContent: {
+                          itemType: 'TimelineTweet',
+                          tweet_results: {
+                            result: tweet,
+                          },
+                        },
+                      },
+                    })),
+                    {
+                      entryId: 'cursor-bottom',
+                      sortIndex: '1',
+                      content: {
+                        cursorType: 'Bottom',
+                        value: cursor,
+                      },
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+        },
+      },
+    },
+  };
+}
+
+test('convertLikedTweetToRecord: produces a complete record from a full liked tweet', () => {
+  const result = convertLikedTweetToRecord(makeLikedTweet(), NOW);
+  assert.ok(result);
+  assert.equal(result.id, '1234567890');
+  assert.equal(result.tweetId, '1234567890');
+  assert.equal(result.text, 'Hello world, this is a liked tweet!');
+  assert.equal(result.authorHandle, 'testuser');
+  assert.equal(result.authorName, 'Test User');
+  assert.equal(result.url, 'https://x.com/testuser/status/1234567890');
+  assert.equal(result.likedAt, null);
+  assert.equal(result.syncedAt, NOW);
+});
+
+test('convertLikedTweetToRecord: extracts engagement, media, and links', () => {
+  const result = convertLikedTweetToRecord(makeLikedTweet(), NOW)!;
+  assert.equal(result.engagement?.likeCount, 42);
+  assert.equal(result.media?.[0], 'https://pbs.twimg.com/media/example.jpg');
+  assert.equal(result.mediaObjects?.[0].extAltText, 'A test image');
+  assert.deepEqual(result.links, ['https://example.com/article']);
+});
+
+test('convertLikedTweetToRecord: returns null when tweet id is missing', () => {
+  assert.equal(convertLikedTweetToRecord({ full_text: 'hi' }, NOW), null);
+});
+
+test('parseLikesResponse: normalizes likes and computes next cursor from last tweet id', () => {
+  const response = parseLikesResponse([
+    makeLikedTweet({ id_str: '200' }),
+    makeLikedTweet({ id_str: '150' }),
+  ], NOW);
+  assert.equal(response.records.length, 2);
+  assert.equal(response.nextCursor, '149');
+});
+
+test('mergeLikeRecord: preserves existing likedAt when incoming record is richer but lacks it', () => {
+  const existing = makeRecord({ likedAt: '2026-03-01T00:00:00Z', text: 'old' });
+  const incoming = makeRecord({
+    id: '100',
+    tweetId: '100',
+    text: 'new',
+    authorHandle: 'alice',
+    mediaObjects: [{ mediaUrl: 'https://img.test/1.jpg' }],
+  });
+  const merged = mergeLikeRecord(existing, incoming);
+  assert.equal(merged.text, 'new');
+  assert.equal(merged.likedAt, '2026-03-01T00:00:00Z');
+});
+
+test('mergeLikes: archive semantics keep existing likes absent from the latest page', () => {
+  const existing = [
+    makeRecord({ id: '1', tweetId: '1', likedAt: '2026-03-02T00:00:00Z' }),
+    makeRecord({ id: '2', tweetId: '2', likedAt: '2026-03-01T00:00:00Z' }),
+  ];
+  const incoming = [
+    makeRecord({ id: '1', tweetId: '1', text: 'updated', likedAt: null }),
+  ];
+  const result = mergeLikes(existing, incoming);
+  assert.equal(result.added, 0);
+  assert.equal(result.merged.length, 2);
+  assert.ok(result.merged.some((record) => record.id === '2'));
+  assert.equal(result.merged.find((record) => record.id === '1')?.likedAt, '2026-03-02T00:00:00Z');
+});
+
+test('syncLikesGraphQL: preserves previously archived likes absent from latest remote pages', async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), 'ft-sync-likes-'));
+  process.env.FT_DATA_DIR = tmpDir;
+  await writeJsonLines(path.join(tmpDir, 'likes.jsonl'), [
+    makeRecord({ id: 'old', tweetId: '50', text: 'older archived like', likedAt: '2026-03-01T00:00:00Z' }),
+  ]);
+
+  const originalFetch = globalThis.fetch;
+  let calls = 0;
+  globalThis.fetch = (async () => {
+    calls += 1;
+    if (calls === 1) {
+      return new Response(JSON.stringify(makeViewerResponse('viewer-1')), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }
+    if (calls === 2) {
+      return new Response(JSON.stringify(
+        makeLikesTimelineResponse([makeLikedTweet({ id_str: '200', full_text: 'new like' })]),
+      ), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }
+    return new Response(JSON.stringify(makeLikesTimelineResponse([], '')), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
+  }) as typeof fetch;
+
+  try {
+    const result = await syncLikesGraphQL({
+      csrfToken: 'ct0-token',
+      cookieHeader: 'ct0=ct0-token; auth_token=auth',
+      maxPages: 5,
+      delayMs: 0,
+      stalePageLimit: 1,
+    });
+    assert.equal(result.added, 1);
+    assert.equal(result.totalLikes, 2);
+  } finally {
+    globalThis.fetch = originalFetch;
+    delete process.env.FT_DATA_DIR;
+    await rm(tmpDir, { recursive: true, force: true });
+  }
+});

--- a/tests/likes-db.test.ts
+++ b/tests/likes-db.test.ts
@@ -1,0 +1,122 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, writeFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import {
+  buildLikesIndex,
+  searchLikes,
+  listLikes,
+  getLikeById,
+  formatLikeSearchResults,
+} from '../src/likes-db.js';
+
+const FIXTURES = [
+  { id: '1', tweetId: '1', url: 'https://x.com/alice/status/1', text: 'Machine learning is transforming healthcare', authorHandle: 'alice', authorName: 'Alice Smith', syncedAt: '2026-01-01T00:00:00Z', postedAt: '2026-01-01T12:00:00Z', likedAt: '2026-03-05T12:00:00Z', engagement: { likeCount: 100, repostCount: 10 }, mediaObjects: [], links: ['https://example.com'], tags: [], ingestedVia: 'browser' },
+  { id: '2', tweetId: '2', url: 'https://x.com/bob/status/2', text: 'Rust is a great systems programming language', authorHandle: 'bob', authorName: 'Bob Jones', syncedAt: '2026-02-01T00:00:00Z', postedAt: '2026-02-01T12:00:00Z', likedAt: null, engagement: { likeCount: 50 }, mediaObjects: [], links: [], tags: [], ingestedVia: 'browser' },
+  { id: '3', tweetId: '3', url: 'https://x.com/alice/status/3', text: 'Deep learning models need massive compute', authorHandle: 'alice', authorName: 'Alice Smith', syncedAt: '2026-03-01T00:00:00Z', postedAt: '2026-03-01T12:00:00Z', likedAt: '2026-03-10T12:00:00Z', engagement: { likeCount: 200, repostCount: 30 }, mediaObjects: [{ type: 'photo', mediaUrl: 'https://img.com/1.jpg' }], links: [], tags: [], ingestedVia: 'browser' },
+];
+
+async function withIsolatedDataDir(fn: () => Promise<void>): Promise<void> {
+  const dir = await mkdtemp(path.join(tmpdir(), 'ft-likes-test-'));
+  const jsonl = FIXTURES.map((r) => JSON.stringify(r)).join('\n') + '\n';
+  await writeFile(path.join(dir, 'likes.jsonl'), jsonl);
+
+  const saved = process.env.FT_DATA_DIR;
+  process.env.FT_DATA_DIR = dir;
+  try {
+    await fn();
+  } finally {
+    if (saved !== undefined) process.env.FT_DATA_DIR = saved;
+    else delete process.env.FT_DATA_DIR;
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+test('buildLikesIndex creates a searchable database', async () => {
+  await withIsolatedDataDir(async () => {
+    const result = await buildLikesIndex();
+    assert.equal(result.recordCount, 3);
+    assert.equal(result.newRecords, 3);
+  });
+});
+
+test('searchLikes: full-text search returns matching results', async () => {
+  await withIsolatedDataDir(async () => {
+    await buildLikesIndex();
+    const results = await searchLikes({ query: 'learning', limit: 10 });
+    assert.equal(results.length, 2);
+    assert.ok(results.some((result) => result.id === '1'));
+    assert.ok(results.some((result) => result.id === '3'));
+  });
+});
+
+test('searchLikes: author filter works', async () => {
+  await withIsolatedDataDir(async () => {
+    await buildLikesIndex();
+    const results = await searchLikes({ query: '', author: 'alice', limit: 10 });
+    assert.equal(results.length, 2);
+    assert.ok(results.every((result) => result.authorHandle === 'alice'));
+  });
+});
+
+test('listLikes sorts by likedAt fallback and getLikeById returns one item', async () => {
+  await withIsolatedDataDir(async () => {
+    await buildLikesIndex();
+    const items = await listLikes({ limit: 10 });
+    assert.equal(items[0].id, '3');
+    assert.equal(items[1].id, '1');
+    assert.equal(items[2].id, '2');
+
+    const item = await getLikeById('2');
+    assert.equal(item?.authorHandle, 'bob');
+    assert.equal(item?.likedAt, null);
+  });
+});
+
+test('buildLikesIndex with force rebuild does not duplicate rows', async () => {
+  await withIsolatedDataDir(async () => {
+    await buildLikesIndex();
+    const result = await buildLikesIndex({ force: true });
+    assert.equal(result.recordCount, 3);
+  });
+});
+
+test('buildLikesIndex updates existing rows when cache content changes', async () => {
+  await withIsolatedDataDir(async () => {
+    await buildLikesIndex({ force: true });
+    let item = await getLikeById('1');
+    assert.equal(item?.text, 'Machine learning is transforming healthcare');
+
+    const updated = {
+      ...FIXTURES[0],
+      text: 'Updated text with richer content',
+      authorName: 'Alice Updated',
+    };
+    const jsonl = [updated, ...FIXTURES.slice(1)].map((r) => JSON.stringify(r)).join('\n') + '\n';
+    await writeFile(path.join(process.env.FT_DATA_DIR!, 'likes.jsonl'), jsonl);
+
+    await buildLikesIndex();
+    item = await getLikeById('1');
+    assert.equal(item?.text, 'Updated text with richer content');
+    assert.equal(item?.authorName, 'Alice Updated');
+  });
+});
+
+test('formatLikeSearchResults formats results with liked date when present', () => {
+  const formatted = formatLikeSearchResults([
+    {
+      id: '1',
+      url: 'https://x.com/test/status/1',
+      text: 'Hello world',
+      authorHandle: 'test',
+      authorName: 'Test',
+      likedAt: '2026-03-15T00:00:00Z',
+      postedAt: '2026-01-15T00:00:00Z',
+      score: -1.5,
+    },
+  ]);
+  assert.ok(formatted.includes('[2026-03-15]'));
+  assert.ok(formatted.includes('@test'));
+  assert.ok(formatted.includes('Hello world'));
+});

--- a/tests/likes-service.test.ts
+++ b/tests/likes-service.test.ts
@@ -1,0 +1,46 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import os from 'node:os';
+import path from 'node:path';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { writeJson } from '../src/fs.js';
+import { formatLikesStatus, getLikesStatusView } from '../src/likes-service.js';
+
+test('formatLikesStatus produces human-readable summary', () => {
+  const text = formatLikesStatus({
+    likeCount: 42,
+    lastUpdated: '2026-03-28T17:23:00Z',
+    mode: 'Full archive sync via browser session',
+    cachePath: '/tmp/x-likes.jsonl',
+  });
+
+  assert.match(text, /^Likes/);
+  assert.match(text, /likes: 42/);
+  assert.match(text, /last updated: 2026-03-28T17:23:00Z/);
+  assert.match(text, /sync mode: Full archive sync via browser session/);
+  assert.match(text, /cache: \/tmp\/x-likes\.jsonl/);
+});
+
+test('getLikesStatusView uses the most recent sync timestamp', async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), 'ft-likes-status-view-'));
+  process.env.FT_DATA_DIR = tmpDir;
+
+  try {
+    await writeJson(path.join(tmpDir, 'likes-meta.json'), {
+      provider: 'twitter',
+      schemaVersion: 1,
+      lastIncrementalSyncAt: '2026-04-05T10:00:00Z',
+      lastFullSyncAt: '2026-04-05T12:34:56Z',
+      totalLikes: 3,
+    });
+
+    const view = await getLikesStatusView();
+
+    assert.equal(view.likeCount, 3);
+    assert.equal(view.lastUpdated, '2026-04-05T12:34:56Z');
+    assert.equal(view.mode, 'Full archive sync via browser session');
+  } finally {
+    delete process.env.FT_DATA_DIR;
+    await rm(tmpDir, { recursive: true, force: true });
+  }
+});

--- a/tests/likes-status.test.ts
+++ b/tests/likes-status.test.ts
@@ -1,0 +1,80 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import os from 'node:os';
+import path from 'node:path';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { writeJson, writeJsonLines } from '../src/fs.js';
+import { getTwitterLikesStatus, latestLikeSyncAt } from '../src/likes.js';
+
+test('latestLikeSyncAt prefers the latest timestamp', () => {
+  const latest = latestLikeSyncAt({
+    lastIncrementalSyncAt: '2026-04-05T10:00:00Z',
+    lastFullSyncAt: '2026-04-05T12:00:00Z',
+  });
+  assert.equal(latest, '2026-04-05T12:00:00Z');
+});
+
+test('getTwitterLikesStatus falls back to cache and state when metadata is missing', async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), 'ft-likes-status-'));
+  process.env.FT_DATA_DIR = tmpDir;
+
+  try {
+    await writeJsonLines(path.join(tmpDir, 'likes.jsonl'), [
+      { id: '1', tweetId: '1', url: 'https://x.com/alice/status/1', text: 'one', syncedAt: '2026-04-05T12:00:00Z', tags: [] },
+      { id: '2', tweetId: '2', url: 'https://x.com/bob/status/2', text: 'two', syncedAt: '2026-04-05T12:00:00Z', tags: [] },
+    ]);
+    await writeJson(path.join(tmpDir, 'likes-backfill-state.json'), {
+      provider: 'twitter',
+      lastRunAt: '2026-04-05T12:34:56Z',
+      totalRuns: 1,
+      totalAdded: 2,
+      lastAdded: 2,
+      lastSeenIds: ['1', '2'],
+      stopReason: 'end of likes',
+    });
+
+    const status = await getTwitterLikesStatus();
+    assert.equal(status.totalLikes, 2);
+    assert.equal(status.lastIncrementalSyncAt, '2026-04-05T12:34:56Z');
+    assert.equal(status.cachePath, path.join(tmpDir, 'likes.jsonl'));
+    assert.equal(status.metaPath, path.join(tmpDir, 'likes-meta.json'));
+  } finally {
+    delete process.env.FT_DATA_DIR;
+    await rm(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test('getTwitterLikesStatus prefers newer state over stale metadata', async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), 'ft-likes-status-'));
+  process.env.FT_DATA_DIR = tmpDir;
+
+  try {
+    await writeJson(path.join(tmpDir, 'likes-meta.json'), {
+      provider: 'twitter',
+      schemaVersion: 1,
+      lastIncrementalSyncAt: '2026-04-05T10:00:00Z',
+      totalLikes: 1,
+    });
+    await writeJsonLines(path.join(tmpDir, 'likes.jsonl'), [
+      { id: '1', tweetId: '1', url: 'https://x.com/alice/status/1', text: 'one', syncedAt: '2026-04-05T12:00:00Z', tags: [] },
+      { id: '2', tweetId: '2', url: 'https://x.com/bob/status/2', text: 'two', syncedAt: '2026-04-05T12:00:00Z', tags: [] },
+      { id: '3', tweetId: '3', url: 'https://x.com/carol/status/3', text: 'three', syncedAt: '2026-04-05T12:00:00Z', tags: [] },
+    ]);
+    await writeJson(path.join(tmpDir, 'likes-backfill-state.json'), {
+      provider: 'twitter',
+      lastRunAt: '2026-04-05T12:34:56Z',
+      totalRuns: 2,
+      totalAdded: 3,
+      lastAdded: 2,
+      lastSeenIds: ['1', '2', '3'],
+      stopReason: 'no new likes (stale)',
+    });
+
+    const status = await getTwitterLikesStatus();
+    assert.equal(status.totalLikes, 3);
+    assert.equal(status.lastIncrementalSyncAt, '2026-04-05T12:34:56Z');
+  } finally {
+    delete process.env.FT_DATA_DIR;
+    await rm(tmpDir, { recursive: true, force: true });
+  }
+});

--- a/tests/web-api.test.ts
+++ b/tests/web-api.test.ts
@@ -1,0 +1,135 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import os from 'node:os';
+import path from 'node:path';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { writeJson, writeJsonLines } from '../src/fs.js';
+import { buildIndex } from '../src/bookmarks-db.js';
+import { buildLikesIndex } from '../src/likes-db.js';
+import { createWebApp } from '../src/web-server.js';
+
+const BOOKMARK_FIXTURES = [
+  {
+    id: 'bm-1',
+    tweetId: '101',
+    url: 'https://x.com/alice/status/101',
+    text: 'Claude Code makes CLI workflows much faster.',
+    authorHandle: 'alice',
+    authorName: 'Alice',
+    syncedAt: '2026-04-01T00:00:00Z',
+    postedAt: '2026-03-31T12:00:00Z',
+    bookmarkedAt: '2026-04-01T00:00:00Z',
+    links: ['https://example.com/claude-code'],
+    tags: [],
+    media: [],
+    ingestedVia: 'browser',
+  },
+];
+
+const LIKE_FIXTURES = [
+  {
+    id: 'lk-1',
+    tweetId: '202',
+    url: 'https://x.com/bob/status/202',
+    text: 'Claude Code and Codex both matter for local agent workflows.',
+    authorHandle: 'bob',
+    authorName: 'Bob',
+    syncedAt: '2026-04-02T00:00:00Z',
+    postedAt: '2026-04-01T11:00:00Z',
+    likedAt: '2026-04-02T00:00:00Z',
+    links: ['https://example.com/agents'],
+    tags: [],
+    media: [],
+    ingestedVia: 'browser',
+  },
+];
+
+async function withArchiveData(fn: (dir: string) => Promise<void>): Promise<void> {
+  const dir = await mkdtemp(path.join(os.tmpdir(), 'ft-web-api-'));
+  process.env.FT_DATA_DIR = dir;
+
+  try {
+    await writeJsonLines(path.join(dir, 'bookmarks.jsonl'), BOOKMARK_FIXTURES);
+    await writeJsonLines(path.join(dir, 'likes.jsonl'), LIKE_FIXTURES);
+    await writeJson(path.join(dir, 'bookmarks-meta.json'), {
+      provider: 'twitter',
+      schemaVersion: 1,
+      lastIncrementalSyncAt: '2026-04-01T00:00:00Z',
+      totalBookmarks: 1,
+    });
+    await writeJson(path.join(dir, 'likes-meta.json'), {
+      provider: 'twitter',
+      schemaVersion: 1,
+      lastFullSyncAt: '2026-04-02T00:00:00Z',
+      totalLikes: 1,
+    });
+    await buildIndex();
+    await buildLikesIndex();
+    await fn(dir);
+  } finally {
+    delete process.env.FT_DATA_DIR;
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+test('web api status returns bookmark and like summaries', { concurrency: false }, async () => {
+  await withArchiveData(async () => {
+    const app = await createWebApp();
+    const response = await app.request('/api/status');
+    assert.equal(response.status, 200);
+
+    const data = await response.json() as any;
+    assert.equal(data.bookmarks.total, 1);
+    assert.equal(data.likes.total, 1);
+  });
+});
+
+test('web api lists bookmarks and returns bookmark detail', { concurrency: false }, async () => {
+  await withArchiveData(async () => {
+    const app = await createWebApp();
+
+    const listResponse = await app.request('/api/bookmarks?limit=2');
+    assert.equal(listResponse.status, 200);
+    const listData = await listResponse.json() as any;
+    assert.equal(listData.total, 1);
+    assert.equal(listData.items[0].id, 'bm-1');
+
+    const detailResponse = await app.request('/api/bookmarks/bm-1');
+    assert.equal(detailResponse.status, 200);
+    const detailData = await detailResponse.json() as any;
+    assert.equal(detailData.authorHandle, 'alice');
+  });
+});
+
+test('web api lists likes with query filters and 404s missing ids', { concurrency: false }, async () => {
+  await withArchiveData(async () => {
+    const app = await createWebApp();
+
+    const listResponse = await app.request('/api/likes?query=Claude&limit=10');
+    assert.equal(listResponse.status, 200);
+    const listData = await listResponse.json() as any;
+    assert.equal(listData.total, 1);
+    assert.equal(listData.items[0].id, 'lk-1');
+
+    const notFound = await app.request('/api/likes/missing');
+    assert.equal(notFound.status, 404);
+  });
+});
+
+test('web api returns empty lists when indexes are missing', { concurrency: false }, async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), 'ft-web-api-empty-'));
+  process.env.FT_DATA_DIR = dir;
+
+  try {
+    const app = await createWebApp();
+    const response = await app.request('/api/bookmarks?limit=5&offset=bad');
+    assert.equal(response.status, 200);
+
+    const data = await response.json() as any;
+    assert.equal(data.total, 0);
+    assert.deepEqual(data.items, []);
+  } finally {
+    delete process.env.FT_DATA_DIR;
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Field Theory Archive</title>
+    <script type="module" src="/src/main.tsx"></script>
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+  </html>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,0 +1,101 @@
+import { startTransition, useEffect, useState } from 'react';
+import { fetchArchiveItem, fetchArchiveList, fetchStatus } from './api';
+import { ArchiveLayout } from './components/archive-layout';
+import type { ArchiveSource, BookmarkItem, LikeItem, StatusResponse } from './types';
+
+export function App() {
+  const [source, setSource] = useState<ArchiveSource>('bookmarks');
+  const [status, setStatus] = useState<StatusResponse | null>(null);
+  const [items, setItems] = useState<Array<BookmarkItem | LikeItem>>([]);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [selectedItem, setSelectedItem] = useState<BookmarkItem | LikeItem | null>(null);
+  const [queryInput, setQueryInput] = useState('');
+  const [submittedQuery, setSubmittedQuery] = useState('');
+  const [listLoading, setListLoading] = useState(true);
+  const [detailLoading, setDetailLoading] = useState(false);
+  const [detailError, setDetailError] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetchStatus().then(setStatus).catch(() => null);
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    setListLoading(true);
+    setDetailError(null);
+
+    fetchArchiveList(source, { query: submittedQuery, limit: 40, offset: 0 })
+      .then((response) => {
+        if (cancelled) return;
+        setItems(response.items);
+        setSelectedId(response.items[0]?.id ?? null);
+      })
+      .catch((error: Error) => {
+        if (cancelled) return;
+        setItems([]);
+        setSelectedId(null);
+        setDetailError(error.message);
+      })
+      .finally(() => {
+        if (!cancelled) setListLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [source, submittedQuery]);
+
+  useEffect(() => {
+    if (!selectedId) {
+      setSelectedItem(null);
+      return;
+    }
+
+    let cancelled = false;
+    setDetailLoading(true);
+    setDetailError(null);
+
+    fetchArchiveItem(source, selectedId)
+      .then((item) => {
+        if (!cancelled) setSelectedItem(item);
+      })
+      .catch((error: Error) => {
+        if (!cancelled) {
+          setSelectedItem(null);
+          setDetailError(error.message);
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setDetailLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [source, selectedId]);
+
+  return (
+    <ArchiveLayout
+      source={source}
+      status={status}
+      items={items}
+      selectedId={selectedId}
+      selectedItem={selectedItem}
+      listLoading={listLoading}
+      detailLoading={detailLoading}
+      detailError={detailError}
+      query={queryInput}
+      onQueryChange={setQueryInput}
+      onSearch={() => {
+        startTransition(() => {
+          setSubmittedQuery(queryInput.trim());
+        });
+      }}
+      onSelectSource={(nextSource) => {
+        setSource(nextSource);
+        setSelectedItem(null);
+      }}
+      onSelectItem={setSelectedId}
+    />
+  );
+}

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -1,0 +1,36 @@
+import type {
+  ArchiveSource,
+  BookmarkItem,
+  LikeItem,
+  ListResponse,
+  StatusResponse,
+} from './types';
+
+async function requestJson<T>(input: string): Promise<T> {
+  const response = await fetch(input);
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(text || `Request failed: ${response.status}`);
+  }
+  return response.json() as Promise<T>;
+}
+
+export async function fetchStatus(): Promise<StatusResponse> {
+  return requestJson<StatusResponse>('/api/status');
+}
+
+export async function fetchArchiveList(
+  source: ArchiveSource,
+  options: { query?: string; limit?: number; offset?: number } = {},
+): Promise<ListResponse<BookmarkItem> | ListResponse<LikeItem>> {
+  const params = new URLSearchParams();
+  if (options.query) params.set('query', options.query);
+  if (options.limit) params.set('limit', String(options.limit));
+  if (options.offset) params.set('offset', String(options.offset));
+  const suffix = params.toString();
+  return requestJson(`/api/${source}${suffix ? `?${suffix}` : ''}`);
+}
+
+export async function fetchArchiveItem(source: ArchiveSource, id: string): Promise<BookmarkItem | LikeItem> {
+  return requestJson(`/api/${source}/${id}`);
+}

--- a/web/src/components/archive-layout.tsx
+++ b/web/src/components/archive-layout.tsx
@@ -1,0 +1,92 @@
+import type { ArchiveSource, BookmarkItem, LikeItem, StatusResponse } from '../types';
+import { DetailPane } from './detail-pane';
+import { ItemList } from './item-list';
+import { SearchBar } from './search-bar';
+
+interface ArchiveLayoutProps {
+  source: ArchiveSource;
+  status: StatusResponse | null;
+  items: Array<BookmarkItem | LikeItem>;
+  selectedId: string | null;
+  selectedItem: BookmarkItem | LikeItem | null;
+  listLoading: boolean;
+  detailLoading: boolean;
+  detailError: string | null;
+  query: string;
+  onQueryChange: (value: string) => void;
+  onSearch: () => void;
+  onSelectSource: (source: ArchiveSource) => void;
+  onSelectItem: (id: string) => void;
+}
+
+function formatCount(value: number | undefined): string {
+  return typeof value === 'number' ? value.toLocaleString() : '0';
+}
+
+export function ArchiveLayout(props: ArchiveLayoutProps) {
+  const activeCount = props.source === 'bookmarks' ? props.status?.bookmarks.total : props.status?.likes.total;
+
+  return (
+    <main className="app-shell">
+      <section className="hero">
+        <div>
+          <div className="eyebrow">Local archive browser</div>
+          <h1>Bookmarks and likes, on your machine.</h1>
+          <p>
+            Search the archive, open details fast, and jump back to the original post when you need the full thread.
+          </p>
+        </div>
+        <div className="hero-stats">
+          <div>
+            <span>Bookmarks</span>
+            <strong>{formatCount(props.status?.bookmarks.total)}</strong>
+          </div>
+          <div>
+            <span>Likes</span>
+            <strong>{formatCount(props.status?.likes.total)}</strong>
+          </div>
+          <div>
+            <span>Active view</span>
+            <strong>{formatCount(activeCount)}</strong>
+          </div>
+        </div>
+      </section>
+
+      <section className="toolbar">
+        <div className="tabs" role="tablist" aria-label="Archive type">
+          {(['bookmarks', 'likes'] as const).map((source) => (
+            <button
+              key={source}
+              type="button"
+              role="tab"
+              aria-selected={props.source === source}
+              className={`tab${props.source === source ? ' is-active' : ''}`}
+              onClick={() => props.onSelectSource(source)}
+            >
+              {source}
+            </button>
+          ))}
+        </div>
+        <SearchBar query={props.query} onQueryChange={props.onQueryChange} onSubmit={props.onSearch} />
+      </section>
+
+      <section className="workspace">
+        <aside className="list-panel">
+          <ItemList
+            items={props.items}
+            source={props.source}
+            selectedId={props.selectedId}
+            loading={props.listLoading}
+            onSelect={props.onSelectItem}
+          />
+        </aside>
+        <DetailPane
+          source={props.source}
+          item={props.selectedItem}
+          loading={props.detailLoading}
+          error={props.detailError}
+        />
+      </section>
+    </main>
+  );
+}

--- a/web/src/components/detail-pane.tsx
+++ b/web/src/components/detail-pane.tsx
@@ -1,0 +1,89 @@
+import type { ArchiveSource, BookmarkItem, LikeItem } from '../types';
+
+interface DetailPaneProps {
+  source: ArchiveSource;
+  item: BookmarkItem | LikeItem | null;
+  loading: boolean;
+  error: string | null;
+}
+
+function renderDateLabel(source: ArchiveSource, item: BookmarkItem | LikeItem): string {
+  if (source === 'bookmarks') {
+    const bookmark = item as BookmarkItem;
+    return `Bookmarked ${bookmark.bookmarkedAt?.slice(0, 10) ?? '?'} · posted ${bookmark.postedAt?.slice(0, 10) ?? '?'}`;
+  }
+  const like = item as LikeItem;
+  return `Liked ${like.likedAt?.slice(0, 10) ?? '?'} · posted ${like.postedAt?.slice(0, 10) ?? '?'}`;
+}
+
+export function DetailPane({ source, item, loading, error }: DetailPaneProps) {
+  if (loading) {
+    return <section className="detail-pane"><div className="empty-state">Loading detail…</div></section>;
+  }
+
+  if (error) {
+    return <section className="detail-pane"><div className="empty-state">{error}</div></section>;
+  }
+
+  if (!item) {
+    return <section className="detail-pane"><div className="empty-state">Select an item to inspect its full archive entry.</div></section>;
+  }
+
+  const bookmark = source === 'bookmarks' ? item as BookmarkItem : null;
+
+  return (
+    <section className="detail-pane">
+      <div className="detail-header">
+        <div>
+          <div className="eyebrow">{source === 'bookmarks' ? 'Bookmark' : 'Like'}</div>
+          <h2>{item.authorName || item.authorHandle || 'Unknown author'}</h2>
+          <p className="detail-date">{renderDateLabel(source, item)}</p>
+        </div>
+        <a href={item.url} target="_blank" rel="noreferrer">Open on X</a>
+      </div>
+
+      <article className="detail-body">
+        <p>{item.text}</p>
+      </article>
+
+      <dl className="detail-stats">
+        <div><dt>Likes</dt><dd>{item.likeCount ?? 0}</dd></div>
+        <div><dt>Reposts</dt><dd>{item.repostCount ?? 0}</dd></div>
+        <div><dt>Replies</dt><dd>{item.replyCount ?? 0}</dd></div>
+        <div><dt>Bookmarks</dt><dd>{item.bookmarkCount ?? 0}</dd></div>
+      </dl>
+
+      {bookmark && (bookmark.categories.length > 0 || bookmark.domains.length > 0) ? (
+        <div className="detail-groups">
+          {bookmark.categories.length > 0 ? (
+            <div>
+              <h3>Categories</h3>
+              <div className="pill-row">
+                {bookmark.categories.map((value) => <span key={value} className="pill">{value}</span>)}
+              </div>
+            </div>
+          ) : null}
+          {bookmark.domains.length > 0 ? (
+            <div>
+              <h3>Domains</h3>
+              <div className="pill-row">
+                {bookmark.domains.map((value) => <span key={value} className="pill">{value}</span>)}
+              </div>
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+
+      {item.links.length > 0 ? (
+        <div className="detail-groups">
+          <h3>Links</h3>
+          <div className="link-stack">
+            {item.links.map((link) => (
+              <a key={link} href={link} target="_blank" rel="noreferrer">{link}</a>
+            ))}
+          </div>
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/web/src/components/item-list.tsx
+++ b/web/src/components/item-list.tsx
@@ -1,0 +1,48 @@
+import type { ArchiveSource, BookmarkItem, LikeItem } from '../types';
+
+interface ItemListProps {
+  items: Array<BookmarkItem | LikeItem>;
+  source: ArchiveSource;
+  selectedId?: string | null;
+  loading: boolean;
+  onSelect: (id: string) => void;
+}
+
+function getItemDate(source: ArchiveSource, item: BookmarkItem | LikeItem): string {
+  return source === 'bookmarks'
+    ? (item as BookmarkItem).bookmarkedAt ?? item.postedAt ?? ''
+    : (item as LikeItem).likedAt ?? item.postedAt ?? '';
+}
+
+export function ItemList({ items, source, selectedId, loading, onSelect }: ItemListProps) {
+  if (loading) {
+    return <div className="empty-state">Loading archive…</div>;
+  }
+
+  if (items.length === 0) {
+    return <div className="empty-state">No items found for this view.</div>;
+  }
+
+  return (
+    <div className="item-list" role="list">
+      {items.map((item) => (
+        <button
+          key={item.id}
+          type="button"
+          className={`item-row${item.id === selectedId ? ' is-selected' : ''}`}
+          onClick={() => onSelect(item.id)}
+        >
+          <div className="item-row-top">
+            <span className="item-handle">{item.authorHandle ? `@${item.authorHandle}` : '@unknown'}</span>
+            <span className="item-date">{getItemDate(source, item).slice(0, 10) || 'unknown date'}</span>
+          </div>
+          <p className="item-text">{item.text}</p>
+          <div className="item-meta">
+            <span>{item.linkCount} links</span>
+            <span>{item.mediaCount} media</span>
+          </div>
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/web/src/components/search-bar.tsx
+++ b/web/src/components/search-bar.tsx
@@ -1,0 +1,26 @@
+interface SearchBarProps {
+  query: string;
+  onQueryChange: (value: string) => void;
+  onSubmit: () => void;
+}
+
+export function SearchBar({ query, onQueryChange, onSubmit }: SearchBarProps) {
+  return (
+    <form
+      className="search-bar"
+      onSubmit={(event) => {
+        event.preventDefault();
+        onSubmit();
+      }}
+    >
+      <input
+        aria-label="Search archive"
+        className="search-input"
+        value={query}
+        onChange={(event) => onQueryChange(event.target.value)}
+        placeholder='Search text, phrase, or author. Example: "Claude Code"'
+      />
+      <button className="search-button" type="submit">Search</button>
+    </form>
+  );
+}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,0 +1,5 @@
+import ReactDOM from 'react-dom/client';
+import { App } from './app';
+import './styles.css';
+
+ReactDOM.createRoot(document.getElementById('root')!).render(<App />);

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1,0 +1,324 @@
+@import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Instrument+Sans:wght@400;500;600;700&display=swap');
+
+:root {
+  --bg: #f4efe6;
+  --surface: rgba(255, 250, 242, 0.84);
+  --ink: #11202f;
+  --muted: #5b6b7a;
+  --line: rgba(17, 32, 47, 0.12);
+  --accent-strong: #0b5d57;
+  --shadow: 0 24px 60px rgba(17, 32, 47, 0.12);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html, body, #root {
+  min-height: 100%;
+  margin: 0;
+}
+
+body {
+  font-family: 'Instrument Sans', 'Avenir Next', sans-serif;
+  color: var(--ink);
+  background:
+    radial-gradient(circle at top left, rgba(15, 118, 110, 0.14), transparent 34%),
+    radial-gradient(circle at top right, rgba(195, 92, 60, 0.12), transparent 30%),
+    linear-gradient(180deg, #faf6ef 0%, var(--bg) 100%);
+}
+
+button, input, a {
+  font: inherit;
+}
+
+a {
+  color: var(--accent-strong);
+}
+
+.app-shell {
+  max-width: 1440px;
+  margin: 0 auto;
+  padding: 40px 24px 24px;
+}
+
+.hero {
+  display: grid;
+  grid-template-columns: 1.7fr 1fr;
+  gap: 24px;
+  align-items: end;
+  margin-bottom: 20px;
+}
+
+.hero h1 {
+  margin: 0;
+  font-size: clamp(2.4rem, 5vw, 4.8rem);
+  line-height: 0.94;
+  letter-spacing: -0.06em;
+}
+
+.hero p,
+.detail-body p,
+.empty-state {
+  color: var(--muted);
+  line-height: 1.6;
+}
+
+.eyebrow,
+.item-date,
+.detail-date,
+.detail-stats dt {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.hero-stats,
+.toolbar,
+.list-panel,
+.detail-pane {
+  border: 1px solid var(--line);
+  background: var(--surface);
+  backdrop-filter: blur(18px);
+  box-shadow: var(--shadow);
+}
+
+.hero-stats {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 12px;
+  padding: 18px;
+  border-radius: 24px;
+}
+
+.hero-stats div {
+  padding: 12px;
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.54);
+}
+
+.hero-stats span {
+  display: block;
+  color: var(--muted);
+  margin-bottom: 6px;
+}
+
+.hero-stats strong {
+  font-size: 1.7rem;
+}
+
+.toolbar {
+  display: flex;
+  gap: 16px;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px;
+  margin-bottom: 18px;
+  border-radius: 22px;
+}
+
+.tabs {
+  display: inline-flex;
+  gap: 8px;
+}
+
+.tab,
+.search-button {
+  border: 0;
+  border-radius: 999px;
+  padding: 12px 18px;
+  cursor: pointer;
+  transition: transform 180ms ease, background 180ms ease;
+}
+
+.tab {
+  background: transparent;
+  color: var(--muted);
+}
+
+.tab.is-active,
+.search-button {
+  background: var(--ink);
+  color: #fff;
+}
+
+.tab:hover,
+.search-button:hover,
+.item-row:hover {
+  transform: translateY(-1px);
+}
+
+.search-bar {
+  display: flex;
+  gap: 10px;
+  flex: 1;
+  max-width: 700px;
+}
+
+.search-input {
+  width: 100%;
+  border-radius: 999px;
+  border: 1px solid var(--line);
+  background: rgba(255, 255, 255, 0.9);
+  padding: 13px 18px;
+  color: var(--ink);
+}
+
+.workspace {
+  display: grid;
+  grid-template-columns: minmax(340px, 430px) 1fr;
+  gap: 18px;
+  min-height: 72vh;
+}
+
+.list-panel,
+.detail-pane {
+  border-radius: 28px;
+  overflow: hidden;
+}
+
+.item-list {
+  display: flex;
+  flex-direction: column;
+  padding: 12px;
+  gap: 10px;
+}
+
+.item-row {
+  text-align: left;
+  border: 1px solid transparent;
+  border-radius: 20px;
+  background: rgba(255, 255, 255, 0.58);
+  padding: 14px;
+  cursor: pointer;
+  transition: transform 180ms ease, border-color 180ms ease, background 180ms ease;
+}
+
+.item-row.is-selected {
+  border-color: rgba(15, 118, 110, 0.45);
+  background: rgba(240, 255, 252, 0.9);
+}
+
+.item-row-top,
+.item-meta,
+.detail-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.item-handle {
+  font-weight: 600;
+}
+
+.item-text {
+  margin: 10px 0;
+  color: var(--ink);
+  line-height: 1.5;
+}
+
+.item-meta {
+  color: var(--muted);
+  font-size: 0.92rem;
+}
+
+.detail-pane {
+  padding: 28px;
+}
+
+.detail-header {
+  align-items: start;
+  margin-bottom: 18px;
+}
+
+.detail-header h2 {
+  margin: 6px 0 8px;
+  font-size: clamp(1.4rem, 2vw, 2.2rem);
+  line-height: 1.05;
+}
+
+.detail-body {
+  padding: 20px 0;
+  border-top: 1px solid var(--line);
+  border-bottom: 1px solid var(--line);
+}
+
+.detail-stats {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 12px;
+  margin: 22px 0;
+}
+
+.detail-stats div,
+.pill,
+.empty-state {
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.72);
+}
+
+.detail-stats div {
+  padding: 14px;
+}
+
+.detail-stats dd {
+  margin: 8px 0 0;
+  font-size: 1.4rem;
+  font-weight: 700;
+}
+
+.detail-groups + .detail-groups {
+  margin-top: 18px;
+}
+
+.pill-row {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 8px 12px;
+}
+
+.link-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.empty-state {
+  padding: 28px;
+  margin: 12px;
+}
+
+.search-input:focus,
+.search-button:focus,
+.tab:focus,
+.item-row:focus {
+  outline: 2px solid rgba(15, 118, 110, 0.55);
+  outline-offset: 2px;
+}
+
+@media (max-width: 980px) {
+  .hero,
+  .workspace {
+    grid-template-columns: 1fr;
+  }
+
+  .toolbar {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .search-bar {
+    max-width: none;
+  }
+
+  .detail-stats {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -1,0 +1,68 @@
+export type ArchiveSource = 'bookmarks' | 'likes';
+
+export interface StatusBucket {
+  total: number;
+  hasCache: boolean;
+  hasIndex: boolean;
+}
+
+export interface StatusResponse {
+  dataDir: string;
+  bookmarks: StatusBucket;
+  likes: StatusBucket;
+}
+
+export interface BookmarkItem {
+  id: string;
+  tweetId: string;
+  url: string;
+  text: string;
+  authorHandle?: string;
+  authorName?: string;
+  authorProfileImageUrl?: string;
+  postedAt?: string | null;
+  bookmarkedAt?: string | null;
+  categories: string[];
+  primaryCategory?: string | null;
+  domains: string[];
+  primaryDomain?: string | null;
+  githubUrls: string[];
+  links: string[];
+  mediaCount: number;
+  linkCount: number;
+  likeCount?: number | null;
+  repostCount?: number | null;
+  replyCount?: number | null;
+  quoteCount?: number | null;
+  bookmarkCount?: number | null;
+  viewCount?: number | null;
+}
+
+export interface LikeItem {
+  id: string;
+  tweetId: string;
+  url: string;
+  text: string;
+  authorHandle?: string;
+  authorName?: string;
+  authorProfileImageUrl?: string;
+  postedAt?: string | null;
+  likedAt?: string | null;
+  links: string[];
+  mediaCount: number;
+  linkCount: number;
+  likeCount?: number | null;
+  repostCount?: number | null;
+  replyCount?: number | null;
+  quoteCount?: number | null;
+  bookmarkCount?: number | null;
+  viewCount?: number | null;
+}
+
+export interface ListResponse<T> {
+  source: ArchiveSource;
+  total: number;
+  limit: number;
+  offset: number;
+  items: T[];
+}

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "noEmit": true,
+    "types": ["vite/client"]
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx", "vite.config.ts"]
+}

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const rootDir = path.dirname(fileURLToPath(import.meta.url));
+
+export default defineConfig({
+  plugins: [react()],
+  root: rootDir,
+  build: {
+    outDir: path.resolve(rootDir, '../dist/web'),
+    emptyOutDir: false,
+  },
+});


### PR DESCRIPTION
## Summary
- add a dedicated read-only Home timeline feed archive with cache, state, meta, and SQLite index
- expose `ft feed sync`, `ft feed status`, `ft feed list`, and `ft feed show` for local feed browsing
- harden X GraphQL requests with a shared curl fallback so feed, likes, bookmarks, and mutations survive Node fetch connect failures

## Verification
- npm test -- tests/graphql-feed.test.ts tests/feed-db.test.ts tests/feed-service.test.ts tests/cli-feed.test.ts tests/cli-actions.test.ts tests/archive-actions.test.ts
- npm run build
- node dist/cli.js feed sync --max-pages 2
- node dist/cli.js feed status
- node dist/cli.js feed list --limit 5
- node dist/cli.js feed show 2043320548776681627
- node dist/cli.js likes sync --max-pages 1

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new X GraphQL integrations (Home timeline fetch plus unlike/unbookmark mutations) and a new local web server/UI build pipeline, which can affect sync reliability and introduces destructive remote actions that must correctly reconcile local archives.
> 
> **Overview**
> Introduces a new **read-only `feed` archive family** that syncs tweet-only Home timeline items via the browser-authenticated GraphQL path, persists `feed.jsonl`/meta/state, builds `feed.db`, and exposes `ft feed sync|status|list|show` for local paging.
> 
> Expands the **likes surface** into a first-class archive (`ft likes sync|search|list|show|status|index`) and adds destructive/maintenance flows: `ft likes unlike`, `ft unbookmark`, and throttled `ft likes trim`, all of which reconcile the local JSONL + rebuild the relevant SQLite index.
> 
> Adds a **local web UI** command (`ft web`) with new frontend/build dependencies (Hono + Vite/React), updates package naming/versioning and README/docs, and hardens X requests by routing GraphQL fetches through a shared `fetchXResource` curl-fallback path (now used by bookmarks and new feed/actions).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c246fa2ac71f66c6c682faae2728948a32389792. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->