### PR TITLE
feat: X bookmark folders + security hardening

### DIFF
--- a/src/bookmark-enrich.ts
+++ b/src/bookmark-enrich.ts
@@ -104,18 +104,117 @@ function isTwitterUrl(url: string): boolean {
   } catch { return false; }
 }
 
-function isSafeUrl(url: string): boolean {
+/**
+ * Block any URL that would resolve to a loopback, private, link-local,
+ * or unique-local address in either IPv4 or IPv6, including numeric
+ * encodings and IPv4-mapped-in-IPv6 forms. Also rejects non-http(s) schemes.
+ *
+ * This is called on the initial URL AND every redirect hop.
+ */
+export function isSafeUrl(url: string): boolean {
   try {
     const parsed = new URL(url);
     if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return false;
-    // Block common private/reserved hostnames
-    const host = parsed.hostname;
-    if (host === 'localhost' || host === '127.0.0.1' || host === '::1') return false;
-    if (host.startsWith('10.') || host.startsWith('192.168.')) return false;
-    if (/^172\.(1[6-9]|2\d|3[01])\./.test(host)) return false;
-    if (host === '169.254.169.254') return false; // cloud metadata
+
+    // URL.hostname for IPv6 normalizes brackets differently across Node versions;
+    // strip them so downstream string checks are uniform.
+    const host = parsed.hostname.toLowerCase().replace(/^\[|\]$/g, '');
+
+    if (host === 'localhost') return false;
+
+    // ─── Numeric IPv4 encodings (decimal, hex, octal) ───────────────
+    // new URL('http://2130706433/').hostname === '2130706433'
+    // new URL('http://0x7f000001/').hostname === '0x7f000001'
+    if (/^\d+$/.test(host)) return false;           // decimal: 2130706433
+    if (/^0x[0-9a-f]+$/.test(host)) return false;   // hex: 0x7f000001
+    if (/^0\d/.test(host) && /^\d+$/.test(host.slice(1))) return false; // octal leading zero
+
+    // ─── Standard IPv4 dotted quad checks ───────────────────────────
+    // Match as dotted quad first so startsWith tests don't accidentally match domains
+    // starting with "10" or "127" that happen to contain a dot.
+    if (/^\d+\.\d+\.\d+\.\d+$/.test(host)) {
+      if (host === '0.0.0.0') return false;
+      if (/^127\./.test(host)) return false;                    // 127.0.0.0/8 loopback
+      if (/^10\./.test(host)) return false;                     // 10.0.0.0/8
+      if (/^192\.168\./.test(host)) return false;               // 192.168.0.0/16
+      if (/^172\.(1[6-9]|2\d|3[01])\./.test(host)) return false; // 172.16.0.0/12
+      if (/^169\.254\./.test(host)) return false;               // 169.254.0.0/16 link-local + metadata
+      if (/^100\.(6[4-9]|[7-9]\d|1[01]\d|12[0-7])\./.test(host)) return false; // 100.64/10 CGNAT
+    }
+
+    // ─── IPv6 checks ────────────────────────────────────────────────
+    if (host === '::' || host === '::1') return false;
+    if (host.startsWith('fe80:')) return false;  // fe80::/10 link-local
+    if (host.startsWith('fc') && host.includes(':')) return false; // fc00::/8 unique-local
+    if (host.startsWith('fd') && host.includes(':')) return false; // fd00::/8 unique-local
+    if (host.startsWith('::ffff:')) return false; // IPv4-mapped IPv6: ::ffff:127.0.0.1 etc.
+    if (host.startsWith('::') && /\./.test(host)) return false; // IPv4-compat IPv6
+
     return true;
   } catch { return false; }
+}
+
+// ── Manual redirect walker ─────────────────────────────────────────────────
+
+const MAX_REDIRECT_HOPS = 5;
+
+const BROWSER_HEADERS = {
+  'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+  'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+};
+
+/**
+ * Fetch a URL, walking redirects manually and re-validating every hop
+ * against isSafeUrl. A safe-looking URL that redirects to 127.0.0.1 or
+ * AWS metadata is blocked on the next hop, not allowed through.
+ *
+ * Returns null if any hop fails validation, the fetch errors, or the
+ * redirect limit is exceeded.
+ */
+async function fetchFollowingRedirects(
+  url: string,
+  options: { signal?: AbortSignal; method?: 'GET' | 'HEAD' } = {},
+): Promise<{ response: Response; finalUrl: string } | null> {
+  const method = options.method ?? 'GET';
+  let current = url;
+
+  for (let hop = 0; hop <= MAX_REDIRECT_HOPS; hop++) {
+    if (!isSafeUrl(current)) return null;
+
+    let res: Response;
+    try {
+      res = await fetch(current, {
+        method,
+        headers: BROWSER_HEADERS,
+        redirect: 'manual',
+        signal: options.signal,
+      });
+    } catch {
+      return null;
+    }
+
+    // 304 Not Modified is in the 3xx range but isn't a redirect.
+    const isRedirect = res.status >= 300 && res.status < 400 && res.status !== 304;
+    if (!isRedirect) {
+      return { response: res, finalUrl: current };
+    }
+
+    const location = res.headers.get('location');
+    if (!location) {
+      return { response: res, finalUrl: current };
+    }
+
+    try { await res.body?.cancel(); } catch { /* ignore */ }
+
+    try {
+      // Relative redirects resolve against the current URL.
+      current = new URL(location, current).toString();
+    } catch {
+      return null;
+    }
+  }
+
+  return null;
 }
 
 // ── Fetch with size limit ──────────────────────────────────────────────────
@@ -125,15 +224,9 @@ async function fetchWithLimit(url: string): Promise<string | null> {
   const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
 
   try {
-    const res = await fetch(url, {
-      headers: {
-        'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
-        'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
-      },
-      redirect: 'follow',
-      signal: controller.signal,
-    });
-
+    const result = await fetchFollowingRedirects(url, { signal: controller.signal });
+    if (!result) return null;
+    const res = result.response;
     if (!res.ok) return null;
 
     const contentType = res.headers.get('content-type') ?? '';
@@ -176,20 +269,22 @@ export async function fetchArticle(url: string): Promise<ArticleContent | null> 
 }
 
 /**
- * Resolve t.co shortlinks — returns the expanded URL without fetching the full page.
- * Returns null if resolution fails.
+ * Resolve t.co shortlinks — returns the expanded URL after walking
+ * redirects, with isSafeUrl re-checked on every hop. Returns null if any
+ * hop points at a blocked host or resolution fails.
  */
 export async function resolveTcoLink(url: string): Promise<string | null> {
   if (!url.includes('t.co/')) return url;
-  try {
-    const res = await fetch(url, {
-      method: 'HEAD',
-      redirect: 'follow',
-      signal: AbortSignal.timeout(5_000),
-    });
-    const resolved = res.url;
-    // Skip if it resolved to another t.co or to a twitter media URL
-    if (resolved.includes('t.co/') || isTwitterUrl(resolved)) return null;
-    return resolved;
-  } catch { return null; }
+
+  const result = await fetchFollowingRedirects(url, {
+    method: 'HEAD',
+    signal: AbortSignal.timeout(5_000),
+  });
+  if (!result) return null;
+
+  try { await result.response.body?.cancel(); } catch { /* ignore */ }
+
+  const resolved = result.finalUrl;
+  if (resolved.includes('t.co/') || isTwitterUrl(resolved)) return null;
+  return resolved;
 }

--- a/src/bookmarks-db.ts
+++ b/src/bookmarks-db.ts
@@ -7,7 +7,7 @@ import type { BookmarkRecord, QuotedTweetSnapshot } from './types.js';
 import { classifyCorpus, formatClassificationSummary } from './bookmark-classify.js';
 import type { ClassificationSummary } from './bookmark-classify.js';
 
-const SCHEMA_VERSION = 5;
+const SCHEMA_VERSION = 6;
 
 export interface SearchResult {
   id: string;
@@ -25,6 +25,7 @@ export interface SearchOptions {
   limit?: number;
   before?: string;
   after?: string;
+  folder?: string;
 }
 
 export interface BookmarkTimelineItem {
@@ -51,6 +52,8 @@ export interface BookmarkTimelineItem {
   quoteCount?: number | null;
   bookmarkCount?: number | null;
   viewCount?: number | null;
+  folderIds: string[];
+  folderNames: string[];
 }
 
 export interface BookmarkTimelineFilters {
@@ -60,6 +63,7 @@ export interface BookmarkTimelineFilters {
   before?: string;
   category?: string;
   domain?: string;
+  folder?: string;
   sort?: 'asc' | 'desc';
   limit?: number;
   offset?: number;
@@ -133,6 +137,8 @@ function mapTimelineRow(row: unknown[]): BookmarkTimelineItem {
     quoteCount: row[20] as number | null,
     bookmarkCount: row[21] as number | null,
     viewCount: row[22] as number | null,
+    folderIds: parseJsonArray(row[23]),
+    folderNames: parseJsonArray(row[24]),
   };
 }
 
@@ -166,6 +172,12 @@ function buildBookmarkWhereClause(filters: BookmarkTimelineFilters): {
   if (filters.domain) {
     conditions.push(`b.domains LIKE ?`);
     params.push(`%${filters.domain}%`);
+  }
+  if (filters.folder) {
+    conditions.push(
+      `EXISTS (SELECT 1 FROM json_each(b.folder_names) WHERE json_each.value = ? COLLATE NOCASE)`
+    );
+    params.push(filters.folder);
   }
 
   return {
@@ -225,7 +237,9 @@ function initSchema(db: Database): void {
     article_title TEXT,
     article_text TEXT,
     article_site TEXT,
-    enriched_at TEXT
+    enriched_at TEXT,
+    folder_ids TEXT,
+    folder_names TEXT
   )`);
 
   db.run(`CREATE INDEX IF NOT EXISTS idx_bookmarks_author ON bookmarks(author_handle)`);
@@ -247,34 +261,62 @@ function initSchema(db: Database): void {
   db.run("REPLACE INTO meta VALUES ('schema_version', ?)", [String(SCHEMA_VERSION)]);
 }
 
+function columnExists(db: Database, table: string, column: string): boolean {
+  try {
+    const rows = db.exec(`PRAGMA table_info(${table})`);
+    const cols = rows[0]?.values ?? [];
+    // table_info columns: cid, name, type, notnull, dflt_value, pk
+    return cols.some((col) => col[1] === column);
+  } catch {
+    return false;
+  }
+}
+
+function ensureColumn(db: Database, table: string, column: string, definition: string): void {
+  if (columnExists(db, table, column)) return;
+  db.run(`ALTER TABLE ${table} ADD COLUMN ${column} ${definition}`);
+}
+
+function ftsHasColumn(db: Database, column: string): boolean {
+  try {
+    db.exec(`SELECT ${column} FROM bookmarks_fts LIMIT 0`);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 function ensureMigrations(db: Database): void {
   // Ensure meta table exists (may not on a fresh/empty DB)
   db.run('CREATE TABLE IF NOT EXISTS meta (key TEXT PRIMARY KEY, value TEXT)');
-  const rows = db.exec("SELECT value FROM meta WHERE key = 'schema_version'");
-  const version = rows.length ? Number(rows[0].values[0]?.[0] ?? 0) : 0;
-  if (version < 3) {
-    // bookmarks table may not exist yet (first run before index build)
-    const tableExists = db.exec("SELECT name FROM sqlite_master WHERE type='table' AND name='bookmarks'");
-    if (tableExists.length && tableExists[0].values.length > 0) {
-      try { db.run('ALTER TABLE bookmarks ADD COLUMN domains TEXT'); } catch { /* already exists */ }
-      try { db.run('ALTER TABLE bookmarks ADD COLUMN primary_domain TEXT'); } catch { /* already exists */ }
-      db.run('CREATE INDEX IF NOT EXISTS idx_bookmarks_domain ON bookmarks(primary_domain)');
-    }
-  }
-  if (version < 4) {
-    const tableExists = db.exec("SELECT name FROM sqlite_master WHERE type='table' AND name='bookmarks'");
-    if (tableExists.length && tableExists[0].values.length > 0) {
-      try { db.run('ALTER TABLE bookmarks ADD COLUMN quoted_tweet_json TEXT'); } catch { /* already exists */ }
-    }
-  }
-  if (version < 5) {
-    const tableExists = db.exec("SELECT name FROM sqlite_master WHERE type='table' AND name='bookmarks'");
-    if (tableExists.length && tableExists[0].values.length > 0) {
-      try { db.run('ALTER TABLE bookmarks ADD COLUMN article_title TEXT'); } catch { /* already exists */ }
-      try { db.run('ALTER TABLE bookmarks ADD COLUMN article_text TEXT'); } catch { /* already exists */ }
-      try { db.run('ALTER TABLE bookmarks ADD COLUMN article_site TEXT'); } catch { /* already exists */ }
-      try { db.run('ALTER TABLE bookmarks ADD COLUMN enriched_at TEXT'); } catch { /* already exists */ }
-      // Rebuild FTS to include article_text column
+
+  // Only run column additions if the bookmarks table actually exists — first
+  // run comes through initSchema, not here.
+  const tableExists = db.exec("SELECT name FROM sqlite_master WHERE type='table' AND name='bookmarks'");
+  const hasBookmarksTable = tableExists.length > 0 && tableExists[0].values.length > 0;
+
+  if (hasBookmarksTable) {
+    // Migrations are driven by actual column existence, not by meta.schema_version.
+    // A past bug could leave meta ahead of reality (v4 migration was marked done
+    // without its ALTER actually succeeding, because a later throw halted the run
+    // after meta had been pre-bumped). Checking the real schema is self-healing.
+    ensureColumn(db, 'bookmarks', 'domains', 'TEXT');
+    ensureColumn(db, 'bookmarks', 'primary_domain', 'TEXT');
+    db.run('CREATE INDEX IF NOT EXISTS idx_bookmarks_domain ON bookmarks(primary_domain)');
+
+    ensureColumn(db, 'bookmarks', 'quoted_tweet_json', 'TEXT');
+
+    ensureColumn(db, 'bookmarks', 'article_title', 'TEXT');
+    ensureColumn(db, 'bookmarks', 'article_text', 'TEXT');
+    ensureColumn(db, 'bookmarks', 'article_site', 'TEXT');
+    ensureColumn(db, 'bookmarks', 'enriched_at', 'TEXT');
+
+    ensureColumn(db, 'bookmarks', 'folder_ids', 'TEXT');
+    ensureColumn(db, 'bookmarks', 'folder_names', 'TEXT');
+
+    // FTS rebuild: only if the FTS table is missing the article_text column.
+    // Check via a zero-row SELECT so we don't rebuild unnecessarily.
+    if (!ftsHasColumn(db, 'article_text')) {
       db.run('DROP TABLE IF EXISTS bookmarks_fts');
       db.run(`CREATE VIRTUAL TABLE IF NOT EXISTS bookmarks_fts USING fts5(
         text, author_handle, author_name, article_text,
@@ -284,9 +326,8 @@ function ensureMigrations(db: Database): void {
       db.run("INSERT INTO bookmarks_fts(bookmarks_fts) VALUES('rebuild')");
     }
   }
-  if (version < SCHEMA_VERSION) {
-    db.run("REPLACE INTO meta VALUES ('schema_version', ?)", [String(SCHEMA_VERSION)]);
-  }
+
+  db.run("REPLACE INTO meta VALUES ('schema_version', ?)", [String(SCHEMA_VERSION)]);
 }
 
 interface PreservedBookmarkFields {
@@ -300,6 +341,13 @@ interface PreservedBookmarkFields {
   articleText: string | null;
   articleSite: string | null;
   enrichedAt: string | null;
+  folderIds: string | null;
+  folderNames: string | null;
+}
+
+function serializeJsonArray(values: string[] | undefined | null): string | null {
+  if (!values || values.length === 0) return null;
+  return JSON.stringify(values);
 }
 
 function insertRecord(db: Database, r: BookmarkRecord, preserved?: PreservedBookmarkFields): void {
@@ -310,7 +358,7 @@ function insertRecord(db: Database, r: BookmarkRecord, preserved?: PreservedBook
   const githubUrls = [...new Set([...githubMatches.map((m) => `https://${m}`), ...githubFromLinks])];
 
   db.run(
-    `INSERT OR REPLACE INTO bookmarks VALUES (${Array(35).fill('?').join(',')})`,
+    `INSERT OR REPLACE INTO bookmarks VALUES (${Array(37).fill('?').join(',')})`,
     [
       r.id,
       r.tweetId,
@@ -347,6 +395,8 @@ function insertRecord(db: Database, r: BookmarkRecord, preserved?: PreservedBook
       preserved?.articleText ?? null,
       preserved?.articleSite ?? null,
       preserved?.enrichedAt ?? null,
+      serializeJsonArray(r.folderIds) ?? preserved?.folderIds ?? null,
+      serializeJsonArray(r.folderNames) ?? preserved?.folderNames ?? null,
     ]
   );
 }
@@ -368,11 +418,16 @@ export async function buildIndex(options?: { force?: boolean }): Promise<{ dbPat
     ensureMigrations(db);
 
     // Preserve classification and enrichment fields when refreshing existing rows.
+    // Folder fields are normally sourced from JSONL (source of truth) but we also
+    // preserve them here as defense-in-depth: if a future code path writes folder
+    // state to the DB without updating JSONL, this keeps it from being wiped on
+    // the next buildIndex.
     const existingRows = new Map<string, PreservedBookmarkFields>();
     try {
       const rows = db.exec(
         `SELECT id, categories, primary_category, github_urls, domains, primary_domain,
-                quoted_tweet_json, article_title, article_text, article_site, enriched_at
+                quoted_tweet_json, article_title, article_text, article_site, enriched_at,
+                folder_ids, folder_names
          FROM bookmarks`
       );
       for (const r of (rows[0]?.values ?? [])) {
@@ -387,6 +442,8 @@ export async function buildIndex(options?: { force?: boolean }): Promise<{ dbPat
           articleText: (r[8] as string) ?? null,
           articleSite: (r[9] as string) ?? null,
           enrichedAt: (r[10] as string) ?? null,
+          folderIds: (r[11] as string) ?? null,
+          folderNames: (r[12] as string) ?? null,
         });
       }
     } catch { /* table may be empty */ }
@@ -417,17 +474,34 @@ export async function buildIndex(options?: { force?: boolean }): Promise<{ dbPat
   }
 }
 
-/** Escape FTS5 special syntax so user queries are treated as literal terms. */
-function sanitizeFtsQuery(query: string): string {
-  // If the query contains FTS5 operators, wrap each word in double quotes for literal matching
-  if (/[*{}:^"]|^(AND|OR|NOT|NEAR)\b/i.test(query)) {
-    return query
-      .split(/\s+/)
-      .filter(Boolean)
-      .map((term) => `"${term.replace(/"/g, '')}"`)
-      .join(' ');
-  }
-  return query;
+/**
+ * Escape FTS5 special syntax so user queries are treated as literal terms.
+ *
+ * FTS5 operators we need to defend against:
+ *   - Boolean keywords: AND, OR, NOT, NEAR
+ *   - Grouping: ( )
+ *   - Negation / required terms: leading - or +
+ *   - Column filters: column_name:term
+ *   - Prefix matching: *
+ *   - Expression escapes: { } ^ " \
+ *
+ * When any of these are present, wrap each whitespace-separated term in
+ * double quotes so FTS5 treats it as a literal token. Without this, a query
+ * like `foo(bar)` throws a parse error before it even hits the index.
+ */
+export function sanitizeFtsQuery(query: string): string {
+  const hasFts5Operator =
+    /[*{}:^"()\\+]/.test(query) ||
+    /(^|\s)-\S/.test(query) ||
+    /(^|\s)(AND|OR|NOT|NEAR)(\s|$)/i.test(query);
+
+  if (!hasFts5Operator) return query;
+
+  return query
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((term) => `"${term.replace(/"/g, '')}"`)
+    .join(' ');
 }
 
 export async function searchBookmarks(options: SearchOptions): Promise<SearchResult[]> {
@@ -549,7 +623,9 @@ export async function listBookmarks(
         b.reply_count,
         b.quote_count,
         b.bookmark_count,
-        b.view_count
+        b.view_count,
+        b.folder_ids,
+        b.folder_names
       FROM bookmarks b
       ${where}
       ${bookmarkSortClause(filters.sort)}
@@ -615,7 +691,9 @@ export async function exportBookmarksForSyncSeed(): Promise<BookmarkRecord[]> {
         b.quote_count,
         b.bookmark_count,
         b.view_count,
-        b.links_json
+        b.links_json,
+        b.folder_ids,
+        b.folder_names
       FROM bookmarks b
       ${bookmarkSortClause('desc')}
     `;
@@ -646,6 +724,8 @@ export async function exportBookmarksForSyncSeed(): Promise<BookmarkRecord[]> {
         viewCount: row[19] as number | undefined,
       },
       links: parseJsonArray(row[20]),
+      folderIds: parseJsonArray(row[21]),
+      folderNames: parseJsonArray(row[22]),
       tags: [],
       ingestedVia: 'graphql',
     }));
@@ -684,7 +764,9 @@ export async function getBookmarkById(id: string): Promise<BookmarkTimelineItem 
         b.reply_count,
         b.quote_count,
         b.bookmark_count,
-        b.view_count
+        b.view_count,
+        b.folder_ids,
+        b.folder_names
       FROM bookmarks b
       WHERE b.id = ?
       LIMIT 1`,
@@ -852,6 +934,32 @@ export async function getDomainCounts(existingDb?: Database): Promise<Record<str
       counts[row[0] as string] = row[1] as number;
     }
     return counts;
+  } finally {
+    if (!existingDb) db.close();
+  }
+}
+
+export async function getFolderCounts(existingDb?: Database): Promise<{ counts: Record<string, number>; untagged: number }> {
+  const db = existingDb ?? await openDb(twitterBookmarksIndexPath());
+  if (!existingDb) ensureMigrations(db);
+  try {
+    const counts: Record<string, number> = {};
+    const rows = db.exec(
+      `SELECT folder_names FROM bookmarks WHERE folder_names IS NOT NULL AND folder_names != ''`
+    );
+    let tagged = 0;
+    for (const row of rows[0]?.values ?? []) {
+      const names = parseJsonArray(row[0]);
+      if (names.length === 0) continue;
+      tagged += 1;
+      for (const name of names) {
+        counts[name] = (counts[name] ?? 0) + 1;
+      }
+    }
+    const totalRow = db.exec('SELECT COUNT(*) FROM bookmarks')[0]?.values[0]?.[0] as number | undefined;
+    const total = Number(totalRow ?? 0);
+    const untagged = Math.max(0, total - tagged);
+    return { counts, untagged };
   } finally {
     if (!existingDb) db.close();
   }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,8 +3,9 @@ import { Command } from 'commander';
 import { syncTwitterBookmarks } from './bookmarks.js';
 import { getBookmarkStatusView, formatBookmarkStatus } from './bookmarks-service.js';
 import { runTwitterOAuthFlow } from './xauth.js';
-import { syncBookmarksGraphQL, syncGaps } from './graphql-bookmarks.js';
-import type { SyncProgress, GapFillProgress } from './graphql-bookmarks.js';
+import { syncBookmarksGraphQL, syncGaps, syncBookmarkFolders } from './graphql-bookmarks.js';
+import type { SyncProgress, GapFillProgress, FolderSyncProgress } from './graphql-bookmarks.js';
+import type { BookmarkFolder } from './types.js';
 import { fetchBookmarkMediaBatch } from './bookmark-media.js';
 import {
   buildIndex,
@@ -15,6 +16,7 @@ import {
   getCategoryCounts,
   sampleByCategory,
   getDomainCounts,
+  getFolderCounts,
   listBookmarks,
   getBookmarkById,
 } from './bookmarks-db.js';
@@ -335,6 +337,46 @@ function requireIndex(): boolean {
   return true;
 }
 
+/**
+ * Strip control characters and ANSI escape sequences from user-controlled
+ * strings before printing them. Folder names come from X — in principle
+ * the user controls them, but if their account is compromised an attacker
+ * could set a folder name that wipes the terminal or injects escape codes.
+ * Replacement character keeps lengths roughly stable for padding.
+ */
+export function sanitizeForDisplay(value: string): string {
+  return value.replace(/[\x00-\x1f\x7f-\x9f]/g, '?');
+}
+
+export function formatFolderMirrorStats(stats: { added: number; tagged: number; untagged: number; unchanged: number }): string {
+  const parts: string[] = [];
+  if (stats.added > 0) parts.push(`${stats.added} new`);
+  if (stats.tagged > 0) parts.push(`${stats.tagged} tagged`);
+  if (stats.untagged > 0) parts.push(`${stats.untagged} removed`);
+  if (stats.unchanged > 0) parts.push(`${stats.unchanged} unchanged`);
+  return parts.length > 0 ? parts.join(', ') : 'no changes';
+}
+
+/**
+ * Resolve a folder query to a specific folder, case-insensitive.
+ * Priority: exact match > unambiguous prefix. Ambiguity/no-match throws.
+ * Trims whitespace on both sides so `"  Coding  "` matches `"Coding"`.
+ */
+export function resolveFolder(folders: BookmarkFolder[], query: string): BookmarkFolder {
+  const lower = query.trim().toLowerCase();
+  const exact = folders.find((f) => f.name.trim().toLowerCase() === lower);
+  if (exact) return exact;
+  const prefix = folders.filter((f) => f.name.trim().toLowerCase().startsWith(lower));
+  if (prefix.length === 1) return prefix[0];
+  if (prefix.length > 1) {
+    throw new Error(
+      `Multiple folders match "${query}": ${prefix.map((f) => f.name).join(', ')}. Be more specific.`
+    );
+  }
+  const available = folders.map((f) => f.name).join(', ') || '(none)';
+  throw new Error(`No folder matches "${query}". Available: ${available}`);
+}
+
 /** Wrap an async action with graceful error handling. */
 function safe(fn: (...args: any[]) => Promise<void>): (...args: any[]) => Promise<void> {
   return async (...args: any[]) => {
@@ -428,6 +470,8 @@ export function buildCli() {
     .option('--chrome-user-data-dir <path>', 'Chrome-family user-data directory')
     .option('--chrome-profile-directory <name>', 'Chrome-family profile name')
     .option('--firefox-profile-dir <path>', 'Firefox profile directory')
+    .option('--folders', 'Also sync bookmark folder tags (mirrors X\u2019s current folder state)', false)
+    .option('--folder <name>', 'Sync only this folder (case-insensitive, supports unambiguous prefix)')
     .action(async (options) => {
       const firstRun = isFirstRun();
       if (firstRun) showSyncWelcome();
@@ -437,6 +481,26 @@ export function buildCli() {
         const mutuallyExclusive = [options.rebuild, options.continue, options.gaps].filter(Boolean).length;
         if (mutuallyExclusive > 1) {
           console.error('  Error: --rebuild, --continue, and --gaps cannot be used together.');
+          process.exitCode = 1;
+          return;
+        }
+
+        // Folder flags: --folders (all) and --folder <name> (one) are mutually exclusive.
+        const folderAll = Boolean(options.folders);
+        const folderName = options.folder ? String(options.folder) : undefined;
+        if (folderAll && folderName) {
+          console.error('  Error: --folders and --folder cannot be used together. Pick one.');
+          process.exitCode = 1;
+          return;
+        }
+        const folderMode: 'off' | 'all' | 'one' = folderName ? 'one' : folderAll ? 'all' : 'off';
+        if (folderMode !== 'off' && options.api) {
+          console.error('  Error: Folder sync requires browser session (GraphQL). Remove --api.');
+          process.exitCode = 1;
+          return;
+        }
+        if (folderMode !== 'off' && options.gaps) {
+          console.error('  Error: --folders/--folder cannot be combined with --gaps. Run them separately.');
           process.exitCode = 1;
           return;
         }
@@ -482,7 +546,7 @@ export function buildCli() {
               for (const f of result.failures) {
                 byReason[f.reason] = (byReason[f.reason] ?? 0) + 1;
               }
-              fs.writeFileSync(logPath, JSON.stringify({ failures: result.failures, summary: byReason }, null, 2));
+              fs.writeFileSync(logPath, JSON.stringify({ failures: result.failures, summary: byReason }, null, 2), { mode: 0o600 });
 
               console.log(`  ${result.failed} unavailable:`);
               for (const [reason, count] of Object.entries(byReason)) {
@@ -610,6 +674,58 @@ export function buildCli() {
 
           warnIfEmpty(result.totalBookmarks);
 
+          // ── Folder sync (runs after main timeline when --folders is passed) ──
+          if (folderMode !== 'off') {
+            try {
+              process.stderr.write(`\n  Syncing bookmark folders...\n`);
+              const folderResult = await syncBookmarkFolders({
+                csrfToken,
+                cookieHeader,
+                browser: options.browser ? String(options.browser) : undefined,
+                chromeUserDataDir: options.chromeUserDataDir ? String(options.chromeUserDataDir) : undefined,
+                chromeProfileDirectory: options.chromeProfileDirectory ? String(options.chromeProfileDirectory) : undefined,
+                firefoxProfileDir: options.firefoxProfileDir ? String(options.firefoxProfileDir) : undefined,
+                delayMs: Number(options.delayMs) || 600,
+                onlyFolderName: folderMode === 'one' ? folderName : undefined,
+                onProgress: (status: FolderSyncProgress) => {
+                  if (status.phase === 'walking' && status.folder) {
+                    process.stderr.write(`  \u2192 ${sanitizeForDisplay(status.folder.name)}...\n`);
+                  }
+                },
+              });
+
+              // Summary output — one line per folder that we actually walked
+              const synced = folderResult.perFolder.filter((f) => f.stats);
+              if (synced.length > 0) {
+                console.log('');
+                for (const { folder, stats } of synced) {
+                  if (!stats) continue;
+                  const safeName = sanitizeForDisplay(folder.name);
+                  console.log(`  \u2713 ${safeName.padEnd(24)}  ${formatFolderMirrorStats(stats)}`);
+                }
+              }
+
+              if (folderResult.skippedFolders.length > 0) {
+                console.log('');
+                for (const { folder, reason } of folderResult.skippedFolders) {
+                  console.log(`  \u26a0 Skipped ${sanitizeForDisplay(folder.name)}: ${reason}`);
+                }
+                const retryCmd = folderMode === 'one' ? `ft sync --folder "${folderName}"` : `ft sync --folders`;
+                console.log(`  Re-run \`${retryCmd}\` to retry.`);
+              }
+
+              if (folderResult.orphanFoldersCleared.length > 0) {
+                const total = folderResult.orphanFoldersCleared.reduce((a, b) => a + b.recordsAffected, 0);
+                console.log(`\n  \u2713 Cleaned up ${total} tags from ${folderResult.orphanFoldersCleared.length} deleted folder(s).`);
+              }
+
+              console.log('');
+            } catch (err) {
+              console.error(`\n  Folder sync error: ${(err as Error).message}\n`);
+              // Continue — main sync already succeeded, folders are bonus
+            }
+          }
+
           const newCount = await rebuildIndex();
           if (options.classify && newCount > 0) {
             await classifyNew();
@@ -685,11 +801,28 @@ export function buildCli() {
     .option('--before <date>', 'Posted before (YYYY-MM-DD)')
     .option('--category <category>', 'Filter by category')
     .option('--domain <domain>', 'Filter by domain')
+    .option('--folder <name>', 'Filter by X bookmark folder name (exact or unambiguous prefix)')
     .option('--limit <n>', 'Max results', (v: string) => Number(v), 30)
     .option('--offset <n>', 'Offset into results', (v: string) => Number(v), 0)
     .option('--json', 'JSON output')
     .action(safe(async (options) => {
       if (!requireIndex()) return;
+
+      // Resolve --folder to an exact name via the same exact-then-prefix rules
+      // that `ft sync --folder` uses, so both flags behave identically.
+      let resolvedFolder: string | undefined;
+      if (options.folder) {
+        const { counts } = await getFolderCounts();
+        const names = Object.keys(counts);
+        if (names.length === 0) {
+          console.error(`  No folder data in local cache. Run: ft sync --folders`);
+          process.exitCode = 1;
+          return;
+        }
+        const stubFolders: BookmarkFolder[] = names.map((name) => ({ id: name, name }));
+        resolvedFolder = resolveFolder(stubFolders, String(options.folder)).name;
+      }
+
       const items = await listBookmarks({
         query: options.query ? String(options.query) : undefined,
         author: options.author ? String(options.author) : undefined,
@@ -697,6 +830,7 @@ export function buildCli() {
         before: options.before ? String(options.before) : undefined,
         category: options.category ? String(options.category) : undefined,
         domain: options.domain ? String(options.domain) : undefined,
+        folder: resolvedFolder,
         limit: Number(options.limit) || 30,
         offset: Number(options.offset) || 0,
       });
@@ -933,6 +1067,32 @@ export function buildCli() {
         const pct = ((count / total) * 100).toFixed(1);
         console.log(`  ${dom.padEnd(20)} ${String(count).padStart(5)}  (${pct}%)`);
       }
+    }));
+
+  // ── folders ─────────────────────────────────────────────────────────────
+
+  program
+    .command('folders')
+    .description('Show X bookmark folder distribution (local counts)')
+    .action(safe(async () => {
+      if (!requireIndex()) return;
+      const { counts, untagged } = await getFolderCounts();
+      if (Object.keys(counts).length === 0) {
+        console.log('  No folder data. Run: ft sync --folders');
+        return;
+      }
+      const tagged = Object.values(counts).reduce((a, b) => a + b, 0);
+      const total = tagged + untagged;
+      const sorted = Object.entries(counts).sort((a, b) => b[1] - a[1]);
+      for (const [name, count] of sorted) {
+        const pct = total > 0 ? ((count / total) * 100).toFixed(1) : '0.0';
+        console.log(`  ${sanitizeForDisplay(name).padEnd(24)} ${String(count).padStart(5)}  (${pct}%)`);
+      }
+      if (untagged > 0) {
+        const pct = total > 0 ? ((untagged / total) * 100).toFixed(1) : '0.0';
+        console.log(`  ${'(untagged)'.padEnd(24)} ${String(untagged).padStart(5)}  (${pct}%)`);
+      }
+      console.log(`\n  Total: ${total} bookmarks, ${Object.keys(counts).length} folder(s)`);
     }));
 
   // ── index ───────────────────────────────────────────────────────────────
@@ -1194,7 +1354,7 @@ export function buildCli() {
 
   const bookmarksAlias = program.command('bookmarks').description('(alias) Bookmark commands').helpOption(false);
   for (const cmd of ['sync', 'search', 'list', 'show', 'stats', 'viz', 'classify', 'classify-domains',
-    'categories', 'domains', 'model', 'index', 'auth', 'status', 'path', 'sample', 'fetch-media']) {
+    'categories', 'domains', 'folders', 'model', 'index', 'auth', 'status', 'path', 'sample', 'fetch-media']) {
     bookmarksAlias.command(cmd).description(`Alias for: ft ${cmd}`).allowUnknownOption(true)
       .action(async () => {
         const args = ['node', 'ft', cmd, ...process.argv.slice(4)];

--- a/src/db.ts
+++ b/src/db.ts
@@ -36,6 +36,27 @@ export function saveDb(db: Database, filePath: string): void {
   if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
   const data = db.export();
   const tmp = filePath + '.tmp';
-  fs.writeFileSync(tmp, Buffer.from(data), { mode: 0o600 });
+
+  // Crash-durable write: openSync → writeSync → fsyncSync → close → rename → fsync parent dir.
+  // On power loss, the target file either has the old content or the full new content —
+  // never a zero-byte or partially-written bookmarks.db.
+  const fd = fs.openSync(tmp, 'w', 0o600);
+  try {
+    fs.writeSync(fd, Buffer.from(data));
+    fs.fsyncSync(fd);
+  } finally {
+    fs.closeSync(fd);
+  }
   fs.renameSync(tmp, filePath);
+
+  try {
+    const dirFd = fs.openSync(dir, 'r');
+    try {
+      fs.fsyncSync(dirFd);
+    } finally {
+      fs.closeSync(dirFd);
+    }
+  } catch {
+    // Windows can't open a dir for fsync — the file fsync above is the critical guarantee.
+  }
 }

--- a/src/fs.ts
+++ b/src/fs.ts
@@ -1,4 +1,4 @@
-import { access, appendFile, mkdir, readFile, readdir, writeFile, rename } from 'node:fs/promises';
+import { access, appendFile, mkdir, readFile, readdir, writeFile, rename, open } from 'node:fs/promises';
 import path from 'node:path';
 
 interface WriteOptions {
@@ -26,10 +26,38 @@ export async function listFiles(dirPath: string): Promise<string[]> {
   }
 }
 
-export async function writeJson(filePath: string, value: unknown, options: WriteOptions = {}): Promise<void> {
+/**
+ * Crash-durable atomic write: write to tmp → fsync file → rename → fsync parent dir.
+ * On power loss, the target file either has the old content or the full new content —
+ * never zero-byte or partially-written.
+ */
+async function writeFileDurable(filePath: string, content: string, mode: number): Promise<void> {
   const tmp = filePath + '.tmp';
-  await writeFile(tmp, JSON.stringify(value, null, 2), { encoding: 'utf8', mode: options.mode ?? 0o600 });
+  const handle = await open(tmp, 'w', mode);
+  try {
+    await handle.writeFile(content, 'utf8');
+    await handle.sync();
+  } finally {
+    await handle.close();
+  }
   await rename(tmp, filePath);
+  // fsync the parent directory so the rename itself is durable.
+  const parent = path.dirname(filePath);
+  try {
+    const dirHandle = await open(parent, 'r');
+    try {
+      await dirHandle.sync();
+    } finally {
+      await dirHandle.close();
+    }
+  } catch {
+    // Some platforms (Windows) can't open a dir for fsync. The file fsync
+    // above is still the critical durability guarantee.
+  }
+}
+
+export async function writeJson(filePath: string, value: unknown, options: WriteOptions = {}): Promise<void> {
+  await writeFileDurable(filePath, JSON.stringify(value, null, 2), options.mode ?? 0o600);
 }
 
 export async function readJson<T>(filePath: string): Promise<T> {
@@ -38,10 +66,8 @@ export async function readJson<T>(filePath: string): Promise<T> {
 }
 
 export async function writeJsonLines(filePath: string, rows: unknown[], options: WriteOptions = {}): Promise<void> {
-  const tmp = filePath + '.tmp';
   const content = rows.map((row) => JSON.stringify(row)).join('\n') + (rows.length ? '\n' : '');
-  await writeFile(tmp, content, { encoding: 'utf8', mode: options.mode ?? 0o600 });
-  await rename(tmp, filePath);
+  await writeFileDurable(filePath, content, options.mode ?? 0o600);
 }
 
 export async function readJsonLines<T>(filePath: string): Promise<T[]> {

--- a/src/graphql-bookmarks.ts
+++ b/src/graphql-bookmarks.ts
@@ -4,7 +4,7 @@ import { loadChromeSessionConfig } from './config.js';
 import { extractChromeXCookies } from './chrome-cookies.js';
 import { extractFirefoxXCookies } from './firefox-cookies.js';
 import { parseTimestampMs } from './date-utils.js';
-import type { BookmarkBackfillState, BookmarkCacheMeta, BookmarkRecord, QuotedTweetSnapshot } from './types.js';
+import type { BookmarkBackfillState, BookmarkCacheMeta, BookmarkFolder, BookmarkRecord, QuotedTweetSnapshot } from './types.js';
 import { exportBookmarksForSyncSeed, updateQuotedTweets, updateBookmarkText, updateArticleContent } from './bookmarks-db.js';
 import type { ArticleUpdate } from './bookmarks-db.js';
 import { fetchArticle, resolveTcoLink } from './bookmark-enrich.js';
@@ -16,6 +16,16 @@ const X_PUBLIC_BEARER =
 
 const BOOKMARKS_QUERY_ID = 'Z9GWmP0kP2dajyckAaDUBw';
 const BOOKMARKS_OPERATION = 'Bookmarks';
+
+// ──────────────────────────────────────────────────────────────────────────
+// Folder endpoints — READ ONLY. We never POST/PUT/DELETE to X.
+// The folder feature makes exactly these two GraphQL GET calls, nothing else.
+// If you're adding a third, justify it in review and update this comment.
+// ──────────────────────────────────────────────────────────────────────────
+const BOOKMARK_FOLDERS_QUERY_ID = 'i78YDd0Tza-dV4SYs58kRg';
+const BOOKMARK_FOLDERS_OPERATION = 'BookmarkFoldersSlice';
+const BOOKMARK_FOLDER_TIMELINE_QUERY_ID = 'LML09uXDwh87F1zd7pbf2w';
+const BOOKMARK_FOLDER_TIMELINE_OPERATION = 'BookmarkFolderTimeline';
 
 const GRAPHQL_FEATURES = {
   graphql_timeline_v2_bookmark_timeline: true,
@@ -437,6 +447,7 @@ export function mergeRecords(
   for (const record of incoming) {
     const prev = byId.get(record.id);
     if (!prev) added += 1;
+    // Preserve folder arrays from prev since main sync never carries folder data.
     byId.set(record.id, mergeBookmarkRecord(prev, record));
   }
   const merged = Array.from(byId.values());
@@ -707,6 +718,535 @@ export async function syncBookmarksGraphQL(
     stopReason,
     cachePath,
     statePath,
+  };
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Bookmark folders (READ ONLY — GET requests only)
+//
+// Mirror semantics: for each folder we walk successfully, the local cache
+// is updated to reflect X's CURRENT state of that folder. No stale data
+// accumulates. NEVER writes to X — only reads.
+// ──────────────────────────────────────────────────────────────────────────
+
+function buildFoldersListUrl(): string {
+  const params = new URLSearchParams({
+    variables: JSON.stringify({}),
+    features: JSON.stringify(GRAPHQL_FEATURES),
+  });
+  return `https://x.com/i/api/graphql/${BOOKMARK_FOLDERS_QUERY_ID}/${BOOKMARK_FOLDERS_OPERATION}?${params}`;
+}
+
+function buildFolderTimelineUrl(folderId: string, cursor?: string, count = 20): string {
+  const variables: Record<string, unknown> = {
+    bookmark_collection_id: folderId,
+    count,
+  };
+  if (cursor) variables.cursor = cursor;
+  const params = new URLSearchParams({
+    variables: JSON.stringify(variables),
+    features: JSON.stringify(GRAPHQL_FEATURES),
+  });
+  return `https://x.com/i/api/graphql/${BOOKMARK_FOLDER_TIMELINE_QUERY_ID}/${BOOKMARK_FOLDER_TIMELINE_OPERATION}?${params}`;
+}
+
+export async function fetchBookmarkFolders(
+  csrfToken: string,
+  cookieHeader?: string,
+): Promise<BookmarkFolder[]> {
+  const response = await fetch(buildFoldersListUrl(), {
+    headers: buildHeaders(csrfToken, cookieHeader),
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(
+      `BookmarkFoldersSlice API returned ${response.status}.\n` +
+        `Response: ${text.slice(0, 300)}\n\n` +
+        (response.status === 401 || response.status === 403
+          ? 'Fix: Your X session may have expired. Open your browser, log into x.com, and retry.'
+          : 'This may be a temporary issue. Try again in a few minutes.')
+    );
+  }
+
+  const json = await response.json();
+  // Try the known response paths in order (X has used a few shapes).
+  const items: any[] =
+    json?.data?.viewer?.user_results?.result?.bookmark_collections_slice?.items ??
+    json?.data?.viewer?.bookmark_collections_slice?.items ??
+    json?.data?.bookmark_collections_slice?.items ??
+    [];
+
+  return items
+    .map((item: any) => ({
+      id: String(item.id ?? item.rest_id ?? ''),
+      name: String(item.name ?? ''),
+    }))
+    .filter((f) => f.id && f.name);
+}
+
+export function parseFolderTimelineResponse(json: any, now?: string): PageResult {
+  const ts = now ?? new Date().toISOString();
+  // Try both known response paths — X has used both at various times.
+  const instructions =
+    json?.data?.bookmark_collection_timeline?.timeline?.instructions ??
+    json?.data?.bookmark_folder_timeline?.timeline?.instructions ??
+    [];
+
+  const entries: any[] = [];
+  for (const inst of instructions) {
+    if (inst.type === 'TimelineAddEntries' && Array.isArray(inst.entries)) {
+      entries.push(...inst.entries);
+    }
+  }
+
+  const records: BookmarkRecord[] = [];
+  let nextCursor: string | undefined;
+
+  for (const entry of entries) {
+    if (typeof entry.entryId === 'string' && entry.entryId.startsWith('cursor-bottom')) {
+      nextCursor = entry.content?.value;
+      continue;
+    }
+    const tweetResult = entry?.content?.itemContent?.tweet_results?.result;
+    if (!tweetResult) continue;
+    const record = convertTweetToRecord(tweetResult, ts);
+    if (record) {
+      record.sortIndex = typeof entry.sortIndex === 'string' ? entry.sortIndex : null;
+      records.push(sanitizeBookmarkedAt(record));
+    }
+  }
+
+  return { records, nextCursor };
+}
+
+async function fetchFolderPage(
+  csrfToken: string,
+  folderId: string,
+  cursor?: string,
+  cookieHeader?: string,
+  pageSize = 20,
+): Promise<PageResult> {
+  let lastError: Error | undefined;
+
+  for (let attempt = 0; attempt < 4; attempt++) {
+    const response = await fetch(buildFolderTimelineUrl(folderId, cursor, pageSize), {
+      headers: buildHeaders(csrfToken, cookieHeader),
+    });
+
+    if (response.status === 429) {
+      const waitSec = Math.min(15 * Math.pow(2, attempt), 120);
+      lastError = new Error(`Rate limited (429) on attempt ${attempt + 1}`);
+      await new Promise((r) => setTimeout(r, waitSec * 1000));
+      continue;
+    }
+    if (response.status >= 500) {
+      lastError = new Error(`Server error (${response.status}) on attempt ${attempt + 1}`);
+      await new Promise((r) => setTimeout(r, 5000 * (attempt + 1)));
+      continue;
+    }
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(
+        `BookmarkFolderTimeline API returned ${response.status}.\n` +
+          `Response: ${text.slice(0, 300)}`
+      );
+    }
+
+    const json = await response.json();
+    return parseFolderTimelineResponse(json);
+  }
+
+  throw lastError ?? new Error('BookmarkFolderTimeline: all retry attempts failed.');
+}
+
+export interface FolderWalkResult {
+  /** True only if we paginated to the natural end of the folder. */
+  complete: boolean;
+  records: BookmarkRecord[];
+}
+
+/** Soft cap on walked records per folder. Folders larger than this abort
+ * with complete=false so the caller skips modifying DB state. 50k records
+ * is comfortably above any realistic X bookmark folder. */
+const MAX_RECORDS_PER_FOLDER = 50_000;
+
+export async function walkFolderTimeline(
+  csrfToken: string,
+  folderId: string,
+  options: { cookieHeader?: string; delayMs?: number; pageSize?: number; maxPages?: number } = {},
+): Promise<FolderWalkResult> {
+  const delayMs = options.delayMs ?? 600;
+  const pageSize = Math.max(1, Math.min(options.pageSize ?? 20, 100));
+  const maxPages = options.maxPages ?? 1000;
+
+  const seen = new Map<string, BookmarkRecord>();
+  let cursor: string | undefined;
+  let page = 0;
+
+  while (page < maxPages) {
+    const result = await fetchFolderPage(csrfToken, folderId, cursor, options.cookieHeader, pageSize);
+    page += 1;
+
+    for (const r of result.records) seen.set(r.id, r);
+
+    // Defensive: stop walking if we blow past the soft cap. Treat as incomplete
+    // so the caller skips modifying state — we'd rather leave tags stale than
+    // risk OOM or an endless pagination loop.
+    if (seen.size > MAX_RECORDS_PER_FOLDER) {
+      return { complete: false, records: Array.from(seen.values()) };
+    }
+
+    if (!result.nextCursor) {
+      return { complete: true, records: Array.from(seen.values()) };
+    }
+
+    cursor = result.nextCursor;
+    if (page < maxPages) await new Promise((r) => setTimeout(r, delayMs));
+  }
+
+  return { complete: false, records: Array.from(seen.values()) };
+}
+
+export interface FolderMirrorStats {
+  added: number;     // new records added during the mirror
+  tagged: number;    // existing records that gained this folder tag
+  untagged: number;  // existing records that lost this folder tag
+  unchanged: number; // records that already had the tag and still do
+}
+
+/**
+ * Return a new record with every occurrence of this folder id removed
+ * from both parallel arrays. Returns the same reference unchanged if the
+ * folder wasn't present. Uses filter rather than indexOf so duplicate ids
+ * (from a corrupted JSONL, say) are all cleared, not just the first.
+ */
+function withoutFolder(record: BookmarkRecord, folderId: string): BookmarkRecord {
+  const oldIds = record.folderIds ?? [];
+  if (!oldIds.includes(folderId)) return record;
+  const oldNames = record.folderNames ?? [];
+  const newIds: string[] = [];
+  const newNames: string[] = [];
+  for (let i = 0; i < oldIds.length; i++) {
+    if (oldIds[i] === folderId) continue;
+    newIds.push(oldIds[i]);
+    newNames.push(oldNames[i] ?? '');
+  }
+  return { ...record, folderIds: newIds, folderNames: newNames };
+}
+
+/**
+ * Return a new record with this folder present exactly once.
+ * Removes any prior instances of this folder id first (defensive against
+ * corrupt duplicates), then appends a single clean entry with the current
+ * display name. Handles folder rename on X as a side effect.
+ */
+function withFolder(record: BookmarkRecord, folder: BookmarkFolder): BookmarkRecord {
+  const oldIds = record.folderIds ?? [];
+  const oldNames = record.folderNames ?? [];
+
+  // Fast path: already tagged exactly once with the current name — no-op.
+  const firstIdx = oldIds.indexOf(folder.id);
+  const matchCount = oldIds.reduce((n, id) => (id === folder.id ? n + 1 : n), 0);
+  if (matchCount === 1 && oldNames[firstIdx] === folder.name) return record;
+
+  // Slow path: remove every existing occurrence (defensive against duplicates)
+  // and append exactly one clean entry.
+  const cleanedIds: string[] = [];
+  const cleanedNames: string[] = [];
+  for (let i = 0; i < oldIds.length; i++) {
+    if (oldIds[i] === folder.id) continue;
+    cleanedIds.push(oldIds[i]);
+    cleanedNames.push(oldNames[i] ?? '');
+  }
+  return {
+    ...record,
+    folderIds: [...cleanedIds, folder.id],
+    folderNames: [...cleanedNames, folder.name],
+  };
+}
+
+/**
+ * Apply a folder mirror to the record set.
+ *
+ * IMPORTANT: only call with records from a COMPLETE walk
+ * (FolderWalkResult.complete === true). On incomplete walks, do not call —
+ * old data stays intact rather than being corrupted.
+ *
+ * Semantics (mirror X's current state for this one folder):
+ *  - Records in walked set gain/keep the folder tag
+ *  - Records NOT in walked set have this folder tag removed (if present)
+ *  - Other folder tags on the same records are untouched
+ *  - Records for tweets we've never seen are added with this folder tag
+ */
+export function applyFolderMirror(
+  existing: BookmarkRecord[],
+  folder: BookmarkFolder,
+  walkedRecords: BookmarkRecord[],
+): { merged: BookmarkRecord[]; stats: FolderMirrorStats } {
+  const byId = new Map(existing.map((r) => [r.id, r]));
+  const walkedIds = new Set(walkedRecords.map((r) => r.id));
+
+  let added = 0;
+  let tagged = 0;
+  let untagged = 0;
+  let unchanged = 0;
+
+  // Pass 1: remove this folder's tag from records no longer in the folder.
+  for (const [id, record] of byId) {
+    if (walkedIds.has(id)) continue;
+    const stripped = withoutFolder(record, folder.id);
+    if (stripped !== record) {
+      byId.set(id, stripped);
+      untagged += 1;
+    }
+  }
+
+  // Pass 2: tag records currently in the folder.
+  for (const walked of walkedRecords) {
+    const prev = byId.get(walked.id);
+
+    if (!prev) {
+      byId.set(walked.id, withFolder(walked, folder));
+      added += 1;
+      continue;
+    }
+
+    const wasTagged = (prev.folderIds ?? []).includes(folder.id);
+    const base = mergeBookmarkRecord(prev, walked);
+    byId.set(walked.id, withFolder(base, folder));
+    if (wasTagged) unchanged += 1;
+    else tagged += 1;
+  }
+
+  const merged = Array.from(byId.values());
+  merged.sort((a, b) => compareBookmarkChronology(b, a));
+  return { merged, stats: { added, tagged, untagged, unchanged } };
+}
+
+/**
+ * Remove a folder tag from every record. Used for orphan cleanup when a
+ * folder has been deleted on X.
+ */
+export function clearFolderEverywhere(
+  existing: BookmarkRecord[],
+  folderId: string,
+): { merged: BookmarkRecord[]; cleared: number } {
+  let cleared = 0;
+  const merged = existing.map((record) => {
+    const next = withoutFolder(record, folderId);
+    if (next !== record) cleared += 1;
+    return next;
+  });
+  return { merged, cleared };
+}
+
+export interface FolderSyncOptions {
+  csrfToken?: string;
+  cookieHeader?: string;
+  browser?: string;
+  chromeUserDataDir?: string;
+  chromeProfileDirectory?: string;
+  firefoxProfileDir?: string;
+  /** If set, sync only the folder with this id (resolved ahead of time). */
+  onlyFolderId?: string;
+  /**
+   * If set, sync only the folder matching this display name.
+   * Resolved against the fetched folder list (case-insensitive
+   * exact-match, then unambiguous prefix).
+   */
+  onlyFolderName?: string;
+  delayMs?: number;
+  onProgress?: (status: FolderSyncProgress) => void;
+}
+
+export interface FolderSyncProgress {
+  phase: 'listing' | 'walking' | 'applying' | 'done';
+  folder?: BookmarkFolder;
+  folderIndex?: number;
+  totalFolders?: number;
+  stats?: FolderMirrorStats;
+}
+
+export interface FolderSyncResult {
+  folders: BookmarkFolder[];
+  perFolder: Array<{ folder: BookmarkFolder; stats: FolderMirrorStats | null; skipped?: string }>;
+  totalAdded: number;
+  totalTagged: number;
+  totalUntagged: number;
+  skippedFolders: Array<{ folder: BookmarkFolder; reason: string }>;
+  orphanFoldersCleared: Array<{ folderId: string; recordsAffected: number }>;
+}
+
+async function resolveFolderSyncCookies(
+  options: FolderSyncOptions,
+): Promise<{ csrfToken: string; cookieHeader?: string }> {
+  if (options.csrfToken) {
+    return { csrfToken: options.csrfToken, cookieHeader: options.cookieHeader };
+  }
+  const config = loadChromeSessionConfig({ browserId: options.browser });
+  if (config.browser.cookieBackend === 'firefox') {
+    const cookies = extractFirefoxXCookies(options.firefoxProfileDir);
+    return { csrfToken: cookies.csrfToken, cookieHeader: cookies.cookieHeader };
+  }
+  const chromeDir = options.chromeUserDataDir ?? config.chromeUserDataDir;
+  const chromeProfile = options.chromeProfileDirectory ?? config.chromeProfileDirectory;
+  const cookies = extractChromeXCookies(chromeDir, chromeProfile, config.browser);
+  return { csrfToken: cookies.csrfToken, cookieHeader: cookies.cookieHeader };
+}
+
+/**
+ * Persist the record set and update meta so `ft status` reflects the new total.
+ * Folder sync can change `totalBookmarks` if the walk discovers records the main
+ * timeline missed; without this, meta stays stale.
+ */
+async function persistFolderCheckpoint(
+  cachePath: string,
+  metaPath: string,
+  records: BookmarkRecord[],
+): Promise<void> {
+  await writeJsonLines(cachePath, records);
+  const syncedAt = new Date().toISOString();
+  const previousMeta: BookmarkCacheMeta | undefined = (await pathExists(metaPath))
+    ? await readJson<BookmarkCacheMeta>(metaPath)
+    : undefined;
+  await writeJson(metaPath, {
+    provider: 'twitter',
+    schemaVersion: 1,
+    lastFullSyncAt: previousMeta?.lastFullSyncAt,
+    lastIncrementalSyncAt: syncedAt,
+    totalBookmarks: records.length,
+  } satisfies BookmarkCacheMeta);
+}
+
+export async function syncBookmarkFolders(
+  options: FolderSyncOptions = {},
+): Promise<FolderSyncResult> {
+  const { csrfToken, cookieHeader } = await resolveFolderSyncCookies(options);
+  const delayMs = options.delayMs ?? 600;
+
+  ensureDataDir();
+  const cachePath = twitterBookmarksCachePath();
+  const metaPath = twitterBookmarksMetaPath();
+  const loaded = await loadExistingBookmarks();
+  let existing = loaded.records;
+
+  options.onProgress?.({ phase: 'listing' });
+  const allFolders = await fetchBookmarkFolders(csrfToken, cookieHeader);
+
+  let targetFolders: BookmarkFolder[];
+  if (options.onlyFolderId) {
+    const match = allFolders.find((f) => f.id === options.onlyFolderId);
+    if (!match) {
+      throw new Error(
+        `Folder "${options.onlyFolderName ?? options.onlyFolderId}" not found on X. ` +
+          `Available: ${allFolders.map((f) => f.name).join(', ') || '(none)'}`
+      );
+    }
+    targetFolders = [match];
+  } else if (options.onlyFolderName) {
+    // Resolve name against fetched list: exact match (case-insensitive) > unambiguous prefix.
+    // Trim whitespace so `ft sync --folder " Coding "` works the same as `--folder Coding`.
+    const lower = options.onlyFolderName.trim().toLowerCase();
+    const exact = allFolders.find((f) => f.name.trim().toLowerCase() === lower);
+    const prefix = allFolders.filter((f) => f.name.trim().toLowerCase().startsWith(lower));
+    const resolved = exact ?? (prefix.length === 1 ? prefix[0] : undefined);
+    if (!resolved) {
+      const hint = prefix.length > 1
+        ? `Multiple matches: ${prefix.map((f) => f.name).join(', ')}. Be more specific.`
+        : `Available: ${allFolders.map((f) => f.name).join(', ') || '(none)'}`;
+      throw new Error(`No folder matches "${options.onlyFolderName}". ${hint}`);
+    }
+    targetFolders = [resolved];
+  } else {
+    targetFolders = allFolders;
+  }
+
+  const perFolder: Array<{ folder: BookmarkFolder; stats: FolderMirrorStats | null; skipped?: string }> = [];
+  const skippedFolders: Array<{ folder: BookmarkFolder; reason: string }> = [];
+  let totalAdded = 0;
+  let totalTagged = 0;
+  let totalUntagged = 0;
+
+  for (let i = 0; i < targetFolders.length; i++) {
+    const folder = targetFolders[i];
+    options.onProgress?.({ phase: 'walking', folder, folderIndex: i, totalFolders: targetFolders.length });
+
+    let walkResult: FolderWalkResult;
+    try {
+      walkResult = await walkFolderTimeline(csrfToken, folder.id, { cookieHeader, delayMs });
+    } catch (err) {
+      const reason = (err as Error).message ?? 'unknown error';
+      skippedFolders.push({ folder, reason });
+      perFolder.push({ folder, stats: null, skipped: reason });
+      continue;
+    }
+
+    if (!walkResult.complete) {
+      const reason = 'incomplete walk (hit page limit)';
+      skippedFolders.push({ folder, reason });
+      perFolder.push({ folder, stats: null, skipped: reason });
+      continue;
+    }
+
+    // A complete walk with 0 records is a legitimate state: the user may have
+    // intentionally emptied the folder on X. Mirror semantics require us to
+    // clear any prior tags for this folder. We rely on walkFolderTimeline's
+    // `complete: true` signal — not a heuristic about prior state — to know
+    // the walk is authoritative.
+    const mirror = applyFolderMirror(existing, folder, walkResult.records);
+    existing = mirror.merged;
+    perFolder.push({ folder, stats: mirror.stats });
+    totalAdded += mirror.stats.added;
+    totalTagged += mirror.stats.tagged;
+    totalUntagged += mirror.stats.untagged;
+
+    options.onProgress?.({
+      phase: 'applying',
+      folder,
+      folderIndex: i,
+      totalFolders: targetFolders.length,
+      stats: mirror.stats,
+    });
+
+    // Checkpoint after each successful folder so a crash loses at most one folder's work.
+    // Also updates bookmarks-meta.json so `ft status` reflects the new total.
+    await persistFolderCheckpoint(cachePath, metaPath, existing);
+
+    if (i < targetFolders.length - 1) {
+      await new Promise((r) => setTimeout(r, Math.max(delayMs, 1000)));
+    }
+  }
+
+  // Orphan cleanup: only on full sync (not single-folder mode).
+  const orphanFoldersCleared: Array<{ folderId: string; recordsAffected: number }> = [];
+  if (!options.onlyFolderId) {
+    const currentFolderIds = new Set(allFolders.map((f) => f.id));
+    const knownTaggedIds = new Set<string>();
+    for (const r of existing) {
+      for (const fid of r.folderIds ?? []) knownTaggedIds.add(fid);
+    }
+    for (const fid of knownTaggedIds) {
+      if (currentFolderIds.has(fid)) continue;
+      const { merged, cleared } = clearFolderEverywhere(existing, fid);
+      existing = merged;
+      if (cleared > 0) orphanFoldersCleared.push({ folderId: fid, recordsAffected: cleared });
+    }
+    if (orphanFoldersCleared.length > 0) {
+      await persistFolderCheckpoint(cachePath, metaPath, existing);
+    }
+  }
+
+  options.onProgress?.({ phase: 'done' });
+
+  return {
+    folders: allFolders,
+    perFolder,
+    totalAdded,
+    totalTagged,
+    totalUntagged,
+    skippedFolders,
+    orphanFoldersCleared,
   };
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -80,6 +80,14 @@ export interface BookmarkRecord {
   links?: string[];
   tags?: string[];
   ingestedVia?: 'api' | 'browser' | 'graphql';
+  /** Parallel arrays of folder IDs and display names this bookmark is in on X. */
+  folderIds?: string[];
+  folderNames?: string[];
+}
+
+export interface BookmarkFolder {
+  id: string;
+  name: string;
 }
 
 export interface BookmarkCacheMeta {

--- a/tests/bookmark-enrich.test.ts
+++ b/tests/bookmark-enrich.test.ts
@@ -1,0 +1,120 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { isSafeUrl } from '../src/bookmark-enrich.js';
+
+// ── Safe URLs (should pass) ──────────────────────────────────────────────
+
+test('isSafeUrl: accepts public https URLs', () => {
+  assert.equal(isSafeUrl('https://example.com/article'), true);
+  assert.equal(isSafeUrl('https://news.ycombinator.com/item?id=42'), true);
+  assert.equal(isSafeUrl('https://sub.domain.co.uk/path'), true);
+});
+
+test('isSafeUrl: accepts public http URLs', () => {
+  assert.equal(isSafeUrl('http://example.com'), true);
+});
+
+test('isSafeUrl: accepts public IPv4 that happens to start with 1 or 17', () => {
+  // Numeric-prefix domains that are NOT private ranges
+  assert.equal(isSafeUrl('https://173.252.74.22'), true); // Facebook
+  assert.equal(isSafeUrl('https://8.8.8.8'), true);        // Google DNS
+});
+
+// ── IPv4 loopback and private ranges ─────────────────────────────────────
+
+test('isSafeUrl: rejects localhost by name', () => {
+  assert.equal(isSafeUrl('http://localhost/admin'), false);
+  assert.equal(isSafeUrl('https://LOCALHOST'), false);
+});
+
+test('isSafeUrl: rejects entire 127.0.0.0/8 loopback range', () => {
+  assert.equal(isSafeUrl('http://127.0.0.1/'), false);
+  assert.equal(isSafeUrl('http://127.1.2.3/'), false);
+  assert.equal(isSafeUrl('http://127.255.255.254/'), false);
+});
+
+test('isSafeUrl: rejects 0.0.0.0', () => {
+  assert.equal(isSafeUrl('http://0.0.0.0/'), false);
+});
+
+test('isSafeUrl: rejects RFC1918 private ranges', () => {
+  assert.equal(isSafeUrl('http://10.0.0.1/'), false);
+  assert.equal(isSafeUrl('http://10.255.255.255/'), false);
+  assert.equal(isSafeUrl('http://192.168.1.1/'), false);
+  assert.equal(isSafeUrl('http://172.16.0.1/'), false);
+  assert.equal(isSafeUrl('http://172.31.255.255/'), false);
+  // Just outside 172.16-31 should pass
+  assert.equal(isSafeUrl('http://172.15.0.1/'), true);
+  assert.equal(isSafeUrl('http://172.32.0.1/'), true);
+});
+
+test('isSafeUrl: rejects entire 169.254.0.0/16 link-local (not just metadata IP)', () => {
+  assert.equal(isSafeUrl('http://169.254.169.254/latest/meta-data/'), false); // AWS metadata
+  assert.equal(isSafeUrl('http://169.254.1.1/'), false);
+  assert.equal(isSafeUrl('http://169.254.255.255/'), false);
+});
+
+test('isSafeUrl: rejects CGNAT 100.64.0.0/10', () => {
+  assert.equal(isSafeUrl('http://100.64.0.1/'), false);
+  assert.equal(isSafeUrl('http://100.127.255.254/'), false);
+});
+
+// ── Numeric IP encoding bypasses ─────────────────────────────────────────
+
+test('isSafeUrl: rejects decimal integer form of 127.0.0.1', () => {
+  // 2130706433 === 0x7f000001 === 127.0.0.1
+  assert.equal(isSafeUrl('http://2130706433/'), false);
+});
+
+test('isSafeUrl: rejects hex form of 127.0.0.1', () => {
+  assert.equal(isSafeUrl('http://0x7f000001/'), false);
+});
+
+// ── IPv6 loopback and link-local ─────────────────────────────────────────
+
+test('isSafeUrl: rejects IPv6 loopback ::1', () => {
+  assert.equal(isSafeUrl('http://[::1]/'), false);
+});
+
+test('isSafeUrl: rejects IPv6 unspecified ::', () => {
+  assert.equal(isSafeUrl('http://[::]/'), false);
+});
+
+test('isSafeUrl: rejects IPv6 link-local fe80::/10', () => {
+  assert.equal(isSafeUrl('http://[fe80::1]/'), false);
+  assert.equal(isSafeUrl('http://[fe80::abcd:1234]/'), false);
+});
+
+test('isSafeUrl: rejects IPv6 unique-local fc00::/7', () => {
+  assert.equal(isSafeUrl('http://[fc00::1]/'), false);
+  assert.equal(isSafeUrl('http://[fd12:3456:789a::1]/'), false);
+});
+
+test('isSafeUrl: rejects IPv4-mapped IPv6 loopback', () => {
+  assert.equal(isSafeUrl('http://[::ffff:127.0.0.1]/'), false);
+});
+
+// ── Non-http schemes ─────────────────────────────────────────────────────
+
+test('isSafeUrl: rejects file://', () => {
+  assert.equal(isSafeUrl('file:///etc/passwd'), false);
+});
+
+test('isSafeUrl: rejects ftp://', () => {
+  assert.equal(isSafeUrl('ftp://example.com/'), false);
+});
+
+test('isSafeUrl: rejects javascript:', () => {
+  assert.equal(isSafeUrl('javascript:alert(1)'), false);
+});
+
+test('isSafeUrl: rejects data:', () => {
+  assert.equal(isSafeUrl('data:text/html,<script>alert(1)</script>'), false);
+});
+
+// ── Malformed ────────────────────────────────────────────────────────────
+
+test('isSafeUrl: rejects garbage', () => {
+  assert.equal(isSafeUrl('not a url'), false);
+  assert.equal(isSafeUrl(''), false);
+});

--- a/tests/bookmarks-db.test.ts
+++ b/tests/bookmarks-db.test.ts
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 import { mkdtemp, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
-import { buildIndex, searchBookmarks, getStats, formatSearchResults, getBookmarkById } from '../src/bookmarks-db.js';
+import { buildIndex, searchBookmarks, getStats, formatSearchResults, getBookmarkById, sanitizeFtsQuery } from '../src/bookmarks-db.js';
 import { openDb, saveDb } from '../src/db.js';
 import { twitterBookmarksIndexPath } from '../src/paths.js';
 
@@ -183,4 +183,49 @@ test('formatSearchResults: formats results with author, date, text, url', () => 
 
 test('formatSearchResults: returns message for empty results', () => {
   assert.equal(formatSearchResults([]), 'No results found.');
+});
+
+// ── sanitizeFtsQuery: FTS5 operator handling ──────────────────────────
+
+test('sanitizeFtsQuery: leaves plain queries alone', () => {
+  assert.equal(sanitizeFtsQuery('rust async'), 'rust async');
+  assert.equal(sanitizeFtsQuery('machine learning'), 'machine learning');
+});
+
+test('sanitizeFtsQuery: escapes parentheses (was parse error before)', () => {
+  const result = sanitizeFtsQuery('foo(bar)');
+  assert.ok(result.includes('"foo(bar)"'));
+});
+
+test('sanitizeFtsQuery: escapes leading dash', () => {
+  const result = sanitizeFtsQuery('-foo');
+  assert.ok(result.includes('"-foo"'));
+});
+
+test('sanitizeFtsQuery: escapes leading plus', () => {
+  const result = sanitizeFtsQuery('+foo');
+  assert.ok(result.includes('"+foo"'));
+});
+
+test('sanitizeFtsQuery: escapes column filters', () => {
+  const result = sanitizeFtsQuery('author:foo');
+  assert.ok(result.includes('"author:foo"'));
+});
+
+test('sanitizeFtsQuery: escapes Boolean keywords', () => {
+  const result = sanitizeFtsQuery('rust AND async');
+  assert.ok(result.includes('"rust"'));
+  assert.ok(result.includes('"AND"'));
+  assert.ok(result.includes('"async"'));
+});
+
+test('sanitizeFtsQuery: escapes prefix wildcards', () => {
+  const result = sanitizeFtsQuery('java*');
+  assert.ok(result.includes('"java*"'));
+});
+
+test('sanitizeFtsQuery: strips internal quotes to avoid double-escaping', () => {
+  const result = sanitizeFtsQuery('"foo"bar');
+  // Internal quotes stripped; term wrapped once
+  assert.ok(!result.includes('""'));
 });

--- a/tests/graphql-bookmarks.test.ts
+++ b/tests/graphql-bookmarks.test.ts
@@ -3,13 +3,17 @@ import assert from 'node:assert/strict';
 import {
   convertTweetToRecord,
   parseBookmarksResponse,
+  parseFolderTimelineResponse,
   sanitizeBookmarkedAt,
   scoreRecord,
   mergeBookmarkRecord,
   mergeRecords,
+  applyFolderMirror,
+  clearFolderEverywhere,
   formatSyncResult,
 } from '../src/graphql-bookmarks.js';
-import type { BookmarkRecord } from '../src/types.js';
+import { resolveFolder, formatFolderMirrorStats } from '../src/cli.js';
+import type { BookmarkFolder, BookmarkRecord } from '../src/types.js';
 
 const NOW = '2026-03-28T00:00:00.000Z';
 
@@ -583,4 +587,349 @@ test('formatSyncResult: formats all fields', () => {
   assert.ok(result.includes('300'));
   assert.ok(result.includes('end of bookmarks'));
   assert.ok(result.includes('/tmp/cache.jsonl'));
+});
+
+// ── Folder support ─────────────────────────────────────────────────────
+
+const CODING_FOLDER: BookmarkFolder = { id: 'f-coding', name: 'Coding' };
+const AI_FOLDER: BookmarkFolder = { id: 'f-ai', name: 'AI Research' };
+
+test('parseFolderTimelineResponse: parses bookmark_collection_timeline shape', () => {
+  const tr = makeTweetResult();
+  const resp = {
+    data: {
+      bookmark_collection_timeline: {
+        timeline: {
+          instructions: [
+            {
+              type: 'TimelineAddEntries',
+              entries: [
+                { entryId: 'tweet-0', content: { itemContent: { tweet_results: { result: tr } } } },
+                { entryId: 'cursor-bottom-xyz', content: { value: 'cursor-abc' } },
+              ],
+            },
+          ],
+        },
+      },
+    },
+  };
+  const result = parseFolderTimelineResponse(resp, NOW);
+  assert.equal(result.records.length, 1);
+  assert.equal(result.records[0].id, '1234567890');
+  assert.equal(result.nextCursor, 'cursor-abc');
+});
+
+test('parseFolderTimelineResponse: falls back to bookmark_folder_timeline shape', () => {
+  const tr = makeTweetResult();
+  const resp = {
+    data: {
+      bookmark_folder_timeline: {
+        timeline: {
+          instructions: [
+            { type: 'TimelineAddEntries', entries: [
+              { entryId: 'tweet-0', content: { itemContent: { tweet_results: { result: tr } } } },
+            ] },
+          ],
+        },
+      },
+    },
+  };
+  const result = parseFolderTimelineResponse(resp, NOW);
+  assert.equal(result.records.length, 1);
+});
+
+test('parseFolderTimelineResponse: returns empty for missing data', () => {
+  const result = parseFolderTimelineResponse({}, NOW);
+  assert.equal(result.records.length, 0);
+  assert.equal(result.nextCursor, undefined);
+});
+
+test('applyFolderMirror: tags records in the walked set', () => {
+  const existing = [
+    makeRecord({ id: '1', tweetId: '1' }),
+    makeRecord({ id: '2', tweetId: '2' }),
+  ];
+  const walked = [makeRecord({ id: '1', tweetId: '1' })];
+
+  const { merged, stats } = applyFolderMirror(existing, CODING_FOLDER, walked);
+
+  assert.equal(stats.tagged, 1);
+  assert.equal(stats.untagged, 0);
+  assert.equal(stats.added, 0);
+
+  const record1 = merged.find((r) => r.id === '1')!;
+  const record2 = merged.find((r) => r.id === '2')!;
+  assert.deepEqual(record1.folderIds, ['f-coding']);
+  assert.deepEqual(record1.folderNames, ['Coding']);
+  assert.deepEqual(record2.folderIds ?? [], []);
+});
+
+test('applyFolderMirror: removes folder tag from records NOT in walked set (mirror semantics)', () => {
+  const existing = [
+    makeRecord({ id: '1', tweetId: '1', folderIds: ['f-coding'], folderNames: ['Coding'] }),
+    makeRecord({ id: '2', tweetId: '2', folderIds: ['f-coding'], folderNames: ['Coding'] }),
+  ];
+  // User moved record 2 out of Coding on X; walk only returns record 1
+  const walked = [makeRecord({ id: '1', tweetId: '1' })];
+
+  const { merged, stats } = applyFolderMirror(existing, CODING_FOLDER, walked);
+
+  assert.equal(stats.untagged, 1);
+  const record2 = merged.find((r) => r.id === '2')!;
+  assert.deepEqual(record2.folderIds, []);
+  assert.deepEqual(record2.folderNames, []);
+});
+
+test('applyFolderMirror: preserves OTHER folder tags when removing one', () => {
+  const existing = [
+    makeRecord({
+      id: '1',
+      tweetId: '1',
+      folderIds: ['f-coding', 'f-ai'],
+      folderNames: ['Coding', 'AI Research'],
+    }),
+  ];
+  // Record 1 is no longer in Coding, but should still be in AI Research
+  const walked: BookmarkRecord[] = [];
+
+  const { merged, stats } = applyFolderMirror(existing, CODING_FOLDER, walked);
+
+  assert.equal(stats.untagged, 1);
+  const record = merged[0];
+  assert.deepEqual(record.folderIds, ['f-ai']);
+  assert.deepEqual(record.folderNames, ['AI Research']);
+});
+
+test('applyFolderMirror: adds new records discovered during folder walk', () => {
+  const existing: BookmarkRecord[] = [];
+  const walked = [makeRecord({ id: 'new-1', tweetId: 'new-1' })];
+
+  const { merged, stats } = applyFolderMirror(existing, CODING_FOLDER, walked);
+
+  assert.equal(stats.added, 1);
+  assert.equal(merged.length, 1);
+  assert.deepEqual(merged[0].folderIds, ['f-coding']);
+  assert.deepEqual(merged[0].folderNames, ['Coding']);
+});
+
+test('applyFolderMirror: re-tagging an already-tagged record is unchanged', () => {
+  const existing = [
+    makeRecord({ id: '1', tweetId: '1', folderIds: ['f-coding'], folderNames: ['Coding'] }),
+  ];
+  const walked = [makeRecord({ id: '1', tweetId: '1' })];
+
+  const { merged, stats } = applyFolderMirror(existing, CODING_FOLDER, walked);
+
+  assert.equal(stats.unchanged, 1);
+  assert.equal(stats.added, 0);
+  assert.equal(stats.tagged, 0);
+  assert.equal(stats.untagged, 0);
+  assert.deepEqual(merged[0].folderIds, ['f-coding']);
+  assert.deepEqual(merged[0].folderNames, ['Coding']);
+});
+
+test('applyFolderMirror: updates folder name on rename (same folder id)', () => {
+  const existing = [
+    makeRecord({ id: '1', tweetId: '1', folderIds: ['f-coding'], folderNames: ['Coding'] }),
+  ];
+  const walked = [makeRecord({ id: '1', tweetId: '1' })];
+  const renamedFolder: BookmarkFolder = { id: 'f-coding', name: 'Software' };
+
+  const { merged } = applyFolderMirror(existing, renamedFolder, walked);
+
+  assert.deepEqual(merged[0].folderIds, ['f-coding']);
+  assert.deepEqual(merged[0].folderNames, ['Software']);
+});
+
+test('applyFolderMirror: does not duplicate tags on repeated mirrors', () => {
+  const existing = [makeRecord({ id: '1', tweetId: '1' })];
+  const walked = [makeRecord({ id: '1', tweetId: '1' })];
+
+  const first = applyFolderMirror(existing, CODING_FOLDER, walked);
+  const second = applyFolderMirror(first.merged, CODING_FOLDER, walked);
+
+  assert.deepEqual(second.merged[0].folderIds, ['f-coding']);
+  assert.deepEqual(second.merged[0].folderNames, ['Coding']);
+  assert.equal(second.merged[0].folderIds!.length, 1);
+});
+
+test('clearFolderEverywhere: removes folder tag from all records', () => {
+  const existing = [
+    makeRecord({ id: '1', tweetId: '1', folderIds: ['f-coding', 'f-ai'], folderNames: ['Coding', 'AI Research'] }),
+    makeRecord({ id: '2', tweetId: '2', folderIds: ['f-coding'], folderNames: ['Coding'] }),
+    makeRecord({ id: '3', tweetId: '3' }),
+  ];
+
+  const { merged, cleared } = clearFolderEverywhere(existing, 'f-coding');
+
+  assert.equal(cleared, 2);
+  const r1 = merged.find((r) => r.id === '1')!;
+  const r2 = merged.find((r) => r.id === '2')!;
+  const r3 = merged.find((r) => r.id === '3')!;
+  assert.deepEqual(r1.folderIds, ['f-ai']);
+  assert.deepEqual(r1.folderNames, ['AI Research']);
+  assert.deepEqual(r2.folderIds, []);
+  assert.deepEqual(r2.folderNames, []);
+  assert.equal(r3.folderIds, undefined);
+});
+
+test('applyFolderMirror: parallel arrays stay aligned after multiple untags', () => {
+  // Record has three folders. Two of them get emptied (walked sets return nothing).
+  // After both clears, folderIds and folderNames should still match positionally.
+  const F1: BookmarkFolder = { id: 'f1', name: 'F-One' };
+  const F2: BookmarkFolder = { id: 'f2', name: 'F-Two' };
+  const F3: BookmarkFolder = { id: 'f3', name: 'F-Three' };
+  const existing = [
+    makeRecord({
+      id: '1',
+      tweetId: '1',
+      folderIds: ['f1', 'f2', 'f3'],
+      folderNames: ['F-One', 'F-Two', 'F-Three'],
+    }),
+  ];
+
+  // Simulate clearing f1 (no records in walk)
+  const step1 = applyFolderMirror(existing, F1, []);
+  assert.equal(step1.stats.untagged, 1);
+  assert.equal(step1.merged[0].folderIds!.length, 2);
+  assert.equal(step1.merged[0].folderNames!.length, 2);
+  assert.deepEqual(step1.merged[0].folderIds, ['f2', 'f3']);
+  assert.deepEqual(step1.merged[0].folderNames, ['F-Two', 'F-Three']);
+
+  // Now clear f3 — f2 must remain and arrays still aligned
+  const step2 = applyFolderMirror(step1.merged, F3, []);
+  assert.deepEqual(step2.merged[0].folderIds, ['f2']);
+  assert.deepEqual(step2.merged[0].folderNames, ['F-Two']);
+
+  // Unused reference to avoid unused-var lint noise
+  void F2;
+});
+
+test('applyFolderMirror: tag-then-rename-then-walk keeps arrays aligned', () => {
+  const original: BookmarkFolder = { id: 'f1', name: 'Coding' };
+  const renamed: BookmarkFolder = { id: 'f1', name: 'Software' };
+  const existing = [makeRecord({ id: '1', tweetId: '1' })];
+  const walked = [makeRecord({ id: '1', tweetId: '1' })];
+
+  const first = applyFolderMirror(existing, original, walked);
+  assert.deepEqual(first.merged[0].folderIds, ['f1']);
+  assert.deepEqual(first.merged[0].folderNames, ['Coding']);
+
+  const second = applyFolderMirror(first.merged, renamed, walked);
+  assert.deepEqual(second.merged[0].folderIds, ['f1']);
+  assert.deepEqual(second.merged[0].folderNames, ['Software']);
+});
+
+test('main-sync merge preserves folder tags on existing records', () => {
+  // Main sync never carries folder data — records from main sync have
+  // no folderIds/folderNames. Spread merge should preserve them.
+  const existing = [
+    makeRecord({ id: '1', tweetId: '1', folderIds: ['f-coding'], folderNames: ['Coding'] }),
+  ];
+  const incoming = [makeRecord({ id: '1', tweetId: '1', text: 'Updated' })];
+
+  const { merged } = mergeRecords(existing, incoming);
+
+  assert.equal(merged[0].text, 'Updated');
+  assert.deepEqual(merged[0].folderIds, ['f-coding']);
+  assert.deepEqual(merged[0].folderNames, ['Coding']);
+});
+
+// ── resolveFolder helper ───────────────────────────────────────────────
+
+const FOLDERS: BookmarkFolder[] = [
+  { id: 'f1', name: 'Coding' },
+  { id: 'f2', name: 'AI Research' },
+  { id: 'f3', name: 'AI Tools' },
+  { id: 'f4', name: 'Music' },
+];
+
+test('resolveFolder: exact case-insensitive match', () => {
+  assert.equal(resolveFolder(FOLDERS, 'coding').id, 'f1');
+  assert.equal(resolveFolder(FOLDERS, 'CODING').id, 'f1');
+  assert.equal(resolveFolder(FOLDERS, 'Music').id, 'f4');
+});
+
+test('resolveFolder: unambiguous prefix match', () => {
+  assert.equal(resolveFolder(FOLDERS, 'Cod').id, 'f1');
+  assert.equal(resolveFolder(FOLDERS, 'Mus').id, 'f4');
+});
+
+test('resolveFolder: ambiguous prefix throws with folder names listed', () => {
+  assert.throws(
+    () => resolveFolder(FOLDERS, 'AI'),
+    (err: Error) =>
+      err.message.includes('Multiple folders') &&
+      err.message.includes('AI Research') &&
+      err.message.includes('AI Tools'),
+  );
+});
+
+test('resolveFolder: no match throws with available folders listed', () => {
+  assert.throws(
+    () => resolveFolder(FOLDERS, 'Nonexistent'),
+    (err: Error) => err.message.includes('No folder matches') && err.message.includes('Coding'),
+  );
+});
+
+test('formatFolderMirrorStats: shows only non-zero fields', () => {
+  assert.equal(
+    formatFolderMirrorStats({ added: 3, tagged: 5, untagged: 0, unchanged: 10 }),
+    '3 new, 5 tagged, 10 unchanged',
+  );
+});
+
+test('formatFolderMirrorStats: returns "no changes" when all zero', () => {
+  assert.equal(
+    formatFolderMirrorStats({ added: 0, tagged: 0, untagged: 0, unchanged: 0 }),
+    'no changes',
+  );
+});
+
+// ── resolveFolder whitespace handling ──────────────────────────────────
+
+test('resolveFolder: trims whitespace on both sides', () => {
+  assert.equal(resolveFolder(FOLDERS, '  coding  ').id, 'f1');
+  assert.equal(resolveFolder(FOLDERS, '\tcoding\n').id, 'f1');
+});
+
+test('resolveFolder: trims whitespace on folder names too', () => {
+  const padded: BookmarkFolder[] = [{ id: 'fx', name: '  Spaced  ' }];
+  assert.equal(resolveFolder(padded, 'spaced').id, 'fx');
+});
+
+// ── withoutFolder dedup (M1) ───────────────────────────────────────────
+
+test('applyFolderMirror: removes all duplicate folder id occurrences on untag', () => {
+  // Simulate a corrupt record with duplicate folder ids. Should be fully cleared.
+  const existing = [
+    makeRecord({
+      id: '1',
+      tweetId: '1',
+      folderIds: ['f-coding', 'f-ai', 'f-coding'],
+      folderNames: ['Coding', 'AI', 'Coding'],
+    }),
+  ];
+  const walked: BookmarkRecord[] = []; // empty walk → should clear all Coding tags
+
+  const { merged } = applyFolderMirror(existing, CODING_FOLDER, walked);
+  assert.deepEqual(merged[0].folderIds, ['f-ai']);
+  assert.deepEqual(merged[0].folderNames, ['AI']);
+});
+
+test('applyFolderMirror: collapses duplicate folder id occurrences on re-tag', () => {
+  // Corrupt record with duplicates. Re-tagging should produce exactly one entry.
+  const existing = [
+    makeRecord({
+      id: '1',
+      tweetId: '1',
+      folderIds: ['f-coding', 'f-coding'],
+      folderNames: ['Coding', 'Coding'],
+    }),
+  ];
+  const walked = [makeRecord({ id: '1', tweetId: '1' })];
+
+  const { merged } = applyFolderMirror(existing, CODING_FOLDER, walked);
+  assert.deepEqual(merged[0].folderIds, ['f-coding']);
+  assert.deepEqual(merged[0].folderNames, ['Coding']);
 });


### PR DESCRIPTION
## Summary

Adds X bookmark folder sync with strict mirror semantics (reads only, never writes to X), plus a batch of security and correctness fixes discovered during review and end-to-end testing.

Closes #2.

## New feature: bookmark folders

- `ft sync --folders` — sync all X bookmark folders (runs main timeline + folder walks)
- `ft sync --folder <name>` — sync a single folder by name (exact or unambiguous prefix)
- `ft list --folder <name>` — filter existing bookmarks by folder
- `ft folders` — show local folder distribution with counts

**Mirror semantics:** each folder walk reflects X's current state. If a bookmark is moved out of a folder on X, the local tag is cleared on next sync. No stale data accumulates. Clear-then-set is per-folder and all-or-nothing — incomplete walks skip DB modification rather than corrupting.

**Safety:** strictly read-only. Two GraphQL GET endpoints only (`BookmarkFoldersSlice`, `BookmarkFolderTimeline`). Zero POST/PUT/DELETE/PATCH verbs in the folder code paths. Grep-guarded.

**Schema:** migration v5 → v6 adds `folder_ids` / `folder_names` JSON columns. Backward compatible — users who never opt in see zero difference.

## Credits

Huge thanks to the contributors whose earlier work on this feature directly shaped the final implementation:

- **@BenevolentFutures** (#34) — Introduced the multi-folder JSON-array data model with `json_each()` filtering, the `touched` counter pattern distinguishing "new" from "enriched existing" records, and case-insensitive prefix matching via `resolveFolder`. All three patterns are in the final code. The PR was an end-to-end implementation built after real-world use on 2,849 bookmarks.
- **@CoeusCC** (#1) — First-principles read-only mirror philosophy, shared-constants refactor (`X_PUBLIC_BEARER`, `GRAPHQL_FEATURES`, `buildHeaders`), and the defensive parse-path fallback that tries both `bookmark_folder_timeline` and `bookmark_collection_timeline` response shapes. The fallback is now in `parseFolderTimelineResponse` and has already paid off — X has served both shapes at different times.
- **@4xiomdev** (#27) — Proposed the opposite direction (local → X write-back) and built a full implementation. Different scope than this PR, but surfaced the demand for folder organization and helped clarify the "read-only mirror" product decision. The write-back direction remains an open conversation.

This PR doesn't merge the contributors' branches directly because all three predated significant main changes (schema v3 → v5, article enrichment, pagination fixes) and would have been rewrites to rebase. Instead, this implementation lifts the best ideas and the sniffed GraphQL query IDs from their work. The contributors deserve real credit for doing the hard exploratory work that made the final shape obvious.

## Security / correctness fixes

- **C1: SSRF via redirect chains in `bookmark-enrich.ts`** — replaced `redirect: 'follow'` with a manual walker that re-validates `isSafeUrl` on every hop. Expanded blocklist: full 127.0.0.0/8, full 169.254.0.0/16, CGNAT 100.64/10, 0.0.0.0, decimal/hex IPv4 encodings, IPv6 (`::`, `::1`, `fe80::/10`, `fc00::/7`, `::ffff:*`). `resolveTcoLink` uses the same walker.
- **H1: fsync durability** — `writeJsonLines`, `writeJson`, and `saveDb` now do `open → write → fsync → close → rename → fsync parent dir`. Crash-safe against power loss.
- **H2: folder sync updates meta** — `ft status` reflects totals after folder walks.
- **H3: `PreservedBookmarkFields` extended** — folder columns survive `buildIndex` rebuilds defensively.
- **H4: FTS5 query sanitizer** — handles parens, leading `-`/`+`, column filters, backslash. `ft search "foo(bar)"` no longer throws a parse error.
- **Latent migration bug (bonus find during testing)** — real user DBs had `meta.schema_version=4` but only 30 columns (v3 shape). `ensureMigrations` now drives column additions off `PRAGMA table_info` checks, self-healing any DB that got stuck in this state.
- **M1/M2/M3 mediums:** positional dedup in folder arrays, ANSI escape sanitization on folder-name display, `0o600` mode on `gaps-failures.json`, whitespace trim in `resolveFolder`, soft cap on `walkFolderTimeline` seen map.

## Testing

- 210 unit tests pass (up from 177, +33 new)
- End-to-end tested against live X account with populated folder: tag, filter, idempotency, main-sync regression all verified
- Isolated `FT_DATA_DIR` for local testing to protect real data

## Test plan

- [x] `npm run build` clean
- [x] `npm test` — 210 passing
- [x] Manual: `ft sync --folders` against live X account
- [x] Manual: `ft list --folder "name"` returns tagged bookmarks
- [x] Manual: `ft sync` (no flags) preserves folder tags via diff
- [x] Manual: idempotency — second `ft sync --folders` shows zero changes
- [x] Manual: schema migration self-heals DB with `meta=4` but v3 shape
- [x] Grep guard: zero POST/PUT/DELETE in folder code paths