### PR TITLE
feat: article enrichment in syncGaps + security hardening

### DIFF
--- a/src/bookmark-enrich.ts
+++ b/src/bookmark-enrich.ts
@@ -1,0 +1,195 @@
+/**
+ * Article extraction for link-heavy bookmarks.
+ *
+ * Fetches linked page content and extracts readable text so it becomes
+ * searchable via FTS5. Used by syncGaps as "Gap 3".
+ *
+ * Strategies:
+ *   1. HTML fetch → extract <article>, <main>, or body text
+ *   2. JSON-LD structured data
+ *   3. OpenGraph / meta description fallback
+ */
+
+const MAX_RESPONSE_BYTES = 2 * 1024 * 1024; // 2 MB
+const FETCH_TIMEOUT_MS = 15_000;
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+export interface ArticleContent {
+  title: string;
+  text: string;
+  siteName?: string;
+}
+
+// ── HTML helpers ───────────────────────────────────────────────────────────
+
+function decodeEntities(text: string): string {
+  return text
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#0?39;/g, "'")
+    .replace(/&#x27;/g, "'")
+    .replace(/&#x2F;/g, '/')
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&#(\d+);/g, (_, n) => String.fromCharCode(parseInt(n)));
+}
+
+function stripHtml(html: string): string {
+  return decodeEntities(html.replace(/<[^>]+>/g, ' ')).replace(/\s+/g, ' ').trim();
+}
+
+// ── Extraction ─────────────────────────────────────────────────────────────
+
+export function extractReadableText(html: string): ArticleContent | null {
+  const ogTitle = html.match(/<meta\s+(?:property|name)="og:title"\s+content="([^"]*)"[^>]*>/i);
+  const htmlTitle = html.match(/<title[^>]*>([\s\S]*?)<\/title>/i);
+  const title = stripHtml(ogTitle?.[1] ?? htmlTitle?.[1] ?? '');
+
+  const siteMatch = html.match(/<meta\s+(?:property|name)="og:site_name"\s+content="([^"]*)"[^>]*>/i);
+  const siteName = siteMatch ? decodeEntities(siteMatch[1]) : undefined;
+
+  // Remove non-content blocks
+  let cleaned = html
+    .replace(/<script[\s\S]*?<\/script>/gi, '')
+    .replace(/<style[\s\S]*?<\/style>/gi, '')
+    .replace(/<nav[\s\S]*?<\/nav>/gi, '')
+    .replace(/<footer[\s\S]*?<\/footer>/gi, '')
+    .replace(/<header[\s\S]*?<\/header>/gi, '')
+    .replace(/<aside[\s\S]*?<\/aside>/gi, '')
+    .replace(/<!--[\s\S]*?-->/g, '');
+
+  // Try content selectors in specificity order
+  let text = '';
+  const articleMatch = cleaned.match(/<article[^>]*>([\s\S]*?)<\/article>/i);
+  const mainMatch = cleaned.match(/<main[^>]*>([\s\S]*?)<\/main>/i);
+
+  if (articleMatch) text = stripHtml(articleMatch[1]);
+  else if (mainMatch) text = stripHtml(mainMatch[1]);
+  else text = stripHtml(cleaned);
+
+  // Fallback to meta description
+  if (text.length < 100) {
+    const ogDesc = html.match(/<meta\s+(?:property|name)="(?:og:)?description"\s+content="([^"]*)"[^>]*>/i);
+    if (ogDesc && ogDesc[1].length > text.length) {
+      text = stripHtml(ogDesc[1]);
+    }
+  }
+
+  // Fallback to JSON-LD
+  if (text.length < 100) {
+    const jsonLd = html.match(/<script[^>]*type="application\/ld\+json"[^>]*>([\s\S]*?)<\/script>/i);
+    if (jsonLd) {
+      try {
+        const data = JSON.parse(jsonLd[1]);
+        const body = data.articleBody ?? data.text ?? data.description ?? '';
+        if (body.length > text.length) text = body;
+      } catch { /* invalid JSON-LD */ }
+    }
+  }
+
+  if (text.length < 50) return null;
+  if (text.length > 15_000) text = text.slice(0, 15_000);
+
+  return { title, text, siteName };
+}
+
+// ── URL filtering ──────────────────────────────────────────────────────────
+
+function isTwitterUrl(url: string): boolean {
+  try {
+    const host = new URL(url).hostname;
+    return host === 'twitter.com' || host === 'x.com' || host.endsWith('.twitter.com') || host.endsWith('.x.com');
+  } catch { return false; }
+}
+
+function isSafeUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return false;
+    // Block common private/reserved hostnames
+    const host = parsed.hostname;
+    if (host === 'localhost' || host === '127.0.0.1' || host === '::1') return false;
+    if (host.startsWith('10.') || host.startsWith('192.168.')) return false;
+    if (/^172\.(1[6-9]|2\d|3[01])\./.test(host)) return false;
+    if (host === '169.254.169.254') return false; // cloud metadata
+    return true;
+  } catch { return false; }
+}
+
+// ── Fetch with size limit ──────────────────────────────────────────────────
+
+async function fetchWithLimit(url: string): Promise<string | null> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+
+  try {
+    const res = await fetch(url, {
+      headers: {
+        'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+        'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+      },
+      redirect: 'follow',
+      signal: controller.signal,
+    });
+
+    if (!res.ok) return null;
+
+    const contentType = res.headers.get('content-type') ?? '';
+    if (!contentType.includes('text/html') && !contentType.includes('application/xhtml')) return null;
+
+    // Read body with size limit
+    const reader = res.body?.getReader();
+    if (!reader) return null;
+
+    const chunks: Uint8Array[] = [];
+    let totalBytes = 0;
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      totalBytes += value.byteLength;
+      if (totalBytes > MAX_RESPONSE_BYTES) {
+        reader.cancel();
+        break;
+      }
+      chunks.push(value);
+    }
+
+    const decoder = new TextDecoder();
+    return chunks.map((c) => decoder.decode(c, { stream: true })).join('') + decoder.decode();
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+// ── Public API ─────────────────────────────────────────────────────────────
+
+export async function fetchArticle(url: string): Promise<ArticleContent | null> {
+  if (isTwitterUrl(url)) return null;
+  if (!isSafeUrl(url)) return null;
+  const html = await fetchWithLimit(url);
+  if (!html) return null;
+  return extractReadableText(html);
+}
+
+/**
+ * Resolve t.co shortlinks — returns the expanded URL without fetching the full page.
+ * Returns null if resolution fails.
+ */
+export async function resolveTcoLink(url: string): Promise<string | null> {
+  if (!url.includes('t.co/')) return url;
+  try {
+    const res = await fetch(url, {
+      method: 'HEAD',
+      redirect: 'follow',
+      signal: AbortSignal.timeout(5_000),
+    });
+    const resolved = res.url;
+    // Skip if it resolved to another t.co or to a twitter media URL
+    if (resolved.includes('t.co/') || isTwitterUrl(resolved)) return null;
+    return resolved;
+  } catch { return null; }
+}

