### PR TITLE
docs: update README for v1.3.5 (folders, --rebuild, browser list)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,11 @@ On first run, `ft sync` extracts your X session from Chrome and downloads your b
 | Command | Description |
 |---------|-------------|
 | `ft sync` | Download and sync bookmarks (no API required) |
-| `ft sync --full` | Full history crawl (not just incremental) |
-| `ft sync --gaps` | Backfill missing quoted tweets and expand truncated articles |
+| `ft sync --rebuild` | Full re-crawl of all bookmarks |
+| `ft sync --continue` | Resume an interrupted sync from the saved cursor |
+| `ft sync --gaps` | Backfill quoted tweets, expand truncated articles, enrich linked article content |
+| `ft sync --folders` | Also sync X bookmark folder tags (read-only mirror of X state) |
+| `ft sync --folder <name>` | Sync a single folder by name (exact or unambiguous prefix) |
 | `ft sync --classify` | Sync then classify new bookmarks with LLM |
 | `ft sync --api` | Sync via OAuth API (cross-platform) |
 | `ft auth` | Set up OAuth for API-based sync (optional) |
@@ -47,13 +50,15 @@ On first run, `ft sync` extracts your X session from Chrome and downloads your b
 | Command | Description |
 |---------|-------------|
 | `ft search <query>` | Full-text search with BM25 ranking |
-| `ft list` | Filter by author, date, category, domain |
+| `ft list` | Filter by author, date, category, domain, or folder |
+| `ft list --folder <name>` | Show bookmarks in an X bookmark folder |
 | `ft show <id>` | Show one bookmark in detail |
 | `ft sample <category>` | Random sample from a category |
 | `ft stats` | Top authors, languages, date range |
 | `ft viz` | Terminal dashboard with sparklines, categories, and domains |
 | `ft categories` | Show category distribution |
 | `ft domains` | Subject domain distribution |
+| `ft folders` | Show X bookmark folder distribution (requires `ft sync --folders` first) |
 
 ### Classification
 
@@ -159,11 +164,11 @@ Use `ft classify` for LLM-powered classification that catches what regex misses.
 
 | Feature | macOS | Linux | Windows |
 |---------|-------|-------|---------|
-| Session sync (`ft sync`) | Chrome, Brave, Arc, Firefox | Firefox | Firefox |
+| Session sync (`ft sync`) | Chrome, Chromium, Brave, Helium, Comet, Firefox | Chrome, Chromium, Brave, Firefox | Chrome, Chromium, Brave, Firefox |
 | OAuth API sync (`ft sync --api`) | Yes | Yes | Yes |
 | Search, list, classify, viz, wiki | Yes | Yes | Yes |
 
-Session sync extracts cookies from your browser's local database. Use `ft sync --browser <name>` to pick a browser. On platforms where session sync isn't available, use `ft auth` + `ft sync --api`.
+Session sync extracts cookies from your browser's local database. Use `ft sync --browser <name>` to pick a browser. On Windows, Firefox requires Node.js 22.5+ or `sqlite3` on PATH. For unsupported browsers or platforms, use `ft auth` + `ft sync --api`.
 
 ## Security
 


### PR DESCRIPTION
## Summary

README was missing documentation for the v1.3.5 features and had a latent stale reference. Catching it up to match current main.

## Changes

- **Sync table:** add `--rebuild` (was stale `--full`, renamed in v1.3.0), `--continue`, `--folders`, `--folder <name>`
- **Search/browse table:** add `ft list --folder <name>` filter and new `ft folders` command
- **Platform support table:** macOS now lists Chrome, Chromium, Brave, Helium, Comet, Firefox. Was listing Arc (never in the registry) and was missing Chromium, Helium, Comet. Linux and Windows rows expanded to reflect the cross-platform browser registry from #36.

Small docs-only change, no code paths touched.