### PR TITLE
fix: codex skip-git-repo-check & dedupe profile images

### DIFF
--- a/src/bookmark-media.ts
+++ b/src/bookmark-media.ts
@@ -66,9 +66,9 @@ export async function fetchBookmarkMediaBatch(
     .slice(0, limit);
   const previous = await loadManifest();
   const priorKeys = new Set((previous?.entries ?? []).map((e) => `${e.bookmarkId}::${e.sourceUrl}`));
-  const knownProfileImageUrls = new Set(
+  const downloadedProfileImageUrls = new Set(
     (previous?.entries ?? [])
-      .filter((entry) => entry.sourceUrl.includes('/profile_images/'))
+      .filter((entry) => entry.status === 'downloaded' && entry.sourceUrl.includes('/profile_images/'))
       .map((entry) => entry.sourceUrl),
   );
   const entries: MediaFetchEntry[] = previous?.entries ? [...previous.entries] : [];
@@ -99,9 +99,8 @@ export async function fetchBookmarkMediaBatch(
     // Also include author profile image (upgraded to 400x400)
     if (bookmark.authorProfileImageUrl) {
       const fullUrl = bookmark.authorProfileImageUrl.replace('_normal.', '_400x400.');
-      if (!knownProfileImageUrls.has(fullUrl)) {
+      if (!downloadedProfileImageUrls.has(fullUrl)) {
         mediaUrls.push({ sourceUrl: fullUrl, isProfileImage: true });
-        knownProfileImageUrls.add(fullUrl);
       }
     }
 
@@ -179,6 +178,7 @@ export async function fetchBookmarkMediaBatch(
           : `${bookmark.tweetId}-${digest}${ext}`;
         const localPath = path.join(mediaDir, filename);
         await writeFile(localPath, buffer);
+        if (isProfileImage) downloadedProfileImageUrls.add(sourceUrl);
 
         entries.push({
           bookmarkId: bookmark.id,

--- a/src/bookmark-media.ts
+++ b/src/bookmark-media.ts
@@ -66,6 +66,11 @@ export async function fetchBookmarkMediaBatch(
     .slice(0, limit);
   const previous = await loadManifest();
   const priorKeys = new Set((previous?.entries ?? []).map((e) => `${e.bookmarkId}::${e.sourceUrl}`));
+  const knownProfileImageUrls = new Set(
+    (previous?.entries ?? [])
+      .filter((entry) => entry.sourceUrl.includes('/profile_images/'))
+      .map((entry) => entry.sourceUrl),
+  );
   const entries: MediaFetchEntry[] = previous?.entries ? [...previous.entries] : [];
 
   let downloaded = 0;
@@ -75,31 +80,34 @@ export async function fetchBookmarkMediaBatch(
 
   for (const bookmark of candidates) {
     // Resolve media URLs: prefer mediaObjects (richer, includes video variants), fall back to media[]
-    const mediaUrls: string[] = [];
+    const mediaUrls: { sourceUrl: string; isProfileImage: boolean }[] = [];
     if (bookmark.mediaObjects?.length) {
       for (const mo of bookmark.mediaObjects) {
         if (mo.type === 'video' || mo.type === 'animated_gif') {
           const mp4s = (mo.videoVariants ?? mo.variants ?? [])
             .filter((v) => v.url && (!v.contentType || v.contentType === 'video/mp4'))
             .sort((a, b) => (b.bitrate ?? 0) - (a.bitrate ?? 0));
-          if (mp4s.length > 0 && mp4s[0].url) { mediaUrls.push(mp4s[0].url); continue; }
+          if (mp4s.length > 0 && mp4s[0].url) { mediaUrls.push({ sourceUrl: mp4s[0].url, isProfileImage: false }); continue; }
         }
         const mediaUrl = mo.url ?? mo.mediaUrl;
-        if (mediaUrl) mediaUrls.push(mediaUrl);
+        if (mediaUrl) mediaUrls.push({ sourceUrl: mediaUrl, isProfileImage: false });
       }
     } else {
-      mediaUrls.push(...(bookmark.media ?? []));
+      mediaUrls.push(...(bookmark.media ?? []).map((sourceUrl) => ({ sourceUrl, isProfileImage: false })));
     }
 
     // Also include author profile image (upgraded to 400x400)
     if (bookmark.authorProfileImageUrl) {
       const fullUrl = bookmark.authorProfileImageUrl.replace('_normal.', '_400x400.');
-      if (!priorKeys.has(`${bookmark.id}::${fullUrl}`)) mediaUrls.push(fullUrl);
+      if (!knownProfileImageUrls.has(fullUrl)) {
+        mediaUrls.push({ sourceUrl: fullUrl, isProfileImage: true });
+        knownProfileImageUrls.add(fullUrl);
+      }
     }
 
-    for (const sourceUrl of mediaUrls) {
+    for (const { sourceUrl, isProfileImage } of mediaUrls) {
       const key = `${bookmark.id}::${sourceUrl}`;
-      if (priorKeys.has(key)) continue;
+      if (!isProfileImage && priorKeys.has(key)) continue;
       processed += 1;
 
       const fetchedAt = new Date().toISOString();
@@ -166,7 +174,9 @@ export async function fetchBookmarkMediaBatch(
 
         const digest = createHash('sha256').update(buffer).digest('hex').slice(0, 16);
         const ext = sanitizeExtFromContentType(response.headers.get('content-type') ?? contentType ?? undefined, sourceUrl);
-        const filename = `${bookmark.tweetId}-${digest}${ext}`;
+        const filename = isProfileImage
+          ? `${digest}${ext}`
+          : `${bookmark.tweetId}-${digest}${ext}`;
         const localPath = path.join(mediaDir, filename);
         await writeFile(localPath, buffer);
 

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -20,7 +20,7 @@ export interface EngineConfig {
 
 const KNOWN_ENGINES: Record<string, EngineConfig> = {
   claude: { bin: 'claude', args: (p) => ['-p', '--output-format', 'text', p] },
-  codex:  { bin: 'codex',  args: (p) => ['exec', p] },
+  codex:  { bin: 'codex',  args: (p) => ['exec', '--skip-git-repo-check', p] },
 };
 
 /** Order used when auto-detecting. */

--- a/tests/bookmark-media.test.ts
+++ b/tests/bookmark-media.test.ts
@@ -146,3 +146,150 @@ test('fetchBookmarkMediaBatch downloads shared profile images only once across b
     globalThis.fetch = originalFetch;
   }
 });
+
+test('fetchBookmarkMediaBatch retries shared profile image after same-run failure', async () => {
+  const profileUrl = 'https://pbs.twimg.com/profile_images/123/avatar_normal.jpg';
+  const fullProfileUrl = profileUrl.replace('_normal.', '_400x400.');
+  const records = [
+    {
+      id: '1',
+      tweetId: '1',
+      url: 'https://x.com/alice/status/1',
+      text: 'first bookmark',
+      authorHandle: 'alice',
+      authorName: 'Alice',
+      authorProfileImageUrl: profileUrl,
+      syncedAt: '2026-04-09T00:00:00.000Z',
+      mediaObjects: [],
+      links: [],
+      tags: [],
+      ingestedVia: 'graphql',
+    },
+    {
+      id: '2',
+      tweetId: '2',
+      url: 'https://x.com/alice/status/2',
+      text: 'second bookmark',
+      authorHandle: 'alice',
+      authorName: 'Alice',
+      authorProfileImageUrl: profileUrl,
+      syncedAt: '2026-04-09T00:00:00.000Z',
+      mediaObjects: [],
+      links: [],
+      tags: [],
+      ingestedVia: 'graphql',
+    },
+  ];
+
+  let profileGetRequests = 0;
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+    const url = String(input instanceof Request ? input.url : input);
+    const method = init?.method ?? 'GET';
+    if (method === 'HEAD') {
+      return new Response(null, {
+        status: 200,
+        headers: { 'content-length': '4', 'content-type': 'image/jpeg' },
+      });
+    }
+    if (url === fullProfileUrl) {
+      profileGetRequests += 1;
+      if (profileGetRequests === 1) {
+        return new Response(null, { status: 500 });
+      }
+    }
+    return new Response(Uint8Array.from([1, 2, 3, 4]), {
+      status: 200,
+      headers: { 'content-type': 'image/jpeg' },
+    });
+  };
+
+  try {
+    await withMediaDataDir(records, async () => {
+      const manifest = await fetchBookmarkMediaBatch({ limit: 10, maxBytes: 1024 });
+      const downloadedProfileEntries = manifest.entries.filter(
+        (entry) => entry.status === 'downloaded' && entry.sourceUrl === fullProfileUrl,
+      );
+      const failedProfileEntries = manifest.entries.filter(
+        (entry) => entry.status === 'failed' && entry.sourceUrl === fullProfileUrl,
+      );
+
+      assert.equal(profileGetRequests, 2);
+      assert.equal(downloadedProfileEntries.length, 1);
+      assert.equal(failedProfileEntries.length, 1);
+    });
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('fetchBookmarkMediaBatch retries failed profile image from previous manifest run', async () => {
+  const profileUrl = 'https://pbs.twimg.com/profile_images/123/avatar_normal.jpg';
+  const fullProfileUrl = profileUrl.replace('_normal.', '_400x400.');
+  const records = [{
+    id: '1',
+    tweetId: '1',
+    url: 'https://x.com/alice/status/1',
+    text: 'first bookmark',
+    authorHandle: 'alice',
+    authorName: 'Alice',
+    authorProfileImageUrl: profileUrl,
+    syncedAt: '2026-04-09T00:00:00.000Z',
+    mediaObjects: [],
+    links: [],
+    tags: [],
+    ingestedVia: 'graphql',
+  }];
+
+  let profileGetRequests = 0;
+  const originalFetch = globalThis.fetch;
+
+  try {
+    await withMediaDataDir(records, async () => {
+      globalThis.fetch = async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+        const url = String(input instanceof Request ? input.url : input);
+        const method = init?.method ?? 'GET';
+        if (method === 'HEAD') {
+          return new Response(null, {
+            status: 200,
+            headers: { 'content-length': '4', 'content-type': 'image/jpeg' },
+          });
+        }
+        if (url === fullProfileUrl) profileGetRequests += 1;
+        return new Response(null, { status: 500 });
+      };
+
+      const firstManifest = await fetchBookmarkMediaBatch({ limit: 10, maxBytes: 1024 });
+      assert.equal(
+        firstManifest.entries.filter((entry) => entry.status === 'failed' && entry.sourceUrl === fullProfileUrl).length,
+        1,
+      );
+
+      globalThis.fetch = async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+        const url = String(input instanceof Request ? input.url : input);
+        const method = init?.method ?? 'GET';
+        if (method === 'HEAD') {
+          return new Response(null, {
+            status: 200,
+            headers: { 'content-length': '4', 'content-type': 'image/jpeg' },
+          });
+        }
+        if (url === fullProfileUrl) profileGetRequests += 1;
+        return new Response(Uint8Array.from([1, 2, 3, 4]), {
+          status: 200,
+          headers: { 'content-type': 'image/jpeg' },
+        });
+      };
+
+      const secondManifest = await fetchBookmarkMediaBatch({ limit: 10, maxBytes: 1024 });
+      const downloadedProfileEntries = secondManifest.entries.filter(
+        (entry) => entry.status === 'downloaded' && entry.sourceUrl === fullProfileUrl,
+      );
+
+      assert.equal(profileGetRequests, 2);
+      assert.equal(downloadedProfileEntries.length, 1);
+    });
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});

--- a/tests/bookmark-media.test.ts
+++ b/tests/bookmark-media.test.ts
@@ -78,3 +78,71 @@ test('fetchBookmarkMediaBatch downloads post media from GraphQL mediaObjects sha
     globalThis.fetch = originalFetch;
   }
 });
+
+test('fetchBookmarkMediaBatch downloads shared profile images only once across bookmarks', async () => {
+  const profileUrl = 'https://pbs.twimg.com/profile_images/123/avatar_normal.jpg';
+  const fullProfileUrl = profileUrl.replace('_normal.', '_400x400.');
+  const records = [
+    {
+      id: '1',
+      tweetId: '1',
+      url: 'https://x.com/alice/status/1',
+      text: 'first bookmark',
+      authorHandle: 'alice',
+      authorName: 'Alice',
+      authorProfileImageUrl: profileUrl,
+      syncedAt: '2026-04-09T00:00:00.000Z',
+      mediaObjects: [],
+      links: [],
+      tags: [],
+      ingestedVia: 'graphql',
+    },
+    {
+      id: '2',
+      tweetId: '2',
+      url: 'https://x.com/alice/status/2',
+      text: 'second bookmark',
+      authorHandle: 'alice',
+      authorName: 'Alice',
+      authorProfileImageUrl: profileUrl,
+      syncedAt: '2026-04-09T00:00:00.000Z',
+      mediaObjects: [],
+      links: [],
+      tags: [],
+      ingestedVia: 'graphql',
+    },
+  ];
+
+  let profileGetRequests = 0;
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+    const url = String(input instanceof Request ? input.url : input);
+    const method = init?.method ?? 'GET';
+    if (method === 'HEAD') {
+      return new Response(null, {
+        status: 200,
+        headers: { 'content-length': '4', 'content-type': 'image/jpeg' },
+      });
+    }
+    if (url === fullProfileUrl) profileGetRequests += 1;
+    return new Response(Uint8Array.from([1, 2, 3, 4]), {
+      status: 200,
+      headers: { 'content-type': 'image/jpeg' },
+    });
+  };
+
+  try {
+    await withMediaDataDir(records, async () => {
+      const manifest = await fetchBookmarkMediaBatch({ limit: 10, maxBytes: 1024 });
+      const downloadedProfileEntries = manifest.entries.filter(
+        (entry) => entry.status === 'downloaded' && entry.sourceUrl === fullProfileUrl,
+      );
+
+      assert.equal(profileGetRequests, 1);
+      assert.equal(downloadedProfileEntries.length, 1);
+      assert.match(path.basename(downloadedProfileEntries[0].localPath ?? ''), /^[a-f0-9]{16}\.jpg$/);
+    });
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});

--- a/tests/engine.test.ts
+++ b/tests/engine.test.ts
@@ -225,6 +225,30 @@ test('resolveEngine: override returns named engine when binary is on PATH', asyn
   }
 });
 
+test('resolveEngine: codex args include skip-git-repo-check', async () => {
+  if (process.platform === 'win32') return;
+
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ft-engine-codex-args-'));
+  const fakeBin = path.join(tmpDir, 'codex');
+  const origPath = process.env.PATH;
+  process.env.PATH = tmpDir;
+
+  try {
+    fs.writeFileSync(fakeBin, '#!/bin/sh\nexit 0\n');
+    fs.chmodSync(fakeBin, 0o755);
+
+    const { resolveEngine } = await import('../src/engine.js');
+    const resolved = await resolveEngine({ override: 'codex' });
+    assert.deepEqual(
+      resolved.config.args('hello'),
+      ['exec', '--skip-git-repo-check', 'hello'],
+    );
+  } finally {
+    process.env.PATH = origPath;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
 // ── ft model CLI parsing ───────────────────────────────────────────────
 
 test('ft model: command is registered and shows help', async () => {


### PR DESCRIPTION
### Motivation

- Fix Codex invocation so `ft classify --engine codex` works outside trusted Git repos (addresses #86).
- Reduce redundant downloads and on-disk duplication of shared author profile images when fetching bookmark media (addresses #79).

### Description

- Update `src/engine.ts` to include `--skip-git-repo-check` in the `codex` engine `args` so Codex does not require a trusted git repo to run. 
- Change `src/bookmark-media.ts` to dedupe profile-image URLs across bookmarks by tracking known profile image URLs from the previous manifest and treating profile images specially. 
- Save profile images with a content-hash filename (no tweet id prefix) so identical profile images map to the same on-disk file. 
- Adjust media URL handling to carry an `isProfileImage` flag and skip prior-key checks for profile images so shared images are fetched only once. 
- Add regression tests: `tests/engine.test.ts` adds `resolveEngine: codex args include skip-git-repo-check`, and `tests/bookmark-media.test.ts` adds `fetchBookmarkMediaBatch downloads shared profile images only once across bookmarks`.

### Testing

- Ran the modified tests with `npx tsx --test tests/engine.test.ts tests/bookmark-media.test.ts`, and those suites passed.
- Ran full test suite with `npm test`; the new tests passed but the run shows one unrelated pre-existing failure in `tests/config.test.ts` (environment-specific Firefox path assertion), consistent with the base repository state. 
- New tests cover the Codex args change and the profile-image dedupe behavior and succeeded in CI-local runs above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de66bf1750832c968afdaaf28718ff)