--- a/src/bookmarks-db.ts
+++ b/src/bookmarks-db.ts
@@ -7,7 +7,7 @@ import type { BookmarkRecord, QuotedTweetSnapshot } from './types.js';
 import { classifyCorpus, formatClassificationSummary } from './bookmark-classify.js';
 import type { ClassificationSummary } from './bookmark-classify.js';
 
-const SCHEMA_VERSION = 4;
+const SCHEMA_VERSION = 5;
 
 export interface SearchResult {
   id: string;
@@ -221,7 +221,11 @@ function initSchema(db: Database): void {
     github_urls TEXT,
     domains TEXT,
     primary_domain TEXT,
-    quoted_tweet_json TEXT
+    quoted_tweet_json TEXT,
+    article_title TEXT,
+    article_text TEXT,
+    article_site TEXT,
+    enriched_at TEXT
   )`);
 
   db.run(`CREATE INDEX IF NOT EXISTS idx_bookmarks_author ON bookmarks(author_handle)`);
@@ -234,12 +238,13 @@ function initSchema(db: Database): void {
     text,
     author_handle,
     author_name,
+    article_text,
     content=bookmarks,
     content_rowid=rowid,
     tokenize='porter unicode61'
   )`);
 
-  db.run(`REPLACE INTO meta VALUES ('schema_version', '${SCHEMA_VERSION}')`);
+  db.run("REPLACE INTO meta VALUES ('schema_version', ?)", [String(SCHEMA_VERSION)]);
 }
 
 function ensureMigrations(db: Database): void {
@@ -262,8 +267,25 @@ function ensureMigrations(db: Database): void {
       try { db.run('ALTER TABLE bookmarks ADD COLUMN quoted_tweet_json TEXT'); } catch { /* already exists */ }
     }
   }
