### PR TITLE
fix(wiki): --engine override + consecutive-failure breaker + friendlier prompts

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1274,9 +1274,15 @@ export function buildCli() {
         });
         const elapsed = ((Date.now() - start) / 1000).toFixed(1);
         const failed = result.pagesFailed > 0 ? ` failed=${result.pagesFailed}` : '';
-        console.log(`Done (${elapsed}s) — engine=${result.engine} created=${result.pagesCreated} updated=${result.pagesUpdated} skipped=${result.pagesSkipped}${failed} total=${result.totalPages}`);
-        if (result.pagesFailed > 0) {
-          console.log(`\n  ${result.pagesFailed} page(s) failed — re-run ft wiki to retry them.`);
+        if (result.aborted) {
+          console.log(`Aborted (${elapsed}s) — engine=${result.engine} created=${result.pagesCreated} updated=${result.pagesUpdated}${failed}`);
+          console.log(`\n  Too many consecutive failures. Check that \`${result.engine}\` is authenticated and not rate-limited, then rerun \`ft wiki\`.`);
+          process.exitCode = 1;
+        } else {
+          console.log(`Done (${elapsed}s) — engine=${result.engine} created=${result.pagesCreated} updated=${result.pagesUpdated} skipped=${result.pagesSkipped}${failed} total=${result.totalPages}`);
+          if (result.pagesFailed > 0) {
+            console.log(`\n  ${result.pagesFailed} page(s) failed — re-run ft wiki to retry them.`);
+          }
         }
         console.log(`\n  Open in your markdown viewer:\n  ${mdDir()}`);
       } finally {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1237,9 +1237,10 @@ export function buildCli() {
 
   program
     .command('wiki')
-    .description('Compile Karpathy-style markdown wiki from bookmarks')
+    .description('Compile Karpathy-style markdown wiki from bookmarks (requires claude or codex CLI on PATH)')
     .option('--full', 'Recompile all pages (ignore incremental cache)')
     .option('--clean', 'Strip leftover LLM code fences from existing wiki pages (no compile)')
+    .addOption(engineOption())
     .action(safe(async (options) => {
       if (!requireIndex()) return;
 
@@ -1268,6 +1269,7 @@ export function buildCli() {
       try {
         const result = await compileMd({
           full: options.full,
+          engineOverride: options.engine ? String(options.engine) : undefined,
           onProgress: (s) => process.stderr.write(s + '\n'),
         });
         const elapsed = ((Date.now() - start) / 1000).toFixed(1);

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -71,10 +71,16 @@ export function detectAvailableEngines(): string[] {
 async function askYesNo(question: string): Promise<boolean> {
   const result = await promptText(question);
   if (result.kind === 'interrupt') {
-    throw new PromptCancelledError('Cancelled before selecting a model.', 130);
+    throw new PromptCancelledError(
+      'Cancelled — no engine selected. Pick one with `ft model <engine>`, or pass `--engine claude` / `--engine codex`.',
+      130,
+    );
   }
   if (result.kind === 'close') {
-    throw new PromptCancelledError('No model selected.', 0);
+    throw new PromptCancelledError(
+      'No engine selected. Pick one with `ft model <engine>`, or pass `--engine claude` / `--engine codex`.',
+      0,
+    );
   }
   return result.value.toLowerCase().startsWith('y');
 }

--- a/src/md.ts
+++ b/src/md.ts
@@ -35,6 +35,10 @@ const MIN_DOMAIN_COUNT   = 5;
 const MIN_ENTITY_COUNT   = 10;
 const MAX_SAMPLE_SIZE    = 50;
 
+/** Abort the compile after this many consecutive page failures — catches
+ * auth expiry and rate-limit cascades before they waste hours. */
+export const MAX_CONSECUTIVE_FAILURES = 5;
+
 /** Scale timeout by sample count — large categories need more time. */
 function llmOpts(sampleCount: number) {
   // Base 120s + 2s per bookmark sampled, capped at 10 min
@@ -52,6 +56,7 @@ export interface MdState {
 export interface CompileOptions {
   full?: boolean;
   only?: string[];
+  engineOverride?: string;
   onProgress?: (status: string) => void;
 }
 
@@ -243,7 +248,7 @@ export async function compileMd(options: CompileOptions = {}): Promise<CompileRe
     let alive = false;
     try { process.kill(Number(existingPid), 0); alive = true; } catch { /* not running */ }
     if (alive) {
-      throw new Error(`Another ft md is already running (pid ${existingPid}). Wait for it to finish or remove ${lockPath}`);
+      throw new Error(`Another ft wiki is already running (pid ${existingPid}). Wait for it to finish or remove ${lockPath}`);
     }
     // Stale lock from a crashed run — take over
     fs.writeFileSync(lockPath, String(process.pid));
@@ -262,7 +267,8 @@ async function doCompile(
   startTime: number,
   onlySet: Set<string> | null,
 ): Promise<CompileResult> {
-  const engine = await resolveEngine();
+  const engine = await resolveEngine({ override: options.engineOverride });
+  progress(`Using ${engine.name}`);
 
   progress('Initializing md directories...');
   await ensureDir(mdDir());
@@ -347,6 +353,8 @@ async function doCompile(
     }
 
     // ── Generate each page ───────────────────────────────────────────────
+    let consecutiveFailures = 0;
+    let firstFailureMsg = '';
     for (let i = 0; i < toGenerate.length; i++) {
       const item = toGenerate[i];
       const tag = `[${i + 1}/${toGenerate.length}]`;
@@ -376,6 +384,15 @@ async function doCompile(
         const isTimeout = msg.includes('ETIMEDOUT') || msg.includes('timed out');
         await logLine(`${tag} ${item.key} — ${isTimeout ? 'TIMEOUT' : 'ERROR'}: ${msg.slice(0, 120)}`);
         pagesFailed++;
+        consecutiveFailures++;
+        if (!firstFailureMsg) firstFailureMsg = msg;
+        if (consecutiveFailures >= MAX_CONSECUTIVE_FAILURES) {
+          await logLine(
+            `Aborted after ${MAX_CONSECUTIVE_FAILURES} consecutive failures — first error: ${firstFailureMsg.slice(0, 200)}`,
+          );
+          await logLine(`Check that \`${engine.name}\` is authenticated and not rate-limited, then rerun \`ft wiki\`.`);
+          break;
+        }
         continue;
       }
 
@@ -394,6 +411,7 @@ async function doCompile(
       await writeJson(mdStatePath(), state);
 
       await logLine(`${tag} ${item.key} → ${outcome}`);
+      consecutiveFailures = 0;
     }
   } finally {
     db.close();

--- a/src/md.ts
+++ b/src/md.ts
@@ -68,6 +68,7 @@ export interface CompileResult {
   pagesFailed: number;
   totalPages: number;
   elapsed: number;
+  aborted: boolean;
 }
 
 function sha256(text: string): string {
@@ -286,6 +287,7 @@ async function doCompile(
   let pagesUpdated = 0;
   let pagesSkipped = 0;
   let pagesFailed  = 0;
+  let aborted      = false;
 
   const db = await openBookmarksDb();
 
@@ -387,6 +389,7 @@ async function doCompile(
         consecutiveFailures++;
         if (!firstFailureMsg) firstFailureMsg = msg;
         if (consecutiveFailures >= MAX_CONSECUTIVE_FAILURES) {
+          aborted = true;
           await logLine(
             `Aborted after ${MAX_CONSECUTIVE_FAILURES} consecutive failures — first error: ${firstFailureMsg.slice(0, 200)}`,
           );
@@ -427,7 +430,7 @@ async function doCompile(
   const totalPages = pagesCreated + pagesUpdated;
   await appendLine(
     mdLogPath(),
-    logEntry('compile', `engine=${engine.name} created=${pagesCreated} updated=${pagesUpdated} skipped=${pagesSkipped} failed=${pagesFailed} elapsed=${elapsed}s`),
+    logEntry('compile', `${aborted ? 'aborted ' : ''}engine=${engine.name} created=${pagesCreated} updated=${pagesUpdated} skipped=${pagesSkipped} failed=${pagesFailed} elapsed=${elapsed}s`),
   );
 
   // ── Save state ───────────────────────────────────────────────────────────
@@ -435,5 +438,5 @@ async function doCompile(
   state.totalCompiles  = (state.totalCompiles ?? 0) + 1;
   await writeJson(mdStatePath(), state);
 
-  return { engine: engine.name, pagesCreated, pagesUpdated, pagesSkipped, pagesFailed, totalPages, elapsed };
+  return { engine: engine.name, pagesCreated, pagesUpdated, pagesSkipped, pagesFailed, totalPages, elapsed, aborted };
 }

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1,6 +1,22 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { compareVersions, runWithSpinner } from '../src/cli.js';
+import { compareVersions, runWithSpinner, buildCli } from '../src/cli.js';
+
+test('ft wiki: --engine option is registered', () => {
+  const program = buildCli();
+  const wikiCmd = program.commands.find((c: any) => c.name() === 'wiki');
+  assert.ok(wikiCmd, 'wiki command should be registered');
+  const opts = wikiCmd.options.map((o: any) => o.long);
+  assert.ok(opts.includes('--engine'), `expected --engine among ${opts.join(', ')}`);
+});
+
+test('ft wiki: description mentions engine prerequisite', () => {
+  const program = buildCli();
+  const wikiCmd = program.commands.find((c: any) => c.name() === 'wiki');
+  assert.ok(wikiCmd);
+  const desc = wikiCmd.description().toLowerCase();
+  assert.ok(desc.includes('claude') && desc.includes('codex'));
+});
 
 test('compareVersions: equal versions return 0', () => {
   assert.equal(compareVersions('1.2.3', '1.2.3'), 0);

--- a/tests/md.test.ts
+++ b/tests/md.test.ts
@@ -51,7 +51,12 @@ test('sanitizeForPrompt: strips XML-like tags', () => {
 });
 
 // ── md: slug + logEntry ─────────────────────────────────────────────────
-import { slug, logEntry } from '../src/md.js';
+import { slug, logEntry, MAX_CONSECUTIVE_FAILURES } from '../src/md.js';
+
+test('MAX_CONSECUTIVE_FAILURES: is a sane positive integer', () => {
+  assert.ok(Number.isInteger(MAX_CONSECUTIVE_FAILURES));
+  assert.ok(MAX_CONSECUTIVE_FAILURES >= 3 && MAX_CONSECUTIVE_FAILURES <= 20);
+});
 
 test('slug: lowercases', () => {
   assert.equal(slug('AI'), 'ai');


### PR DESCRIPTION
## Summary

Addresses two overlapping failure reports of `ft wiki` hanging or cascading into silent failures — three separate gaps compounded to produce the worst-case opaque stall.

- **`--engine <name>` on `ft wiki`** — mirrors PR #84's pattern via the existing `engineOption()` helper; users on machines with both `claude` and `codex` installed can skip the interactive prompt entirely (`ft wiki --engine claude`).
- **Consecutive-failure breaker** — aborts after 5 consecutive page failures, logs the first error verbatim, and suggests checking engine auth. Catches auth-expired / rate-limit cascades before they waste hours. Counter resets on every successful page.
- **Aborted vs. completed compile are now distinguished end-to-end** — `CompileResult.aborted` flows to `cli.ts`, which prints `Aborted (Xs)` instead of `Done (Xs)`, suppresses the generic "re-run to retry" advice (wrong for breaker-triggered aborts), echoes the engine-auth hint, and sets `process.exitCode = 1` so shell scripts can detect the failure. Final `log.md` entry prefixes `aborted ` when applicable.
- **Friendlier `PromptCancelledError` messages** — both interrupt (Ctrl-C) and close paths point at `ft model <engine>` and `--engine`.
- **Echo engine name early** — `progress(\`Using \${engine.name}\`)` right after `resolveEngine()` returns, visible before the scan phase.
- **Lock-file error wording** — `ft wiki` not `ft md`.
- **Help text** — description notes the `claude` or `codex` prerequisite.

Surgical: ~68 / −12 across `src/cli.ts`, `src/engine.ts`, `src/md.ts` + two small test additions. No new dependencies, no schema changes.

## Why this set

Traced each item to the actual failures reported:

| Change | Traces to report? |
|---|---|
| `--engine` on wiki | ✅ escape hatch for hidden engine prompts |
| Consecutive-failure breaker | ✅ \"hours of silent failures\" pattern (both reports) |
| Aborted vs Done distinction | ✅ security-review follow-up; honest exit code |
| `PromptCancelledError` message | ✅ was the literal error one reporter saw |
| Echo engine early | ✅ closes the \"is it doing anything?\" gap |
| Lock-file wording | ⚠️ adjacent one-word fix, touched md.ts anyway |
| Help-text note | ✅ prevents next user from hitting this |

Deferred as follow-ups (considered and rejected for this PR): `--dry-run` plan-only mode, auth-error string-matching (redundant with the breaker), SIGHUP handler for background runs, `--only`/`--max` partial-run flags.

## Credits & related reports

This PR is a direct response to two independent failure reports that described the same underlying pattern — long silent stalls on `ft wiki` with no actionable feedback.

- **Brian Doherty** (@brianjdoherty) opened **#60** (\"Wiki and Classify don't seem to be working for me\") with the first reproducible log line — \`## [2026-04-13] compile | engine=claude created=0 updated=0 skipped=0 failed=7 elapsed=1009s\` — the exact silent-cascade pattern the breaker now catches. Thank you for the specific log output; it's what made the failure mode concrete.
- **Scott Salka** (@scottsalka-dev) added the critical diagnostic on #60: *\"ft wiki ran for ~608 seconds and completed, but produced 152 failures before finishing. … The failures correlate with Claude Code session initialization. After \`claude auth login\`, the first \`ft wiki\` call seems to hit a race condition or timeout before the Claude Code session is fully ready.\"* That data point directly informed the 5-consecutive-failure threshold — catches the cascade without tripping on normal transients.
- **Chris Cage** (@ccage-simp) jumped into #60 early to triage, flagging the related codex-classify work. Thanks for driving triage on community issues.
- **Darron** and **Anthony Russano**, on X/Twitter, independently reported the same symptom against a ~4000-bookmark corpus with the exact \"Cancelled before selecting a model\" exit string. That report directly motivated the friendlier \`PromptCancelledError\` copy and the `--engine` override on `ft wiki`.

Related: #60 is **partially** resolved by this PR — the failure cascade is now handled gracefully and honestly reported, but Scott's observation about a Claude Code first-run race is a separate root cause worth investigating on its own. Leaving #60 open for that follow-up. I'll comment on the issue with an update for folks to test once v1.3.6 ships.

## Test plan

- [x] `npm run build` — clean
- [x] `npm test` — **241 pass** (was 238, +3 new)
- [ ] `ft wiki --help` shows `--engine <name>` and the prerequisite note
- [ ] `ft wiki --engine claude` bypasses the interactive prompt when both engines are on PATH
- [ ] `ft wiki --engine bogus` fails fast with \"Unknown engine\"
- [ ] Ctrl-C at the model prompt shows the friendlier error mentioning `ft model` / `--engine`
- [ ] `Using <engine>` line appears before `Initializing md directories...`
- [ ] Simulate 5 consecutive LLM failures (e.g., temporarily `chmod -x` the engine binary mid-run): compile prints `Aborted (Xs) — ...`, auth-hint advice, exits non-zero; no \"Done\" wording
- [ ] Running two `ft wiki` at once: second prints \"Another ft wiki is already running\"

🤖 Generated with [Claude Code](https://claude.com/claude-code)