### PR TITLE
bump v1.3.5 + README update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ft-bookmarks",
-  "version": "1.3.0",
+  "version": "1.3.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ft-bookmarks",
-      "version": "1.3.0",
+      "version": "1.3.5",
       "license": "MIT",
       "dependencies": {
         "commander": "^14.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fieldtheory",
-  "version": "1.3.2",
+  "version": "1.3.5",
   "description": "Field Theory CLI. Self-custody for your X/Twitter bookmarks. Local sync, full-text search, classification, and terminal dashboards.",
   "type": "module",
   "bin": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -176,6 +176,15 @@ function showCachedUpdateNotice(): void {
 // ── What's new ────────────────────────────────────────────────────────────
 
 const WHATS_NEW: Record<string, string[]> = {
+  '1.3.5': [
+    'ft sync --folders \u2014 sync X bookmark folder tags (read-only mirror)',
+    'ft sync --folder <name> \u2014 sync a single folder by name',
+    'ft list --folder <name> \u2014 filter bookmarks by folder',
+    'ft folders \u2014 show folder distribution',
+    'Security: SSRF fix in article enrichment (redirect chains now validated per hop)',
+    'Durability: writes are now crash-safe against power loss (fsync)',
+    'ft search handles punctuation like foo(bar) without FTS errors',
+  ],
   '1.2.2': [
     'ft sync --gaps \u2014 backfill missing quoted tweets and expand truncated articles',
     'Quoted tweet content and full article text now captured automatically during sync',


### PR DESCRIPTION
## Summary

Release prep for the bookmark folders + security hardening work that landed in #81.

- `package.json` / `package-lock.json` → `1.3.5`
- `WHATS_NEW` entry in `src/cli.ts` so the post-update notice lists the new features on first run
- README updated to document the new commands and flags, fix a stale `--full` reference (renamed to `--rebuild` back in v1.3.0), and correct the browser-support table to match the actual registry

## README changes

- **Sync table:** add `--rebuild` (was stale `--full`), `--continue`, `--folders`, `--folder <name>`
- **Search/browse table:** add `ft list --folder <name>` filter and `ft folders` command; note that list now filters by folder
- **Platform support table:** macOS now lists Chrome, Chromium, Brave, Helium, Comet, Firefox (was Chrome/Brave/Arc/Firefox — Arc was never in the registry). Linux and Windows rows updated to reflect the cross-platform browser registry that landed in #36.

## After merging

```bash
git checkout main && git pull
npm run build
npm test
npm login         # if not already
npm publish --dry-run   # inspect the tarball
npm publish
```

`prepublishOnly` runs `npm run build` automatically, so `npm publish` alone is sufficient.