+  if (version < 5) {
+    const tableExists = db.exec("SELECT name FROM sqlite_master WHERE type='table' AND name='bookmarks'");
+    if (tableExists.length && tableExists[0].values.length > 0) {
+      try { db.run('ALTER TABLE bookmarks ADD COLUMN article_title TEXT'); } catch { /* already exists */ }
+      try { db.run('ALTER TABLE bookmarks ADD COLUMN article_text TEXT'); } catch { /* already exists */ }
+      try { db.run('ALTER TABLE bookmarks ADD COLUMN article_site TEXT'); } catch { /* already exists */ }
+      try { db.run('ALTER TABLE bookmarks ADD COLUMN enriched_at TEXT'); } catch { /* already exists */ }
+      // Rebuild FTS to include article_text column
+      db.run('DROP TABLE IF EXISTS bookmarks_fts');
+      db.run(`CREATE VIRTUAL TABLE IF NOT EXISTS bookmarks_fts USING fts5(
+        text, author_handle, author_name, article_text,
+        content=bookmarks, content_rowid=rowid,
+        tokenize='porter unicode61'
+      )`);
+      db.run("INSERT INTO bookmarks_fts(bookmarks_fts) VALUES('rebuild')");
+    }
+  }
   if (version < SCHEMA_VERSION) {
-    db.run(`REPLACE INTO meta VALUES ('schema_version', '${SCHEMA_VERSION}')`);
+    db.run("REPLACE INTO meta VALUES ('schema_version', ?)", [String(SCHEMA_VERSION)]);
   }
 }
 
@@ -274,6 +296,10 @@ interface PreservedBookmarkFields {
   domains: string | null;
   primaryDomain: string | null;
   quotedTweetJson: string | null;
+  articleTitle: string | null;
+  articleText: string | null;
+  articleSite: string | null;
+  enrichedAt: string | null;
 }
 
 function insertRecord(db: Database, r: BookmarkRecord, preserved?: PreservedBookmarkFields): void {
@@ -284,7 +310,7 @@ function insertRecord(db: Database, r: BookmarkRecord, preserved?: PreservedBook
   const githubUrls = [...new Set([...githubMatches.map((m) => `https://${m}`), ...githubFromLinks])];
 
   db.run(
-    `INSERT OR REPLACE INTO bookmarks VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+    `INSERT OR REPLACE INTO bookmarks VALUES (${Array(35).fill('?').join(',')})`,
     [
       r.id,
       r.tweetId,
@@ -317,6 +343,10 @@ function insertRecord(db: Database, r: BookmarkRecord, preserved?: PreservedBook
       preserved?.domains ?? null,
       preserved?.primaryDomain ?? null,
       r.quotedTweet ? JSON.stringify(r.quotedTweet) : (preserved?.quotedTweetJson ?? null),
+      preserved?.articleTitle ?? null,
+      preserved?.articleText ?? null,
+      preserved?.articleSite ?? null,
+      preserved?.enrichedAt ?? null,
     ]
   );
 }
@@ -341,7 +371,8 @@ export async function buildIndex(options?: { force?: boolean }): Promise<{ dbPat
     const existingRows = new Map<string, PreservedBookmarkFields>();
     try {
       const rows = db.exec(
-        `SELECT id, categories, primary_category, github_urls, domains, primary_domain, quoted_tweet_json
+        `SELECT id, categories, primary_category, github_urls, domains, primary_domain,
+                quoted_tweet_json, article_title, article_text, article_site, enriched_at
          FROM bookmarks`
       );
       for (const r of (rows[0]?.values ?? [])) {
@@ -352,6 +383,10 @@ export async function buildIndex(options?: { force?: boolean }): Promise<{ dbPat
           domains: (r[4] as string) ?? null,
           primaryDomain: (r[5] as string) ?? null,
           quotedTweetJson: (r[6] as string) ?? null,
+          articleTitle: (r[7] as string) ?? null,
+          articleText: (r[8] as string) ?? null,
+          articleSite: (r[9] as string) ?? null,
+          enrichedAt: (r[10] as string) ?? null,
         });
       }
     } catch { /* table may be empty */ }
