### PR TITLE
fix(wiki): stream per-page status to log.md during compile

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1231,23 +1231,27 @@ export function buildCli() {
     .action(safe(async (options) => {
       if (!requireIndex()) return;
       const start = Date.now();
-      let lastLine = '';
-      const spinner = createSpinner(() => lastLine);
-      const result = await compileMd({
-        full: options.full,
-        onProgress: (s) => {
-          lastLine = s;
-          spinner.update();
-        },
-      });
-      spinner.stop();
-      const elapsed = ((Date.now() - start) / 1000).toFixed(1);
-      const failed = result.pagesFailed > 0 ? ` failed=${result.pagesFailed}` : '';
-      console.log(`Done (${elapsed}s) — engine=${result.engine} created=${result.pagesCreated} updated=${result.pagesUpdated} skipped=${result.pagesSkipped}${failed} total=${result.totalPages}`);
-      if (result.pagesFailed > 0) {
-        console.log(`\n  ${result.pagesFailed} page(s) failed — re-run ft wiki to retry them.`);
+      const onSigint = () => {
+        console.log('\n  Interrupted. Your data is safe — progress has been saved.');
+        console.log('  Run the same command again to pick up where you left off.\n');
+        process.exit(0);
+      };
+      process.once('SIGINT', onSigint);
+      try {
+        const result = await compileMd({
+          full: options.full,
+          onProgress: (s) => process.stderr.write(s + '\n'),
+        });
+        const elapsed = ((Date.now() - start) / 1000).toFixed(1);
+        const failed = result.pagesFailed > 0 ? ` failed=${result.pagesFailed}` : '';
+        console.log(`Done (${elapsed}s) — engine=${result.engine} created=${result.pagesCreated} updated=${result.pagesUpdated} skipped=${result.pagesSkipped}${failed} total=${result.totalPages}`);
+        if (result.pagesFailed > 0) {
+          console.log(`\n  ${result.pagesFailed} page(s) failed — re-run ft wiki to retry them.`);
+        }
+        console.log(`\n  Open in your markdown viewer:\n  ${mdDir()}`);
+      } finally {
+        process.removeListener('SIGINT', onSigint);
       }
-      console.log(`\n  Open in your markdown viewer:\n  ${mdDir()}`);
     }));
 
   // ── ft ask ── Q&A against the knowledge base ──────────────────────────

--- a/src/md.ts
+++ b/src/md.ts
@@ -324,13 +324,25 @@ async function doCompile(
 
     pagesSkipped = skipCount;
 
+    // Per-event line: echo to the terminal and append to log.md so the
+    // user can `tail -f` the log from another shell while a compile runs.
+    const logLine = async (msg: string): Promise<void> => {
+      progress(msg);
+      try { await appendLine(mdLogPath(), logEntry('compile', msg)); } catch { /* best effort */ }
+    };
+
     if (toGenerate.length === 0) {
       progress('Nothing to compile — all pages up to date.');
     } else {
       const est = toGenerate.length > 3 ? ` (~${toGenerate.length}–${toGenerate.length * 2} min)` : '';
       progress(`\nGenerating ${toGenerate.length} pages with ${engine.name}${est}`);
       if (skipCount > 0) progress(`  ${skipCount} pages unchanged, skipping`);
+      progress(`  Follow live: tail -f ${mdLogPath()}`);
       progress('');
+      await appendLine(
+        mdLogPath(),
+        logEntry('compile', `start — ${toGenerate.length} pages, engine=${engine.name}`),
+      );
     }
 
     // ── Generate each page ───────────────────────────────────────────────
@@ -352,7 +364,7 @@ async function doCompile(
       }
 
       const opts = llmOpts(samples.length);
-      progress(`${tag} ${item.key} (${samples.length} sampled, ${Math.round(opts.timeout / 1000)}s timeout)...`);
+      await logLine(`${tag} ${item.key} (${samples.length} sampled, ${Math.round(opts.timeout / 1000)}s timeout)...`);
 
       let content: string;
       try {
@@ -360,7 +372,7 @@ async function doCompile(
       } catch (err) {
         const msg = (err as Error).message ?? String(err);
         const isTimeout = msg.includes('ETIMEDOUT') || msg.includes('timed out');
-        progress(`${tag} ${item.key} — ${isTimeout ? 'TIMEOUT' : 'ERROR'}: ${msg.slice(0, 120)}`);
+        await logLine(`${tag} ${item.key} — ${isTimeout ? 'TIMEOUT' : 'ERROR'}: ${msg.slice(0, 120)}`);
         pagesFailed++;
         continue;
       }
@@ -379,7 +391,7 @@ async function doCompile(
       // Save state after each page so Ctrl-C resumes where we left off
       await writeJson(mdStatePath(), state);
 
-      progress(`${tag} ${item.key} → ${outcome}`);
+      await logLine(`${tag} ${item.key} → ${outcome}`);
     }
   } finally {
     db.close();


### PR DESCRIPTION
## Summary

`ft wiki` used a single-line spinner that overwrote each progress message, so during a multi-minute LLM call the screen looked frozen — indistinguishable from an actual hang. And `log.md` was only written once at the very end, so a stuck compile left no paper trail to inspect.

A user reported running `ft wiki` against ~4000 bookmarks, watching it spin silently for 2+ hours, and finding nothing useful in `~/.ft-bookmarks/md/` to diagnose with.

## Changes

- **Replace the spinner with scrolling stderr output.** Each `progress()` event prints on its own line; the history stays visible instead of being overwritten.
- **Stream per-page events to `log.md` as they happen** via a local `logLine` helper (page start, success, failure). `tail -f ~/.ft-bookmarks/md/log.md` from another shell now works mid-compile — previously the file didn't exist until the compile finished.
- **Upfront hint**: after the scan, print `Follow live: tail -f <path-to-log.md>` so users know where to look before the slow work starts.
- **Preserve Ctrl-C UX** ("Your data is safe — progress has been saved") via an inline SIGINT handler, since removing the spinner also removed its SIGINT listener.

Surgical: +35 / -19 across `src/cli.ts` and `src/md.ts`. No new dependencies, no schema changes, no behavior changes to the compile itself — purely visibility.

## Test plan

- [ ] `npm run build` clean
- [ ] `npm run test` — 214/214 pass
- [ ] `node dist/cli.js wiki` with nothing to compile → scrolling lines, no spinner, exits on `Nothing to compile — all pages up to date.`
- [ ] Invalidate one page hash in `md-state.json`, run `node dist/cli.js wiki`, confirm the upfront `Follow live:` hint appears and the `[1/1] ...` lines scroll
- [ ] Terminal A runs `tail -f ~/.ft-bookmarks/md/log.md` while Terminal B runs `ft wiki` — new `## [YYYY-MM-DD] compile | ...` lines should appear in A *during* the compile, not only at the end
- [ ] Ctrl-C during a compile still shows `Interrupted. Your data is safe — progress has been saved.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)