### PR TITLE
fix(wiki): strip LLM code fences from generated pages

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -25,6 +25,7 @@ import { classifyWithLlm, classifyDomainsWithLlm } from './bookmark-classify-llm
 import { resolveEngine, detectAvailableEngines } from './engine.js';
 import { loadPreferences, savePreferences } from './preferences.js';
 import { compileMd } from './md.js';
+import { cleanWikiFences } from './md-fence.js';
 import { askMd } from './md-ask.js';
 import { lintMd, fixLintIssues } from './md-lint.js';
 import { exportBookmarks } from './md-export.js';
@@ -752,6 +753,16 @@ export function buildCli() {
           }
         }
 
+        // Opportunistic wiki hygiene: if previous `ft wiki` runs left fenced
+        // pages on disk, quietly fix them. Silent when clean; one-line summary
+        // when it repaired something.
+        try {
+          const fence = await cleanWikiFences();
+          if (fence.fixed > 0) {
+            console.log(`  ✓ Tidied ${fence.fixed} wiki page${fence.fixed === 1 ? '' : 's'} with leftover code fences`);
+          }
+        } catch { /* best effort — never fail sync on hygiene */ }
+
         if (firstRun) {
           console.log(`\n  Next steps:`);
           console.log(`        ft classify              Classify by category and domain (LLM)`);
@@ -1228,8 +1239,25 @@ export function buildCli() {
     .command('wiki')
     .description('Compile Karpathy-style markdown wiki from bookmarks')
     .option('--full', 'Recompile all pages (ignore incremental cache)')
+    .option('--clean', 'Strip leftover LLM code fences from existing wiki pages (no compile)')
     .action(safe(async (options) => {
       if (!requireIndex()) return;
+
+      if (options.clean) {
+        const fence = await cleanWikiFences({ backup: true });
+        if (fence.fixed === 0) {
+          console.log(`  ✓ All ${fence.scanned} wiki pages are clean. Nothing to fix.`);
+          return;
+        }
+        console.log(`  ✓ Tidied ${fence.fixed} of ${fence.scanned} wiki pages`);
+        if (fence.backupDir) {
+          console.log(`  Backups: ${fence.backupDir}`);
+        }
+        console.log('  Fixed files:');
+        for (const f of fence.fixedFiles) console.log(`    ${f}`);
+        return;
+      }
+
       const start = Date.now();
       const onSigint = () => {
         console.log('\n  Interrupted. Your data is safe — progress has been saved.');

--- a/src/md-fence.ts
+++ b/src/md-fence.ts
@@ -1,0 +1,109 @@
+/**
+ * Strip LLM-generated code fence wrappers from wiki page content.
+ *
+ * LLM engines (Claude CLI, etc.) sometimes wrap an entire markdown response in
+ * a ```markdown ... ``` code block. When that lands on disk it renders the
+ * whole file as a code block instead of markdown. This module both prevents
+ * the corruption at write-time (called from compileMd) and cleans up pages
+ * that were already written before the prevention landed.
+ */
+
+import path from 'node:path';
+import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import { existsSync, readdirSync } from 'node:fs';
+import { mdDir, mdCategoriesDir, mdDomainsDir, mdEntitiesDir } from './paths.js';
+
+/**
+ * Remove an outer markdown code fence wrapper from LLM output, if present.
+ *
+ * Handles three observed shapes in the wild:
+ *   A. Full wrap:       ```markdown\n---\n...\n```
+ *   B. Partial strip:   markdown\n---\n...\n```   (leading backticks eaten, language token left)
+ *   C. Trailing only:   ---\n...\n```              (somehow just the closing fence survived)
+ *
+ * Idempotent: running it twice on the same input yields the same output.
+ */
+export function stripLlmMarkdownFence(raw: string): string {
+  let s = raw.trim();
+
+  // Case A — full fenced block wrapping the entire response.
+  const full = s.match(/^```[a-zA-Z0-9-]*\s*\r?\n([\s\S]*?)\r?\n```\s*$/);
+  if (full) return full[1].trim();
+
+  // Case B — orphan leading language tag, but only if the next line is
+  // frontmatter. Category/domain/entity pages always start with `---`, so
+  // this guard prevents stripping legitimate content that happens to begin
+  // with the literal word "markdown".
+  s = s.replace(/^markdown\r?\n(?=---)/, '');
+
+  // Case C — orphan trailing fence on its own line.
+  s = s.replace(/\r?\n```\s*$/, '');
+
+  return s.trim();
+}
+
+export interface FenceScanResult {
+  scanned: number;
+  fixed: number;
+  fixedFiles: string[];
+  backupDir: string | null;
+}
+
+/**
+ * Walk the wiki subdirectories and rewrite any files whose content changes
+ * under `stripLlmMarkdownFence`. Skips silently if a compile is in progress
+ * (presence of `.lock`) so we don't race the writer.
+ */
+export async function cleanWikiFences(
+  options: { backup?: boolean } = {},
+): Promise<FenceScanResult> {
+  const result: FenceScanResult = { scanned: 0, fixed: 0, fixedFiles: [], backupDir: null };
+
+  if (!existsSync(mdDir())) return result;
+
+  // Avoid racing an in-progress `ft wiki` that holds the lock.
+  if (existsSync(path.join(mdDir(), '.lock'))) return result;
+
+  let backupDir: string | null = null;
+  if (options.backup) {
+    const ts = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
+    backupDir = path.join(mdDir(), `.fence-backup-${ts}`);
+  }
+
+  const subdirs = [mdCategoriesDir(), mdDomainsDir(), mdEntitiesDir()];
+  for (const dir of subdirs) {
+    if (!existsSync(dir)) continue;
+    let files: string[];
+    try { files = readdirSync(dir); } catch { continue; }
+
+    for (const f of files) {
+      if (!f.endsWith('.md')) continue;
+      const filePath = path.join(dir, f);
+      result.scanned++;
+
+      let original: string;
+      try { original = await readFile(filePath, 'utf8'); } catch { continue; }
+
+      const cleaned = stripLlmMarkdownFence(original);
+      if (cleaned === original) continue;
+
+      if (backupDir) {
+        const subdirName = path.basename(dir);
+        const backupPath = path.join(backupDir, subdirName, f);
+        try {
+          await mkdir(path.dirname(backupPath), { recursive: true });
+          await writeFile(backupPath, original, 'utf8');
+          if (!result.backupDir) result.backupDir = backupDir;
+        } catch { /* best effort */ }
+      }
+
+      try {
+        await writeFile(filePath, cleaned, 'utf8');
+        result.fixed++;
+        result.fixedFiles.push(path.relative(mdDir(), filePath));
+      } catch { /* skip */ }
+    }
+  }
+
+  return result;
+}

--- a/src/md-fence.ts
+++ b/src/md-fence.ts
@@ -18,8 +18,11 @@ import { mdDir, mdCategoriesDir, mdDomainsDir, mdEntitiesDir } from './paths.js'
  *
  * Handles three observed shapes in the wild:
  *   A. Full wrap:       ```markdown\n---\n...\n```
- *   B. Partial strip:   markdown\n---\n...\n```   (leading backticks eaten, language token left)
- *   C. Trailing only:   ---\n...\n```              (somehow just the closing fence survived)
+ *   B. Partial strip:   markdown\n---\n...\n```   (backticks eaten, language token + trailing fence remain)
+ *   C. Trailing only:   ---\n...\n```              (orphan trailing fence on its own)
+ *
+ * Cases B and C compose: for shape B we first drop the orphan leading token,
+ * then drop the trailing fence in a second pass.
  *
  * Idempotent: running it twice on the same input yields the same output.
  */

--- a/src/md.ts
+++ b/src/md.ts
@@ -28,6 +28,7 @@ import {
   buildCategoryPagePrompt, buildDomainPagePrompt, buildEntityPagePrompt,
   type MdBookmark,
 } from './md-prompts.js';
+import { stripLlmMarkdownFence } from './md-fence.js';
 
 const MIN_CATEGORY_COUNT = 5;
 const MIN_DOMAIN_COUNT   = 5;
@@ -368,7 +369,8 @@ async function doCompile(
 
       let content: string;
       try {
-        content = await invokeEngineAsync(engine, prompt, opts);
+        const raw = await invokeEngineAsync(engine, prompt, opts);
+        content = stripLlmMarkdownFence(raw);
       } catch (err) {
         const msg = (err as Error).message ?? String(err);
         const isTimeout = msg.includes('ETIMEDOUT') || msg.includes('timed out');

--- a/tests/md-fence.test.ts
+++ b/tests/md-fence.test.ts
@@ -1,0 +1,94 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { stripLlmMarkdownFence } from '../src/md-fence.js';
+
+// ── Case A: full fence wrap ────────────────────────────────────────────
+
+test('stripLlmMarkdownFence: strips full ```markdown ... ``` wrap', () => {
+  const input = '```markdown\n---\ntags: [ft/category]\n---\n\n# Title\n\nBody.\n```';
+  const out = stripLlmMarkdownFence(input);
+  assert.equal(out, '---\ntags: [ft/category]\n---\n\n# Title\n\nBody.');
+});
+
+test('stripLlmMarkdownFence: strips full fence with no language tag', () => {
+  const input = '```\n---\ntags: [ft/category]\n---\n\nBody.\n```';
+  assert.equal(stripLlmMarkdownFence(input), '---\ntags: [ft/category]\n---\n\nBody.');
+});
+
+test('stripLlmMarkdownFence: handles CRLF line endings in full wrap', () => {
+  const input = '```markdown\r\n---\r\ntags: [ft/category]\r\n---\r\n\r\nBody.\r\n```';
+  const out = stripLlmMarkdownFence(input);
+  assert.ok(out.startsWith('---'));
+  assert.ok(!out.includes('```'));
+});
+
+// ── Case B: partial strip (leading language token, trailing fence) ─────
+
+test('stripLlmMarkdownFence: strips orphan leading `markdown` token before frontmatter', () => {
+  const input = 'markdown\n---\ntags: [ft/category]\n---\n\nBody.\n```';
+  const out = stripLlmMarkdownFence(input);
+  assert.equal(out, '---\ntags: [ft/category]\n---\n\nBody.');
+});
+
+test('stripLlmMarkdownFence: does NOT strip leading "markdown" if next line is not frontmatter', () => {
+  // Protects legitimate content that happens to start with the word "markdown".
+  const input = 'markdown is a lightweight markup language.\n\nMore body.';
+  assert.equal(stripLlmMarkdownFence(input), 'markdown is a lightweight markup language.\n\nMore body.');
+});
+
+// ── Case C: orphan trailing fence only ─────────────────────────────────
+
+test('stripLlmMarkdownFence: strips orphan trailing ``` on its own line', () => {
+  const input = '---\ntags: [ft/category]\n---\n\nBody.\n```';
+  assert.equal(stripLlmMarkdownFence(input), '---\ntags: [ft/category]\n---\n\nBody.');
+});
+
+// ── Clean input passes through unchanged ───────────────────────────────
+
+test('stripLlmMarkdownFence: leaves clean frontmatter page unchanged', () => {
+  const input = '---\ntags: [ft/category]\n---\n\n# Title\n\nBody with `inline code`.';
+  assert.equal(stripLlmMarkdownFence(input), input);
+});
+
+test('stripLlmMarkdownFence: preserves inner fenced code blocks in clean input', () => {
+  const input = '---\ntags: [ft/category]\n---\n\n```bash\nnpm run build\n```\n\nMore body.';
+  assert.equal(stripLlmMarkdownFence(input), input);
+});
+
+test('stripLlmMarkdownFence: preserves inner fenced code block when wrapper is stripped', () => {
+  // Outer wrap around content that contains its own inner code block.
+  const input = '```markdown\n---\ntags: [x]\n---\n\n```bash\nls\n```\n\nend\n```';
+  const out = stripLlmMarkdownFence(input);
+  assert.ok(out.includes('```bash'));
+  assert.ok(out.includes('```\n\nend') || out.includes('```\nend'));
+  assert.ok(out.startsWith('---'));
+});
+
+// ── Idempotency ────────────────────────────────────────────────────────
+
+test('stripLlmMarkdownFence: idempotent — running twice yields same result', () => {
+  const input = '```markdown\n---\ntags: [ft/category]\n---\n\nBody.\n```';
+  const once = stripLlmMarkdownFence(input);
+  const twice = stripLlmMarkdownFence(once);
+  assert.equal(once, twice);
+});
+
+test('stripLlmMarkdownFence: idempotent on clean input', () => {
+  const input = '---\ntags: [ft/category]\n---\n\nBody.';
+  assert.equal(stripLlmMarkdownFence(input), stripLlmMarkdownFence(stripLlmMarkdownFence(input)));
+});
+
+// ── Edge cases ─────────────────────────────────────────────────────────
+
+test('stripLlmMarkdownFence: trims surrounding whitespace', () => {
+  assert.equal(stripLlmMarkdownFence('  \n---\nBody.\n  '), '---\nBody.');
+});
+
+test('stripLlmMarkdownFence: empty string returns empty string', () => {
+  assert.equal(stripLlmMarkdownFence(''), '');
+});
+
+test('stripLlmMarkdownFence: whitespace-only returns empty string', () => {
+  assert.equal(stripLlmMarkdownFence('   \n\n  '), '');
+});

--- a/tests/md-fence.test.ts
+++ b/tests/md-fence.test.ts
@@ -1,7 +1,38 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
 
-import { stripLlmMarkdownFence } from '../src/md-fence.js';
+import { stripLlmMarkdownFence, cleanWikiFences } from '../src/md-fence.js';
+
+// ── Test fixture helpers ───────────────────────────────────────────────
+
+const BROKEN_FULL = '```markdown\n---\ntags: [ft/category]\nsource_count: 5\n---\n\n# Title\n\nBody.\n```';
+const BROKEN_PARTIAL = 'markdown\n---\ntags: [ft/category]\nsource_count: 5\n---\n\nBody.\n```';
+const CLEAN = '---\ntags: [ft/category]\nsource_count: 5\n---\n\n# Title\n\nBody.';
+
+function withTempDataDir<T>(fn: (tmpDir: string) => Promise<T>): Promise<T> {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ft-fence-test-'));
+  const origEnv = process.env.FT_DATA_DIR;
+  process.env.FT_DATA_DIR = tmpDir;
+  return (async () => {
+    try {
+      return await fn(tmpDir);
+    } finally {
+      process.env.FT_DATA_DIR = origEnv;
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  })();
+}
+
+function seedWiki(tmpDir: string, files: Record<string, string>): void {
+  for (const [rel, content] of Object.entries(files)) {
+    const full = path.join(tmpDir, 'md', rel);
+    fs.mkdirSync(path.dirname(full), { recursive: true });
+    fs.writeFileSync(full, content, 'utf8');
+  }
+}
 
 // ── Case A: full fence wrap ────────────────────────────────────────────
 
@@ -91,4 +122,101 @@ test('stripLlmMarkdownFence: empty string returns empty string', () => {
 
 test('stripLlmMarkdownFence: whitespace-only returns empty string', () => {
   assert.equal(stripLlmMarkdownFence('   \n\n  '), '');
+});
+
+// ── cleanWikiFences: integration tests with tmp data dir ────────────────
+
+test('cleanWikiFences: fixes broken files across all three subdirs', async () => {
+  await withTempDataDir(async (tmpDir) => {
+    seedWiki(tmpDir, {
+      'categories/broken-full.md':    BROKEN_FULL,
+      'categories/broken-partial.md': BROKEN_PARTIAL,
+      'categories/clean.md':          CLEAN,
+      'domains/broken-full.md':       BROKEN_FULL,
+      'entities/clean.md':            CLEAN,
+    });
+
+    const result = await cleanWikiFences();
+
+    assert.equal(result.scanned, 5);
+    assert.equal(result.fixed, 3);
+    assert.equal(result.backupDir, null);
+    assert.ok(result.fixedFiles.some((f) => f.includes('broken-full')));
+    assert.ok(result.fixedFiles.some((f) => f.includes('broken-partial')));
+
+    // Fixed files no longer have fence artifacts.
+    const brokenFull = fs.readFileSync(path.join(tmpDir, 'md/categories/broken-full.md'), 'utf8');
+    assert.ok(brokenFull.startsWith('---'));
+    assert.ok(!brokenFull.includes('```'));
+
+    const brokenPartial = fs.readFileSync(path.join(tmpDir, 'md/categories/broken-partial.md'), 'utf8');
+    assert.ok(brokenPartial.startsWith('---'));
+    assert.ok(!brokenPartial.includes('```'));
+
+    // Clean file is untouched byte-for-byte.
+    assert.equal(fs.readFileSync(path.join(tmpDir, 'md/categories/clean.md'), 'utf8'), CLEAN);
+  });
+});
+
+test('cleanWikiFences: idempotent — second run is a no-op', async () => {
+  await withTempDataDir(async (tmpDir) => {
+    seedWiki(tmpDir, { 'categories/broken.md': BROKEN_FULL });
+
+    const first = await cleanWikiFences();
+    const second = await cleanWikiFences();
+
+    assert.equal(first.fixed, 1);
+    assert.equal(second.fixed, 0);
+    assert.equal(second.scanned, 1);
+  });
+});
+
+test('cleanWikiFences: backup option preserves originals in timestamped dir', async () => {
+  await withTempDataDir(async (tmpDir) => {
+    seedWiki(tmpDir, { 'categories/broken.md': BROKEN_FULL });
+
+    const result = await cleanWikiFences({ backup: true });
+
+    assert.equal(result.fixed, 1);
+    assert.ok(result.backupDir);
+    assert.ok(result.backupDir!.includes('.fence-backup-'));
+
+    const backedUp = fs.readFileSync(path.join(result.backupDir!, 'categories/broken.md'), 'utf8');
+    assert.equal(backedUp, BROKEN_FULL);
+  });
+});
+
+test('cleanWikiFences: backup dir is null when nothing needed fixing', async () => {
+  await withTempDataDir(async (tmpDir) => {
+    seedWiki(tmpDir, { 'categories/clean.md': CLEAN });
+
+    const result = await cleanWikiFences({ backup: true });
+
+    assert.equal(result.scanned, 1);
+    assert.equal(result.fixed, 0);
+    assert.equal(result.backupDir, null);
+  });
+});
+
+test('cleanWikiFences: skips entirely when .lock file is present', async () => {
+  await withTempDataDir(async (tmpDir) => {
+    seedWiki(tmpDir, { 'categories/broken.md': BROKEN_FULL });
+    fs.writeFileSync(path.join(tmpDir, 'md/.lock'), String(process.pid));
+
+    const result = await cleanWikiFences();
+
+    assert.equal(result.scanned, 0);
+    assert.equal(result.fixed, 0);
+    // Broken file remains untouched — compile owns the dir, not us.
+    assert.equal(fs.readFileSync(path.join(tmpDir, 'md/categories/broken.md'), 'utf8'), BROKEN_FULL);
+  });
+});
+
+test('cleanWikiFences: returns empty result when wiki dir does not exist', async () => {
+  await withTempDataDir(async () => {
+    const result = await cleanWikiFences();
+    assert.equal(result.scanned, 0);
+    assert.equal(result.fixed, 0);
+    assert.equal(result.fixedFiles.length, 0);
+  });
 });


### PR DESCRIPTION
## Summary

LLM engines (Claude CLI, etc.) sometimes wrap their markdown responses in a ```` ```markdown ... ``` ```` code block. When that lands on disk it renders the entire wiki page as a code block in editors like Obsidian instead of as markdown. On the author's wiki, **139 of 167 pages** were affected.

Two observed shapes in the wild, both fixed by this PR:

- **Full wrap**: `` ```markdown\n---\n...\n``` `` — LLM wrapped the whole response.
- **Partial strip**: `markdown\n---\n...\n``` ` — backticks eaten somewhere in the tool-call path, leaving just the language tag + trailing fence.

## Changes

### Prevention (new pages are born clean)
`src/md-fence.ts` exports `stripLlmMarkdownFence`, a pure idempotent helper that handles all observed shapes (including CRLF). `compileMd` now calls it on every LLM response before `writePage`.

### Opportunistic cleanup on `ft sync`
After a successful sync, quietly walks `md/{categories,domains,entities}/` and fixes any file whose content changes under the strip. Silent when clean, one-line summary when it repaired something. Skips entirely if `md/.lock` exists (avoids racing an in-progress compile). Never fails sync — the hygiene call is wrapped in a try/catch.

### Explicit cleanup: `ft wiki --clean`
Runs a standalone rewrite with a timestamped backup at `md/.fence-backup-<ts>/` before touching anything, so the operation is reversible. Lists every file it touched.

### Tests
14 unit tests covering the three cases, CRLF line endings, idempotency, and a guard that prevents stripping legitimate content that happens to begin with the literal word "markdown".

## End-to-end verification on the author's wiki

\`\`\`
$ node dist/cli.js wiki --clean
  ✓ Tidied 139 of 167 wiki pages
  Backups: /Users/afar/.ft-bookmarks/md/.fence-backup-2026-04-13T21-21-39
  Fixed files:
    categories/ai-news.md
    categories/art.md
    ... (137 more)

$ node dist/cli.js wiki --clean    # idempotency check
  ✓ All 167 wiki pages are clean. Nothing to fix.
\`\`\`

Spot-checked `art.md` and `ai-news.md` post-cleanup: both now start with `---` frontmatter (no ```` ```markdown ```` leader) and end with a content line (no orphan ```` ``` ```` footer). Backups preserved at the timestamped dir for rollback.

## Naming note

The user originally asked for \`ft md --clean\`, but \`ft md\` is actually the bookmark-export command. The corrupted files come from \`ft wiki\`, so the flag lives on \`ft wiki\`. Trivial to rename if you'd prefer otherwise.

## Test plan

- [ ] \`npm run build\` clean
- [ ] \`npm run test\` — all tests pass (228 total, +14 new)
- [ ] \`ft wiki --clean\` on a wiki with broken pages → reports what it fixed, creates backup, fixes files
- [ ] \`ft wiki --clean\` on already-clean wiki → no-op with success message
- [ ] \`ft sync\` on a wiki with broken pages → reports one-line summary of what it tidied
- [ ] \`ft wiki\` (normal compile) → new pages from the LLM are clean, no fence artifacts
- [ ] Spot-check a previously-broken file renders as markdown (not a code block) in Obsidian

🤖 Generated with [Claude Code](https://claude.com/claude-code)