### PR TITLE
fix: engine override rejects prototype keys via Object.hasOwn

### DIFF
--- a/src/engine.ts
+++ b/src/engine.ts
@@ -109,7 +109,7 @@ function resolve(name: string): ResolvedEngine {
 export async function resolveEngine(options: { override?: string } = {}): Promise<ResolvedEngine> {
   if (options.override) {
     const name = options.override;
-    if (!KNOWN_ENGINES[name]) {
+    if (!Object.hasOwn(KNOWN_ENGINES, name)) {
       const known = Object.keys(KNOWN_ENGINES).join(', ');
       throw new Error(`Unknown engine "${name}". Known engines: ${known}.`);
     }

--- a/tests/engine.test.ts
+++ b/tests/engine.test.ts
@@ -175,6 +175,17 @@ test('resolveEngine: override rejects unknown engine', async () => {
   );
 });
 
+test('resolveEngine: override rejects prototype keys like __proto__', async () => {
+  const { resolveEngine } = await import('../src/engine.js');
+  for (const name of ['__proto__', 'constructor', 'toString']) {
+    await assert.rejects(
+      () => resolveEngine({ override: name }),
+      /Unknown engine/,
+      `override "${name}" should be rejected as unknown`,
+    );
+  }
+});
+
 test('resolveEngine: override fails fast when binary not on PATH', async () => {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ft-engine-override-'));
   const origPath = process.env.PATH;


### PR DESCRIPTION
## Summary

Defense-in-depth follow-up to #84. The `resolveEngine({ override })` allowlist check used `!KNOWN_ENGINES[name]`, which walked the prototype chain — so `--engine __proto__` (or `constructor`, `toString`, etc.) fell through to a confusing `Engine "__proto__" is not on PATH` error instead of the clean `Unknown engine` path.

**Not exploitable** — the static `KNOWN_ENGINES` record still prevented arbitrary binary invocation (`KNOWN_ENGINES['__proto__'].bin` is `undefined`, and `hasCommandOnPath(undefined)` returns `false`). But the allowlist should reject prototype keys up front so errors and future reasoning stay clean.

Swaps the bracket lookup for `Object.hasOwn(KNOWN_ENGINES, name)` and adds a regression test that covers `__proto__`, `constructor`, and `toString`.

Surfaced by a security review pass on #84 after it merged.

## Test plan

- [x] `npm run build`
- [x] `npx tsx --test tests/engine.test.ts` — 14/14 pass (new test: `resolveEngine: override rejects prototype keys like __proto__`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)