### PR TITLE
bump v1.3.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ft-bookmarks",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ft-bookmarks",
-      "version": "1.3.5",
+      "version": "1.3.6",
       "license": "MIT",
       "dependencies": {
         "commander": "^14.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fieldtheory",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "description": "Field Theory CLI. Self-custody for your X/Twitter bookmarks. Local sync, full-text search, classification, and terminal dashboards.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Version bump to ship the `ft wiki` fixes from PR #90, plus the codex and profile-image fixes from PR #89 that have been sitting on `main` since 2026-04-12.

## What ships in v1.3.6

- `ft wiki --engine <name>` — bypass the interactive model prompt (#90)
- Consecutive-failure breaker: aborts after 5 failures in a row with a clear auth hint instead of silently cascading through thousands of pages (#60, #90)
- Aborted compiles now print `Aborted (Xs)` instead of `Done (Xs)` and exit non-zero (#90)
- Friendlier `PromptCancelledError` messages pointing at `ft model` / `--engine` (#90)
- `Using <engine>` echoed before the scan phase (#90)
- Codex classification works outside trusted git repos (`--skip-git-repo-check`) (#86, #89)
- Profile images deduped to a content-hashed file on disk (#79, #89)
- Wiki compile streams per-page status to `log.md` (#87)
- Strip LLM code fences from generated wiki pages (#88)

## Test plan

- [x] `npm run build` — clean
- [x] `npm test` — 241 pass
- [ ] Post-merge: `npm publish` → `npm view fieldtheory version` shows `1.3.6`
- [ ] Post-publish: `gh release create v1.3.6` with the same notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)