@@ -382,6 +417,19 @@ export async function buildIndex(options?: { force?: boolean }): Promise<{ dbPat
   }
 }
 
+/** Escape FTS5 special syntax so user queries are treated as literal terms. */
+function sanitizeFtsQuery(query: string): string {
+  // If the query contains FTS5 operators, wrap each word in double quotes for literal matching
+  if (/[*{}:^"]|^(AND|OR|NOT|NEAR)\b/i.test(query)) {
+    return query
+      .split(/\s+/)
+      .filter(Boolean)
+      .map((term) => `"${term.replace(/"/g, '')}"`)
+      .join(' ');
+  }
+  return query;
+}
+
 export async function searchBookmarks(options: SearchOptions): Promise<SearchResult[]> {
   const dbPath = twitterBookmarksIndexPath();
   const db = await openDb(dbPath);
@@ -394,7 +442,7 @@ export async function searchBookmarks(options: SearchOptions): Promise<SearchRes
 
     if (options.query) {
       conditions.push(`b.rowid IN (SELECT rowid FROM bookmarks_fts WHERE bookmarks_fts MATCH ?)`);
-      params.push(options.query);
+      params.push(sanitizeFtsQuery(options.query));
     }
     if (options.author) {
       conditions.push(`b.author_handle = ? COLLATE NOCASE`);
@@ -413,7 +461,7 @@ export async function searchBookmarks(options: SearchOptions): Promise<SearchRes
 
     // If we have an FTS query, use bm25 for ranking; otherwise sort by posted_at
     const orderBy = options.query
-      ? `ORDER BY bm25(bookmarks_fts, 5.0, 1.0, 1.0) ASC`
+      ? `ORDER BY bm25(bookmarks_fts, 5.0, 1.0, 1.0, 3.0) ASC`
       : `ORDER BY b.posted_at DESC`;
 
     // For FTS ranking we need to join with the FTS table for bm25
@@ -421,7 +469,7 @@ export async function searchBookmarks(options: SearchOptions): Promise<SearchRes
     if (options.query) {
       sql = `
         SELECT b.id, b.url, b.text, b.author_handle, b.author_name, b.posted_at,
-               bm25(bookmarks_fts, 5.0, 1.0, 1.0) as score
+               bm25(bookmarks_fts, 5.0, 1.0, 1.0, 3.0) as score
         FROM bookmarks b
         JOIN bookmarks_fts ON bookmarks_fts.rowid = b.rowid
         ${where}
@@ -942,6 +990,37 @@ export async function updateBookmarkText(
     }
     stmt.free();
     // Rebuild FTS to reflect updated text
+    db.run("INSERT INTO bookmarks_fts(bookmarks_fts) VALUES('rebuild')");
+    saveDb(db, dbPath);
+  } finally {
+    db.close();
+  }
+}
+
+export interface ArticleUpdate {
+  id: string;
+  articleTitle: string;
+  articleText: string;
+  articleSite?: string;
+}
+
+export async function updateArticleContent(
+  records: ArticleUpdate[],
+): Promise<void> {
+  if (!records.length) return;
+  const dbPath = twitterBookmarksIndexPath();
+  const db = await openDb(dbPath);
+  ensureMigrations(db);
+
+  try {
+    const stmt = db.prepare(
+      'UPDATE bookmarks SET article_title = ?, article_text = ?, article_site = ?, enriched_at = ? WHERE id = ?'
+    );
+    const now = new Date().toISOString();
+    for (const record of records) {
+      stmt.run([record.articleTitle, record.articleText, record.articleSite ?? null, now, record.id]);
+    }
+    stmt.free();
     db.run("INSERT INTO bookmarks_fts(bookmarks_fts) VALUES('rebuild')");
     saveDb(db, dbPath);
   } finally {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -416,7 +416,7 @@ export function buildCli() {
     .option('--api', 'Use OAuth v2 API instead of Chrome session', false)
     .option('--rebuild', 'Full re-crawl of all bookmarks', false)
     .option('--continue', 'Resume a previous sync that was interrupted or hit the page limit', false)
-    .option('--gaps', 'Backfill missing data (quoted tweets, truncated articles)', false)
+    .option('--gaps', 'Backfill missing data (quoted tweets, truncated articles, linked article content)', false)
     .option('--yes', 'Skip confirmation prompts', false)
     .option('--classify', 'Classify new bookmarks with LLM after syncing', false)
     .option('--max-pages <n>', 'Max pages to fetch (default: unlimited)', (v: string) => Number(v))
@@ -444,13 +444,19 @@ export function buildCli() {
         // ── gaps mode: backfill missing data for existing bookmarks ──
         if (options.gaps) {
           const startTime = Date.now();
-          process.stderr.write('  Filling gaps (quoted tweets, truncated text)...\n');
-          let lastProgress: GapFillProgress = { done: 0, total: 0, quotedFetched: 0, textExpanded: 0, failed: 0 };
+          process.stderr.write('  Filling gaps (quoted tweets, truncated text, articles)...\n');
+          let lastProgress: GapFillProgress = { done: 0, total: 0, quotedFetched: 0, textExpanded: 0, articlesEnriched: 0, failed: 0 };
           const spinner = createSpinner(() => {
             const p = lastProgress;
             const pct = p.total > 0 ? Math.round((p.done / p.total) * 100) : 0;
             const elapsed = Math.round((Date.now() - startTime) / 1000);
-            return `${p.done}/${p.total} (${pct}%) \u2502 ${p.quotedFetched} quoted \u2502 ${p.textExpanded} expanded \u2502 ${p.failed} failed \u2502 ${elapsed}s`;
+            const parts = [`${p.done}/${p.total} (${pct}%)`];
+            if (p.quotedFetched) parts.push(`${p.quotedFetched} quoted`);
+            if (p.textExpanded) parts.push(`${p.textExpanded} expanded`);
+            if (p.articlesEnriched) parts.push(`${p.articlesEnriched} articles`);
+            if (p.failed) parts.push(`${p.failed} failed`);
+            parts.push(`${elapsed}s`);
+            return parts.join(' \u2502 ');
           });
           const result = await runWithSpinner(spinner, () => syncGaps({
             delayMs: Number(options.delayMs) || 300,
@@ -464,6 +470,7 @@ export function buildCli() {
           } else {
             if (result.quotedTweetsFilled > 0) console.log(`  \u2713 ${result.quotedTweetsFilled} quoted tweets filled`);
             if (result.textExpanded > 0) console.log(`  \u2713 ${result.textExpanded} truncated texts expanded`);
+            if (result.articlesEnriched > 0) console.log(`  \u2713 ${result.articlesEnriched} linked articles enriched`);
             if (result.bookmarkedAtRepaired > 0) {
               console.log(`  \u2713 ${result.bookmarkedAtRepaired} invalid bookmark dates cleared`);
               await rebuildIndex();

--- a/src/db.ts
+++ b/src/db.ts
@@ -36,6 +36,6 @@ export function saveDb(db: Database, filePath: string): void {
   if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
   const data = db.export();
   const tmp = filePath + '.tmp';
-  fs.writeFileSync(tmp, Buffer.from(data));
+  fs.writeFileSync(tmp, Buffer.from(data), { mode: 0o600 });
   fs.renameSync(tmp, filePath);
 }

--- a/src/fs.ts
+++ b/src/fs.ts
@@ -28,7 +28,7 @@ export async function listFiles(dirPath: string): Promise<string[]> {
 
 export async function writeJson(filePath: string, value: unknown, options: WriteOptions = {}): Promise<void> {
   const tmp = filePath + '.tmp';
-  await writeFile(tmp, JSON.stringify(value, null, 2), { encoding: 'utf8', mode: options.mode });
+  await writeFile(tmp, JSON.stringify(value, null, 2), { encoding: 'utf8', mode: options.mode ?? 0o600 });
   await rename(tmp, filePath);
 }
 
@@ -40,7 +40,7 @@ export async function readJson<T>(filePath: string): Promise<T> {
 export async function writeJsonLines(filePath: string, rows: unknown[], options: WriteOptions = {}): Promise<void> {
   const tmp = filePath + '.tmp';
   const content = rows.map((row) => JSON.stringify(row)).join('\n') + (rows.length ? '\n' : '');
-  await writeFile(tmp, content, { encoding: 'utf8', mode: options.mode });
+  await writeFile(tmp, content, { encoding: 'utf8', mode: options.mode ?? 0o600 });
   await rename(tmp, filePath);
 }
 

--- a/src/graphql-bookmarks.ts
+++ b/src/graphql-bookmarks.ts
@@ -5,7 +5,9 @@ import { extractChromeXCookies } from './chrome-cookies.js';
 import { extractFirefoxXCookies } from './firefox-cookies.js';
 import { parseTimestampMs } from './date-utils.js';
 import type { BookmarkBackfillState, BookmarkCacheMeta, BookmarkRecord, QuotedTweetSnapshot } from './types.js';
-import { exportBookmarksForSyncSeed, updateQuotedTweets, updateBookmarkText } from './bookmarks-db.js';
+import { exportBookmarksForSyncSeed, updateQuotedTweets, updateBookmarkText, updateArticleContent } from './bookmarks-db.js';
+import type { ArticleUpdate } from './bookmarks-db.js';
+import { fetchArticle, resolveTcoLink } from './bookmark-enrich.js';
 
 const CHROME_UA = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.0.0 Safari/537.36';
 
@@ -775,6 +777,7 @@ export interface GapFillProgress {
   total: number;
   quotedFetched: number;
   textExpanded: number;
+  articlesEnriched: number;
   failed: number;
 }
 
@@ -787,6 +790,7 @@ export interface GapFillFailure {
 export interface GapFillResult {
   quotedTweetsFilled: number;
   textExpanded: number;
+  articlesEnriched: number;
   bookmarkedAtRepaired: number;
   bookmarkedAtMissing: number;
   failed: number;
@@ -892,6 +896,7 @@ export async function syncGaps(options?: {
       total,
       quotedFetched,
       textExpanded,
+      articlesEnriched: 0,
       failed,
     });
 
@@ -908,18 +913,88 @@ export async function syncGaps(options?: {
   // Find bookmarks missing bookmarkedAt (filled on next sync, not via syndication)
   const bookmarkedAtMissing = records.filter((r) => !r.bookmarkedAt).length;
 
-  // Final persist
+  // Final persist (gaps 1+2)
   await writeJsonLines(cachePath, records);
   if (dbQuotedUpdates.length > 0) await updateQuotedTweets(dbQuotedUpdates);
   if (dbTextUpdates.length > 0) await updateBookmarkText(dbTextUpdates);
 
+  // ── Gap 3: Article enrichment for link-only bookmarks ───────────────────
+  // Bookmarks with < 80 chars of text after stripping URLs are "link-only"
+  // and invisible to search. Fetch the linked article to make them searchable.
+  // Article content goes directly to SQLite (not JSONL) to avoid memory bloat.
+
+  const LINK_ONLY_THRESHOLD = 80;
+  const articleDbUpdates: ArticleUpdate[] = [];
+  let articlesEnriched = 0;
+
+  // Read enriched_at from DB to skip already-enriched bookmarks
+  const enrichedIds = new Set<string>();
+  try {
+    const { openDb } = await import('./db.js');
+    const { twitterBookmarksIndexPath } = await import('./paths.js');
+    const db = await openDb(twitterBookmarksIndexPath());
+    try {
+      const rows = db.exec('SELECT id FROM bookmarks WHERE enriched_at IS NOT NULL');
+      for (const row of rows[0]?.values ?? []) enrichedIds.add(row[0] as string);
+    } finally { db.close(); }
+  } catch { /* DB may not exist yet */ }
+
+  // Filter to link-only bookmarks not yet enriched
+  const textWithoutUrls = (text: string) => text.replace(/https?:\/\/\S+/g, '').trim();
+  const needsEnrichment = records.filter((r) => {
+    if (enrichedIds.has(r.id)) return false;
+    if (!r.links?.length) return false;
+    return textWithoutUrls(r.text ?? '').length < LINK_ONLY_THRESHOLD;
+  });
+
+  const articleTotal = Math.min(needsEnrichment.length, 50); // cap per run
+  for (let i = 0; i < articleTotal; i++) {
+    const record = needsEnrichment[i];
+    // Find the first non-twitter link
+    let targetUrl: string | null = null;
+    for (const link of record.links ?? []) {
+      const resolved = link.includes('t.co/') ? await resolveTcoLink(link) : link;
+      if (resolved) { targetUrl = resolved; break; }
+    }
+
+    if (targetUrl) {
+      const article = await fetchArticle(targetUrl);
+      if (article && article.text.length >= 50) {
+        articleDbUpdates.push({
+          id: record.id,
+          articleTitle: article.title,
+          articleText: article.text,
+          articleSite: article.siteName,
+        });
+        articlesEnriched++;
+      }
+    }
+
+    options?.onProgress?.({
+      done: allFetchIds.length + i + 1,
+      total: allFetchIds.length + articleTotal,
+      quotedFetched,
+      textExpanded,
+      articlesEnriched,
+      failed,
+    });
+
+    // Rate limit: 500ms between fetches
+    if (i < articleTotal - 1) {
+      await new Promise((r) => setTimeout(r, 500));
+    }
+  }
+
+  if (articleDbUpdates.length > 0) await updateArticleContent(articleDbUpdates);
+
   return {
     quotedTweetsFilled: quotedFetched,
     textExpanded,
+    articlesEnriched,
     bookmarkedAtRepaired: loaded.repaired,
     bookmarkedAtMissing,
     failed,
     failures,
-    total,
+    total: allFetchIds.length + articleTotal,
   };
 }


### PR DESCRIPTION
## Summary

- **Article enrichment (Gap 3)**: `ft sync --gaps` now fetches linked article content for "link-only" bookmarks (< 80 chars after stripping URLs). Extracts readable text via `<article>`/`<main>`/JSON-LD/OG meta cascade. Caps at 50 per run with 500ms rate limiting. Enriched content stored in SQLite only (not JSONL) to avoid memory bloat.
- **Schema v5**: Adds `article_title`, `article_text`, `article_site`, `enriched_at` columns. FTS5 rebuilt with `article_text` at BM25 weight 3.0 — enriched articles are immediately searchable via `ft search`.
- **Security hardening**: Data files written with `0o600` permissions, FTS5 query sanitizer escapes special operators, SSRF protection (private IP blocklist, scheme allowlist, 2MB response limit, 15s timeout), parameterized schema_version query.

Inspired by PR #5 but narrowed to just the enrichment feature integrated into the existing `--gaps` flow, without the unrelated date/viz/media/sort changes.

## Test plan

- [x] `npm run build` — clean
- [x] `npm test` — 157 tests pass, 0 fail
- [x] Non-breaking: additive schema migration, existing behavior unchanged
- [ ] Run `ft sync --gaps` on real bookmarks to verify article fetching