### PR TITLE
fix(cli): fire update-check from showDashboard so no-args ft sees notices

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -287,6 +287,12 @@ export async function showDashboard(): Promise<void> {
   Run: ft sync
 `);
   }
+
+  // The no-args path bypasses Commander, so the postAction update-check
+  // hook never fires here. Call it directly — same 5s network timeout,
+  // 24h cache debounce, and outer try/catch that the subcommand path
+  // already tolerates, so brittleness is bounded to existing behavior.
+  await checkForUpdate();
 }
 
 function timeAgo(dateStr: string): string {

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -29,8 +29,8 @@ test('showDashboard: prints update notice when cache is newer than local', async
 
   const joined = logs.join('\n');
   assert.ok(
-    joined.includes('Update available'),
-    `expected update notice in dashboard output; got:\n${joined}`,
+    joined.includes('Update available') && joined.includes('99.99.99'),
+    `expected update notice mentioning the cached 99.99.99 version; got:\n${joined}`,
   );
 });
 

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1,6 +1,38 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
 import { compareVersions, runWithSpinner, buildCli } from '../src/cli.js';
+
+test('showDashboard: prints update notice when cache is newer than local', async () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ft-dashboard-'));
+  const origEnv = process.env.FT_DATA_DIR;
+  process.env.FT_DATA_DIR = tmpDir;
+
+  // Fresh cache file with an absurdly high version — exercises the cache-hit
+  // path (no network), and guarantees the notice regardless of local version.
+  fs.writeFileSync(path.join(tmpDir, '.update-check'), '99.99.99');
+
+  const logs: string[] = [];
+  const origLog = console.log;
+  console.log = (...args: any[]) => { logs.push(args.map(String).join(' ')); };
+
+  try {
+    const { showDashboard } = await import('../src/cli.js');
+    await showDashboard();
+  } finally {
+    console.log = origLog;
+    process.env.FT_DATA_DIR = origEnv;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+
+  const joined = logs.join('\n');
+  assert.ok(
+    joined.includes('Update available'),
+    `expected update notice in dashboard output; got:\n${joined}`,
+  );
+});
 
 test('ft wiki: --engine option is registered', () => {
   const program = buildCli();


### PR DESCRIPTION
## The bug

`ft` with no args (dashboard view), `ft --version`, and `ft --help` all **bypass the update-check hook entirely**. The check is wired as a Commander `postAction` hook at `src/cli.ts:1438`, but `bin/ft.mjs:7-12` routes the no-args case directly to `showDashboard()` without ever calling `parseAsync()` — so the hook never fires. `--version` and `--help` go through Commander but are built-ins that exit before action handlers run.

Concrete impact: **every user is affected**.

| How the user runs `ft` | Update notice fires? |
|---|---|
| `ft` (dashboard view — the whole pitch) | **Never** |
| `ft --version` | **Never** |
| `ft --help` | **Never** |
| Any completing subcommand (`ft sync`, `ft search`, etc.) | Yes, after 24h cache debounce |
| Any **hanging** subcommand (e.g., the `ft wiki` bug from #60) | **Never** — hook runs post-action, hang never reaches it |

Particularly dark: users on a hanging `ft wiki` (the exact bug #90 fixed) couldn't have learned about the fix through their own CLI.

## The fix

Call `checkForUpdate()` at the end of `showDashboard()`. Same semantics the subcommand path already tolerates:

- 5s `AbortController` timeout on the fetch
- 24h cache debounce (instant cache-hit path ~23/24 runs)
- Top-level `try/catch` that swallows every error class

So the dashboard has **exactly the same** brittleness envelope as any existing subcommand — no new failure modes. On cache-hit days the added work is a single `fs.statSync` + `fs.readFileSync` of a tiny file. On cache-miss days the added work is one HTTPS fetch bounded to 5s with all errors silently swallowed.

Not addressed in this PR (deferred as separate concerns):

- `ft --version` / `ft --help` still don't fire the check. They're Commander built-ins that exit before action handlers run; fixing them requires either a preAction hook or argv preprocessing in `bin/ft.mjs`. Niche enough to leave alone.
- The 24h cache debounce is still 24h. Could add a `--force-update-check` flag for \"I just shipped and want to verify\" but that's a dev tool, not a user need.

## Test

`tests/cli.test.ts` adds **\`showDashboard: prints update notice when cache is newer than local\`**. The test:

1. Creates a temp `FT_DATA_DIR`
2. Writes \`99.99.99\` to the update-check cache (fresh mtime → exercises the cache-hit path, zero network)
3. Captures `console.log` and calls `showDashboard()`
4. Asserts the output contains \"Update available\"

Real cache-hit code path, no mocking, no network, no fixtures. Prevents silent regression if the call gets removed.

## Test plan

- [x] `npm run build` — clean
- [x] `npm test` — **242 pass** (was 241)
- [ ] Manual: `rm ~/.ft-bookmarks/.update-check && echo '9.9.9' > ~/.ft-bookmarks/.update-check && ft` → \"✨ Update available: 1.3.6 → 9.9.9\" appears below the dashboard
- [ ] Manual: `rm ~/.ft-bookmarks/.update-check && ft` (fresh — first run triggers fetch against the real registry; cache now has whatever's on npm; if local < latest, next `ft` shows the notice)
- [ ] Manual: offline (`ifconfig en0 down && ft`) — dashboard still renders; no hang; no crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)