### PR TITLE
bump v1.3.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ft-bookmarks",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ft-bookmarks",
-      "version": "1.3.6",
+      "version": "1.3.7",
       "license": "MIT",
       "dependencies": {
         "commander": "^14.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fieldtheory",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "description": "Field Theory CLI. Self-custody for your X/Twitter bookmarks. Local sync, full-text search, classification, and terminal dashboards.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Version bump to ship PR #92, which fixes the no-args `ft` dashboard bypassing the update-check hook.

## What ships in v1.3.7

- `fix(cli): fire update-check from showDashboard so no-args ft sees notices` (#92) — the update-available notice now actually appears for users who primarily run `ft` with no args (dashboard view), instead of only firing on subcommand paths that go through Commander's `postAction` hook.

## Test plan

- [x] `npm run build` — clean
- [x] `npm test` — 242 pass
- [ ] Post-merge: `npm publish` → `npm view fieldtheory version` shows `1.3.7`
- [ ] Post-publish: `gh release create v1.3.7 --title "v1.3.7" --notes "Fix: update notices now fire on the no-args dashboard path (#92)."`
- [ ] Post-publish smoke test: `rm ~/.ft-bookmarks/.update-check && ft` → confirm no crash, then next `ft` invocation (on a machine running <1.3.7) should see the update notice

🤖 Generated with [Claude Code](https://claude.com/claude-code)