### PR TITLE
feat: --engine override for ft classify, classify-domains, sync --classify

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ On first run, `ft sync` extracts your X session from Chrome and downloads your b
 | `ft classify` | Classify by category and domain using LLM |
 | `ft classify --regex` | Classify by category using simple regex |
 | `ft classify-domains` | Classify by subject domain only (LLM) |
+| `ft classify --engine <name>` | Override the LLM engine for one run (also works on `ft sync --classify` and `ft classify-domains`) |
 | `ft model` | View or change the default LLM engine |
 
 ### Knowledge base

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { Command } from 'commander';
+import { Command, Option } from 'commander';
 import { syncTwitterBookmarks } from './bookmarks.js';
 import { getBookmarkStatusView, formatBookmarkStatus } from './bookmarks-service.js';
 import { runTwitterOAuthFlow } from './xauth.js';
@@ -386,6 +386,11 @@ export function resolveFolder(folders: BookmarkFolder[], query: string): Bookmar
   throw new Error(`No folder matches "${query}". Available: ${available}`);
 }
 
+/** Per-invocation LLM engine override (bypasses saved default, fails fast). */
+export function engineOption(): Option {
+  return new Option('--engine <name>', 'Override the LLM engine for this run (e.g. claude, codex)');
+}
+
 /** Wrap an async action with graceful error handling. */
 function safe(fn: (...args: any[]) => Promise<void>): (...args: any[]) => Promise<void> {
   return async (...args: any[]) => {
@@ -416,8 +421,8 @@ export function buildCli() {
     return idx.newRecords;
   }
 
-  async function classifyNew(): Promise<void> {
-    const engine = await resolveEngine();
+  async function classifyNew(override?: string): Promise<void> {
+    const engine = await resolveEngine({ override });
 
     const start = Date.now();
     process.stderr.write('  Classifying new bookmarks (categories)...\n');
@@ -481,12 +486,18 @@ export function buildCli() {
     .option('--firefox-profile-dir <path>', 'Firefox profile directory')
     .option('--folders', 'Also sync bookmark folder tags (mirrors X\u2019s current folder state)', false)
     .option('--folder <name>', 'Sync only this folder (case-insensitive, supports unambiguous prefix)')
+    .addOption(engineOption())
     .action(async (options) => {
       const firstRun = isFirstRun();
       if (firstRun) showSyncWelcome();
       ensureDataDir();
 
       try {
+        const engineOverride = options.engine ? String(options.engine) : undefined;
+        if (options.classify && engineOverride) {
+          await resolveEngine({ override: engineOverride });
+        }
+
         const mutuallyExclusive = [options.rebuild, options.continue, options.gaps].filter(Boolean).length;
         if (mutuallyExclusive > 1) {
           console.error('  Error: --rebuild, --continue, and --gaps cannot be used together.');
@@ -607,7 +618,7 @@ export function buildCli() {
           warnIfEmpty(result.totalBookmarks);
           const newCount = await rebuildIndex();
           if (options.classify && newCount > 0) {
-            await classifyNew();
+            await classifyNew(engineOverride);
           }
         } else {
           const startTime = Date.now();
@@ -737,7 +748,7 @@ export function buildCli() {
 
           const newCount = await rebuildIndex();
           if (options.classify && newCount > 0) {
-            await classifyNew();
+            await classifyNew(engineOverride);
           }
         }
 
@@ -917,6 +928,7 @@ export function buildCli() {
     .command('classify')
     .description('Classify bookmarks by category and domain using LLM (requires claude or codex CLI)')
     .option('--regex', 'Use simple regex classification instead of LLM')
+    .addOption(engineOption())
     .action(safe(async (options) => {
       if (!requireData()) return;
       if (options.regex) {
@@ -925,7 +937,7 @@ export function buildCli() {
         console.log(`Indexed ${result.recordCount} bookmarks \u2192 ${result.dbPath}`);
         console.log(formatClassificationSummary(result.summary));
       } else {
-        const engine = await resolveEngine();
+        const engine = await resolveEngine({ override: options.engine ? String(options.engine) : undefined });
 
         let catStart = Date.now();
         process.stderr.write('Classifying categories with LLM (batches of 50, ~2 min per batch)...\n');
@@ -961,9 +973,10 @@ export function buildCli() {
     .command('classify-domains')
     .description('Classify bookmarks by subject domain using LLM (ai, finance, etc.)')
     .option('--all', 'Re-classify all bookmarks, not just missing')
+    .addOption(engineOption())
     .action(safe(async (options) => {
       if (!requireData()) return;
-      const engine = await resolveEngine();
+      const engine = await resolveEngine({ override: options.engine ? String(options.engine) : undefined });
       const start = Date.now();
       process.stderr.write('Classifying bookmark domains with LLM (batches of 50, ~2 min per batch)...\n');
       const result = await classifyDomainsWithLlm({

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -93,6 +93,11 @@ function resolve(name: string): ResolvedEngine {
 /**
  * Resolve which engine to use for classification.
  *
+ * If `options.override` is set, require that specific engine: fails fast
+ * if it's unknown or not on PATH. Saved preferences and prompting are
+ * bypassed — this is meant for per-invocation overrides like `--engine`.
+ *
+ * Otherwise:
  * 1. If a saved default exists and is available, use it silently.
  * 2. If only one engine is available, use it silently.
  * 3. If multiple are available and stdin is a TTY, prompt y/n through
@@ -101,7 +106,26 @@ function resolve(name: string): ResolvedEngine {
  *
  * Throws if no engine is found.
  */
-export async function resolveEngine(): Promise<ResolvedEngine> {
+export async function resolveEngine(options: { override?: string } = {}): Promise<ResolvedEngine> {
+  if (options.override) {
+    const name = options.override;
+    if (!KNOWN_ENGINES[name]) {
+      const known = Object.keys(KNOWN_ENGINES).join(', ');
+      throw new Error(`Unknown engine "${name}". Known engines: ${known}.`);
+    }
+    if (!hasCommandOnPath(KNOWN_ENGINES[name].bin)) {
+      const available = detectAvailableEngines();
+      const hint = available.length > 0
+        ? ` Available on PATH: ${available.join(', ')}.`
+        : '';
+      throw new Error(
+        `Engine "${name}" is not on PATH.${hint}\n` +
+        `Install it and log in, or pick a different engine.`
+      );
+    }
+    return resolve(name);
+  }
+
   const available = detectAvailableEngines();
 
   if (available.length === 0) {

--- a/tests/engine.test.ts
+++ b/tests/engine.test.ts
@@ -165,6 +165,55 @@ test('resolveEngine: single available engine is used without prompting', async (
   }
 });
 
+// ── resolveEngine with override ────────────────────────────────────────
+
+test('resolveEngine: override rejects unknown engine', async () => {
+  const { resolveEngine } = await import('../src/engine.js');
+  await assert.rejects(
+    () => resolveEngine({ override: 'bogus' }),
+    /Unknown engine "bogus"/,
+  );
+});
+
+test('resolveEngine: override fails fast when binary not on PATH', async () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ft-engine-override-'));
+  const origPath = process.env.PATH;
+  process.env.PATH = tmpDir;
+
+  try {
+    const { resolveEngine } = await import('../src/engine.js');
+    await assert.rejects(
+      () => resolveEngine({ override: 'claude' }),
+      /Engine "claude" is not on PATH/,
+    );
+  } finally {
+    process.env.PATH = origPath;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test('resolveEngine: override returns named engine when binary is on PATH', async () => {
+  if (process.platform === 'win32') return;
+
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ft-engine-override-ok-'));
+  const fakeBin = path.join(tmpDir, 'claude');
+  const origPath = process.env.PATH;
+  process.env.PATH = tmpDir;
+
+  try {
+    fs.writeFileSync(fakeBin, '#!/bin/sh\nexit 0\n');
+    fs.chmodSync(fakeBin, 0o755);
+
+    const { resolveEngine } = await import('../src/engine.js');
+    const resolved = await resolveEngine({ override: 'claude' });
+    assert.equal(resolved.name, 'claude');
+    assert.equal(resolved.config.bin, 'claude');
+  } finally {
+    process.env.PATH = origPath;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
 // ── ft model CLI parsing ───────────────────────────────────────────────
 
 test('ft model: command is registered and shows help', async () => {


### PR DESCRIPTION
## Summary

Adds a per-invocation `--engine <name>` flag to `ft classify`, `ft classify-domains`, and `ft sync --classify`. Plumbs the choice into `resolveEngine({ override })` on `src/engine.ts`, which:

- Rejects unknown engine names with the known list.
- Fails fast if the named engine's binary isn't on PATH.
- Bypasses saved preferences and interactive prompting — overrides are strict.
- For `ft sync --classify --engine <name>`, runs the check before sync starts so a missing engine doesn't cost a full network sync.

Auto-resolution (no flag) is unchanged. `ft model` remains the way to set a persistent default; `--engine` is for cron/CI pinning and one-off overrides.

## Credit

Picks up the spirit of @ASRagab's #16, which was written on Apr 4 — three days before `src/engine.ts` landed in `3c28909`. That PR ended up stale against main (it added a parallel `resolveLlmEngine` in `bookmark-classify-llm.ts` that no longer exists on main), so this is a fresh take on top of the current engine abstraction. Thanks @ASRagab for the original design and tests — the override semantics here match your fail-fast intent.

## Diff

~95 lines vs #16's 236, because main already has cross-platform detection, preference persistence, and async invocation.

| File | Change |
|------|--------|
| `src/engine.ts` | `resolveEngine()` now accepts `{ override?: string }` for strict per-invocation resolution |
| `src/cli.ts` | New `engineOption()` factory; `--engine` added to three commands; threaded through `classifyNew()` with pre-sync fail-fast |
| `tests/engine.test.ts` | Three new tests: unknown engine, missing binary, available binary |
| `README.md` | One-line doc in the Classification table |

## Test plan

- [x] `npm run build`
- [x] `npx tsx --test tests/engine.test.ts` — 13/13 pass
- [x] `npx tsx src/cli.ts classify --engine bogus` → `Unknown engine "bogus". Known engines: claude, codex.`
- [x] `npx tsx src/cli.ts classify --help` → `--engine <name>` surfaces in help
- [ ] Reviewer: run `ft sync --classify --engine claude` on a machine without Claude Code and confirm it fails before sync

Co-Authored-By: Asim Ragab <ASRagab@users.noreply.github.com>
Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)