### PR TITLE
fix(wiki): close claude -p stdin so ft wiki stops hanging (issue #60)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ft-bookmarks",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ft-bookmarks",
-      "version": "1.3.7",
+      "version": "1.3.8",
       "license": "MIT",
       "dependencies": {
         "commander": "^14.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fieldtheory",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "description": "Field Theory CLI. Self-custody for your X/Twitter bookmarks. Local sync, full-text search, classification, and terminal dashboards.",
   "type": "module",
   "bin": {

--- a/src/bookmarks-db.ts
+++ b/src/bookmarks-db.ts
@@ -905,9 +905,19 @@ export async function getCategoryCounts(existingDb?: Database): Promise<Record<s
   const db = existingDb ?? await openDb(twitterBookmarksIndexPath());
   if (!existingDb) ensureMigrations(db);
   try {
+    // Exclude 'unclassified' — it's the default placeholder for bookmarks
+    // that haven't been run through `ft classify` yet, NOT a real category.
+    // Including it broke `ft wiki`: the wiki scanner would see a huge
+    // "unclassified" count (often N == total bookmarks), pass the
+    // MIN_CATEGORY_COUNT gate, and queue a page generation. But
+    // `sampleByCategory('unclassified', …)` looks up the `categories` column
+    // (a list) rather than `primary_category`, and unclassified rows have
+    // `categories = NULL`, so sampling always returned zero rows. We then
+    // sent the LLM a "summarize these 0 bookmarks" prompt and wasted a
+    // timeout on every compile.
     const rows = db.exec(
       `SELECT primary_category, COUNT(*) as c FROM bookmarks
-       WHERE primary_category IS NOT NULL
+       WHERE primary_category IS NOT NULL AND primary_category != 'unclassified'
        GROUP BY primary_category ORDER BY c DESC`
     );
     const counts: Record<string, number> = {};

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -5,7 +5,7 @@
  * Remembers the user's choice in ~/.ft-bookmarks/.preferences.
  */
 
-import { execFileSync, execFile } from 'node:child_process';
+import { spawn, spawnSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 import { loadPreferences, savePreferences } from './preferences.js';
@@ -180,30 +180,254 @@ export interface InvokeOptions {
   maxBuffer?: number;
 }
 
+/**
+ * Structured failure from an engine invocation.
+ *
+ * Carries the pieces a caller needs to build a useful error message:
+ * - `stderr`: whatever the child wrote before it died (may be empty)
+ * - `killed`: true when we killed it ourselves (timeout / maxBuffer cap)
+ * - `code`/`signal`: standard exit info
+ *
+ * We avoid stuffing the prompt into `.message` — the prompt can be tens of
+ * kilobytes, and `execFile`'s built-in "Command failed: <cmd + args>" format
+ * blew up the `log.md` entries for `ft wiki` by consuming the entire
+ * truncation budget with prompt bytes, leaving no room for the actual
+ * failure signal. Callers should prefer `.stderr` / `.killed` over
+ * `.message` for user-facing output.
+ */
+export class EngineInvocationError extends Error {
+  readonly engine: string;
+  readonly bin: string;
+  readonly stderr: string;
+  readonly killed: boolean;
+  readonly code: number | null;
+  readonly signal: NodeJS.Signals | null;
+  readonly reason: 'timeout' | 'maxbuffer' | 'exit' | 'spawn';
+
+  constructor(params: {
+    engine: string;
+    bin: string;
+    stderr: string;
+    killed: boolean;
+    code: number | null;
+    signal: NodeJS.Signals | null;
+    reason: 'timeout' | 'maxbuffer' | 'exit' | 'spawn';
+    message: string;
+  }) {
+    super(params.message);
+    this.name = 'EngineInvocationError';
+    this.engine = params.engine;
+    this.bin = params.bin;
+    this.stderr = params.stderr;
+    this.killed = params.killed;
+    this.code = params.code;
+    this.signal = params.signal;
+    this.reason = params.reason;
+  }
+}
+
+const DEFAULT_TIMEOUT   = 120_000;
+const DEFAULT_MAXBUF    = 1024 * 1024;
+const STDERR_TAIL_BYTES = 4096; // enough for a claude auth/rate-limit blurb
+
+/** Clip the tail of a buffer to a byte budget — engines put the "what went
+ *  wrong" line at the end of stderr. */
+function tailString(buf: Buffer, bytes: number): string {
+  if (buf.length <= bytes) return buf.toString('utf-8');
+  return '\u2026' + buf.subarray(buf.length - bytes).toString('utf-8');
+}
+
+/** Build a user-facing failure message. Deliberately does NOT inline the
+ *  prompt — see EngineInvocationError for why. */
+function buildMessage(
+  engineName: string,
+  reason: 'timeout' | 'maxbuffer' | 'exit' | 'spawn',
+  stderr: string,
+  code: number | null,
+  signal: NodeJS.Signals | null,
+  timeoutMs: number,
+): string {
+  const stderrSnippet = stderr.trim().slice(-500);
+  const detail = stderrSnippet ? ` \u2014 ${stderrSnippet}` : '';
+  switch (reason) {
+    case 'timeout':
+      return `${engineName} timed out after ${Math.round(timeoutMs / 1000)}s${detail}`;
+    case 'maxbuffer':
+      return `${engineName} output exceeded buffer cap${detail}`;
+    case 'spawn':
+      return `${engineName} failed to start${detail}`;
+    case 'exit':
+    default: {
+      const signalPart = signal ? ` (signal ${signal})` : '';
+      const codePart   = code !== null ? ` exit ${code}` : '';
+      return `${engineName} failed${codePart}${signalPart}${detail}`;
+    }
+  }
+}
+
+/**
+ * Synchronous engine call — uses `spawnSync` with `input: ''` so the child's
+ * stdin is closed with EOF before it starts reading.
+ *
+ * Background: claude-code's `claude -p` reads stdin when it's not a TTY and
+ * concatenates it with the `-p` argument. Leaving stdin open as an unwritten
+ * pipe makes older claude versions block forever (and newer versions eat a
+ * 3s "no stdin data received" delay per call). Passing `input: ''` sends
+ * EOF immediately so the child proceeds with just the prompt arg.
+ */
 export function invokeEngine(engine: ResolvedEngine, prompt: string, opts: InvokeOptions = {}): string {
   const { bin, args } = engine.config;
-  return execFileSync(bin, args(prompt), {
-    encoding: 'utf-8',
-    timeout: opts.timeout ?? 120_000,
-    maxBuffer: opts.maxBuffer ?? 1024 * 1024,
-    stdio: ['pipe', 'pipe', 'ignore'],
-  }).trim();
+  const timeout   = opts.timeout   ?? DEFAULT_TIMEOUT;
+  const maxBuffer = opts.maxBuffer ?? DEFAULT_MAXBUF;
+
+  const result = spawnSync(bin, args(prompt), {
+    input: '',              // EOF on stdin — do not inherit parent stdin
+    timeout,
+    maxBuffer,
+    encoding: 'buffer',
+  });
+
+  const stderrBuf = result.stderr ?? Buffer.alloc(0);
+  const stderr    = tailString(stderrBuf, STDERR_TAIL_BYTES);
+
+  if (result.error) {
+    const anyErr = result.error as NodeJS.ErrnoException & { code?: string };
+    if (anyErr.code === 'ETIMEDOUT') {
+      throw new EngineInvocationError({
+        engine: engine.name, bin, stderr,
+        killed: true, code: null, signal: 'SIGTERM', reason: 'timeout',
+        message: buildMessage(engine.name, 'timeout', stderr, null, 'SIGTERM', timeout),
+      });
+    }
+    if (anyErr.code === 'ERR_CHILD_PROCESS_STDIO_MAXBUFFER') {
+      throw new EngineInvocationError({
+        engine: engine.name, bin, stderr,
+        killed: true, code: null, signal: null, reason: 'maxbuffer',
+        message: buildMessage(engine.name, 'maxbuffer', stderr, null, null, timeout),
+      });
+    }
+    throw new EngineInvocationError({
+      engine: engine.name, bin,
+      stderr: '', killed: false, code: null, signal: null, reason: 'spawn',
+      message: buildMessage(engine.name, 'spawn', anyErr.message ?? '', null, null, timeout),
+    });
+  }
+
+  if (result.signal === 'SIGTERM' && (result.status === null || result.status === 143)) {
+    // spawnSync sets .signal='SIGTERM' when the timeout kills the child.
+    throw new EngineInvocationError({
+      engine: engine.name, bin, stderr,
+      killed: true, code: result.status, signal: result.signal, reason: 'timeout',
+      message: buildMessage(engine.name, 'timeout', stderr, result.status, result.signal, timeout),
+    });
+  }
+
+  if (result.status !== 0) {
+    throw new EngineInvocationError({
+      engine: engine.name, bin, stderr,
+      killed: false, code: result.status, signal: result.signal, reason: 'exit',
+      message: buildMessage(engine.name, 'exit', stderr, result.status, result.signal, timeout),
+    });
+  }
+
+  return (result.stdout ?? Buffer.alloc(0)).toString('utf-8').trim();
 }
 
 /**
  * Async variant — does not block the event loop, so spinners and
  * setInterval callbacks continue to fire while the LLM runs.
+ *
+ * Uses `spawn` (not `execFile`) because `execFile` with a callback builds
+ * its own internal stdio pipes and silently overrides any stdio option we
+ * pass — so we can't close the child's stdin through the execFile API. With
+ * `spawn` we get direct control and can `child.stdin.end()` immediately.
  */
 export function invokeEngineAsync(engine: ResolvedEngine, prompt: string, opts: InvokeOptions = {}): Promise<string> {
   const { bin, args } = engine.config;
+  const timeout   = opts.timeout   ?? DEFAULT_TIMEOUT;
+  const maxBuffer = opts.maxBuffer ?? DEFAULT_MAXBUF;
+
   return new Promise((resolve, reject) => {
-    execFile(bin, args(prompt), {
-      encoding: 'utf-8',
-      timeout: opts.timeout ?? 120_000,
-      maxBuffer: opts.maxBuffer ?? 1024 * 1024,
-    }, (err, stdout) => {
-      if (err) return reject(err);
-      resolve(stdout.trim());
+    const child = spawn(bin, args(prompt), {
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+
+    // Close stdin immediately with EOF so `claude -p` doesn't wait on it.
+    // If spawn itself failed (ENOENT etc) `child.stdin` may be null — guard.
+    try { child.stdin?.end(); } catch { /* spawn error will surface below */ }
+
+    const stdoutChunks: Buffer[] = [];
+    const stderrChunks: Buffer[] = [];
+    let stdoutBytes = 0;
+    let settled = false;
+
+    const fail = (err: EngineInvocationError) => {
+      if (settled) return;
+      settled = true;
+      try { child.kill('SIGTERM'); } catch { /* already dead */ }
+      reject(err);
+    };
+
+    const succeed = (out: string) => {
+      if (settled) return;
+      settled = true;
+      resolve(out);
+    };
+
+    child.stdout?.on('data', (d: Buffer) => {
+      stdoutBytes += d.length;
+      if (stdoutBytes > maxBuffer) {
+        const stderr = tailString(Buffer.concat(stderrChunks), STDERR_TAIL_BYTES);
+        fail(new EngineInvocationError({
+          engine: engine.name, bin, stderr,
+          killed: true, code: null, signal: null, reason: 'maxbuffer',
+          message: buildMessage(engine.name, 'maxbuffer', stderr, null, null, timeout),
+        }));
+        return;
+      }
+      stdoutChunks.push(d);
+    });
+
+    child.stderr?.on('data', (d: Buffer) => {
+      // Bound stderr buffering to avoid RAM blowup on a misbehaving child.
+      stderrChunks.push(d);
+      if (stderrChunks.length > 64) stderrChunks.splice(0, 32);
+    });
+
+    const timer = setTimeout(() => {
+      const stderr = tailString(Buffer.concat(stderrChunks), STDERR_TAIL_BYTES);
+      fail(new EngineInvocationError({
+        engine: engine.name, bin, stderr,
+        killed: true, code: null, signal: 'SIGTERM', reason: 'timeout',
+        message: buildMessage(engine.name, 'timeout', stderr, null, 'SIGTERM', timeout),
+      }));
+    }, timeout);
+
+    child.on('error', (err: NodeJS.ErrnoException) => {
+      clearTimeout(timer);
+      if (settled) return;
+      settled = true;
+      reject(new EngineInvocationError({
+        engine: engine.name, bin,
+        stderr: '', killed: false, code: null, signal: null, reason: 'spawn',
+        message: buildMessage(engine.name, 'spawn', err.message ?? '', null, null, timeout),
+      }));
+    });
+
+    child.on('close', (code, signal) => {
+      clearTimeout(timer);
+      if (settled) return;
+      const stderr = tailString(Buffer.concat(stderrChunks), STDERR_TAIL_BYTES);
+      if (code === 0) {
+        succeed(Buffer.concat(stdoutChunks).toString('utf-8').trim());
+        return;
+      }
+      settled = true;
+      reject(new EngineInvocationError({
+        engine: engine.name, bin, stderr,
+        killed: false, code, signal, reason: 'exit',
+        message: buildMessage(engine.name, 'exit', stderr, code, signal, timeout),
+      }));
     });
   });
 }

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -228,13 +228,35 @@ export class EngineInvocationError extends Error {
 
 const DEFAULT_TIMEOUT   = 120_000;
 const DEFAULT_MAXBUF    = 1024 * 1024;
-const STDERR_TAIL_BYTES = 4096; // enough for a claude auth/rate-limit blurb
+const STDERR_TAIL_BYTES = 4096;     // clipped tail shown in errors/logs
+const STDERR_HARD_CAP   = 64 * 1024; // hard ceiling on in-memory stderr buffering
+const SIGKILL_GRACE_MS  = 2_000;     // grace period between SIGTERM and SIGKILL
 
 /** Clip the tail of a buffer to a byte budget — engines put the "what went
  *  wrong" line at the end of stderr. */
 function tailString(buf: Buffer, bytes: number): string {
   if (buf.length <= bytes) return buf.toString('utf-8');
   return '\u2026' + buf.subarray(buf.length - bytes).toString('utf-8');
+}
+
+/**
+ * Strip high-confidence secret shapes from child stderr before it lands in
+ * an error object or `log.md`. Deliberately narrow — only patterns that are
+ * ~impossible to collide with legitimate error text:
+ *
+ *   - provider-prefixed API keys (sk-…, used by Anthropic/OpenAI/Stripe)
+ *   - GitHub personal/app/oauth tokens (ghp_, gho_, ghu_, ghs_, ghr_)
+ *   - `Bearer <token>` authorization headers
+ *
+ * `claude` / `codex` don't currently echo secrets to stderr, but this is
+ * defense-in-depth: if an engine ever does, we don't want the raw token in
+ * `~/.ft-bookmarks/md/log.md` forever.
+ */
+export function redactSecrets(s: string): string {
+  return s
+    .replace(/\bsk-[A-Za-z0-9_-]{16,}/g, 'sk-***REDACTED***')
+    .replace(/\b(ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9]{16,}/g, '$1_***REDACTED***')
+    .replace(/\bBearer\s+[A-Za-z0-9._-]{16,}/gi, 'Bearer ***REDACTED***');
 }
 
 /** Build a user-facing failure message. Deliberately does NOT inline the
@@ -288,7 +310,7 @@ export function invokeEngine(engine: ResolvedEngine, prompt: string, opts: Invok
   });
 
   const stderrBuf = result.stderr ?? Buffer.alloc(0);
-  const stderr    = tailString(stderrBuf, STDERR_TAIL_BYTES);
+  const stderr    = redactSecrets(tailString(stderrBuf, STDERR_TAIL_BYTES));
 
   if (result.error) {
     const anyErr = result.error as NodeJS.ErrnoException & { code?: string };
@@ -359,25 +381,44 @@ export function invokeEngineAsync(engine: ResolvedEngine, prompt: string, opts: 
     const stdoutChunks: Buffer[] = [];
     const stderrChunks: Buffer[] = [];
     let stdoutBytes = 0;
+    let stderrBytes = 0;
     let settled = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+
+    /** Compute the redacted tail of buffered stderr for error reporting. */
+    const stderrTail = () =>
+      redactSecrets(tailString(Buffer.concat(stderrChunks), STDERR_TAIL_BYTES));
+
+    /** Send SIGTERM, then escalate to SIGKILL after a grace period in case
+     *  the child traps SIGTERM. `.unref()` so the escalation timer does not
+     *  keep the event loop alive past shutdown. */
+    const killChild = () => {
+      try { child.kill('SIGTERM'); } catch { /* already dead */ }
+      const escalate = setTimeout(() => {
+        try { child.kill('SIGKILL'); } catch { /* already dead */ }
+      }, SIGKILL_GRACE_MS);
+      escalate.unref();
+    };
 
     const fail = (err: EngineInvocationError) => {
       if (settled) return;
       settled = true;
-      try { child.kill('SIGTERM'); } catch { /* already dead */ }
+      if (timer !== undefined) clearTimeout(timer);
+      killChild();
       reject(err);
     };
 
     const succeed = (out: string) => {
       if (settled) return;
       settled = true;
+      if (timer !== undefined) clearTimeout(timer);
       resolve(out);
     };
 
     child.stdout?.on('data', (d: Buffer) => {
       stdoutBytes += d.length;
       if (stdoutBytes > maxBuffer) {
-        const stderr = tailString(Buffer.concat(stderrChunks), STDERR_TAIL_BYTES);
+        const stderr = stderrTail();
         fail(new EngineInvocationError({
           engine: engine.name, bin, stderr,
           killed: true, code: null, signal: null, reason: 'maxbuffer',
@@ -389,13 +430,18 @@ export function invokeEngineAsync(engine: ResolvedEngine, prompt: string, opts: 
     });
 
     child.stderr?.on('data', (d: Buffer) => {
-      // Bound stderr buffering to avoid RAM blowup on a misbehaving child.
+      // Bound in-memory stderr by bytes, dropping the oldest chunks first.
+      // Keep at least one chunk so a single giant line still shows its tail.
       stderrChunks.push(d);
-      if (stderrChunks.length > 64) stderrChunks.splice(0, 32);
+      stderrBytes += d.length;
+      while (stderrBytes > STDERR_HARD_CAP && stderrChunks.length > 1) {
+        const dropped = stderrChunks.shift()!;
+        stderrBytes -= dropped.length;
+      }
     });
 
-    const timer = setTimeout(() => {
-      const stderr = tailString(Buffer.concat(stderrChunks), STDERR_TAIL_BYTES);
+    timer = setTimeout(() => {
+      const stderr = stderrTail();
       fail(new EngineInvocationError({
         engine: engine.name, bin, stderr,
         killed: true, code: null, signal: 'SIGTERM', reason: 'timeout',
@@ -404,7 +450,7 @@ export function invokeEngineAsync(engine: ResolvedEngine, prompt: string, opts: 
     }, timeout);
 
     child.on('error', (err: NodeJS.ErrnoException) => {
-      clearTimeout(timer);
+      if (timer !== undefined) clearTimeout(timer);
       if (settled) return;
       settled = true;
       reject(new EngineInvocationError({
@@ -415,9 +461,9 @@ export function invokeEngineAsync(engine: ResolvedEngine, prompt: string, opts: 
     });
 
     child.on('close', (code, signal) => {
-      clearTimeout(timer);
+      if (timer !== undefined) clearTimeout(timer);
       if (settled) return;
-      const stderr = tailString(Buffer.concat(stderrChunks), STDERR_TAIL_BYTES);
+      const stderr = stderrTail();
       if (code === 0) {
         succeed(Buffer.concat(stdoutChunks).toString('utf-8').trim());
         return;

--- a/src/md.ts
+++ b/src/md.ts
@@ -23,7 +23,7 @@ import {
   getCategoryCounts, getDomainCounts, sampleByCategory, sampleByDomain,
   sampleByAuthor, getTopAuthorHandles, openBookmarksDb, type CategorySample,
 } from './bookmarks-db.js';
-import { resolveEngine, invokeEngineAsync, type ResolvedEngine } from './engine.js';
+import { resolveEngine, invokeEngineAsync, EngineInvocationError, type ResolvedEngine } from './engine.js';
 import {
   buildCategoryPagePrompt, buildDomainPagePrompt, buildEntityPagePrompt,
   type MdBookmark,
@@ -234,6 +234,48 @@ export function logEntry(type: string, detail: string): string {
   return `## [${ts}] ${type} | ${detail}`;
 }
 
+/** Short log label from an EngineInvocationError reason. */
+function reasonLabel(reason: EngineInvocationError['reason']): string {
+  switch (reason) {
+    case 'timeout':   return 'TIMEOUT';
+    case 'maxbuffer': return 'OVERFLOW';
+    case 'spawn':     return 'SPAWN-FAIL';
+    case 'exit':      return 'ERROR';
+  }
+}
+
+/** Build the log detail from a structured engine failure. Prefers stderr,
+ *  falls back to the reason-shaped message — never the raw prompt. */
+function formatFailureDetail(err: EngineInvocationError): string {
+  // For spawn failures (ENOENT etc) the message IS the useful content.
+  if (err.reason === 'spawn') return err.message;
+  const stderrLine = err.stderr.trim().split(/\r?\n/).filter(Boolean).pop();
+  if (stderrLine) {
+    return err.reason === 'timeout'
+      ? `${err.message} [stderr: ${stderrLine}]`
+      : stderrLine;
+  }
+  return err.message;
+}
+
+/** Reason-aware advice line shown when the breaker fires. */
+function engineFailureHint(engineName: string, err: EngineInvocationError | null): string {
+  if (err?.reason === 'timeout') {
+    return `${engineName} ran to the full timeout on every page — usually a hung child, not auth. ` +
+           `Upgrade ${engineName} (\`${engineName} --version\`) and retry with \`ft wiki\`.`;
+  }
+  if (err?.reason === 'spawn') {
+    return `Could not spawn \`${engineName}\`. Check that it's installed and on PATH, then rerun \`ft wiki\`.`;
+  }
+  if (err?.stderr && /rate.?limit|quota|429/i.test(err.stderr)) {
+    return `${engineName} is rate-limited. Wait a bit, then rerun \`ft wiki\`.`;
+  }
+  if (err?.stderr && /auth|login|unauthor|invalid.*token|expired/i.test(err.stderr)) {
+    return `${engineName} reports an auth problem — re-authenticate (e.g. \`${engineName} /login\`) and rerun \`ft wiki\`.`;
+  }
+  return `Check that \`${engineName}\` is authenticated and not rate-limited, then rerun \`ft wiki\`.`;
+}
+
 export async function compileMd(options: CompileOptions = {}): Promise<CompileResult> {
   const progress  = options.onProgress ?? ((s: string) => fs.writeSync(2, s + '\n'));
   const startTime = Date.now();
@@ -382,18 +424,26 @@ async function doCompile(
         const raw = await invokeEngineAsync(engine, prompt, opts);
         content = stripLlmMarkdownFence(raw);
       } catch (err) {
-        const msg = (err as Error).message ?? String(err);
-        const isTimeout = msg.includes('ETIMEDOUT') || msg.includes('timed out');
-        await logLine(`${tag} ${item.key} — ${isTimeout ? 'TIMEOUT' : 'ERROR'}: ${msg.slice(0, 120)}`);
+        // Prefer the structured EngineInvocationError fields over err.message.
+        // err.message used to be the execFile-formatted "Command failed: claude
+        // -p --output-format text <FULL PROMPT>", which consumed the entire
+        // log budget with prompt bytes and hid the real signal. We now log a
+        // short label derived from the failure reason plus the tail of stderr,
+        // which is usually where claude/codex put "auth expired" / "rate limit"
+        // / "model not available".
+        const eie = err instanceof EngineInvocationError ? err : null;
+        const label = eie ? reasonLabel(eie.reason) : 'ERROR';
+        const detail = eie ? formatFailureDetail(eie) : (err as Error).message ?? String(err);
+        await logLine(`${tag} ${item.key} — ${label}: ${detail.slice(0, 200)}`);
         pagesFailed++;
         consecutiveFailures++;
-        if (!firstFailureMsg) firstFailureMsg = msg;
+        if (!firstFailureMsg) firstFailureMsg = eie?.message ?? (err as Error).message ?? String(err);
         if (consecutiveFailures >= MAX_CONSECUTIVE_FAILURES) {
           aborted = true;
           await logLine(
-            `Aborted after ${MAX_CONSECUTIVE_FAILURES} consecutive failures — first error: ${firstFailureMsg.slice(0, 200)}`,
+            `Aborted after ${MAX_CONSECUTIVE_FAILURES} consecutive failures — first error: ${firstFailureMsg.slice(0, 300)}`,
           );
-          await logLine(`Check that \`${engine.name}\` is authenticated and not rate-limited, then rerun \`ft wiki\`.`);
+          await logLine(engineFailureHint(engine.name, eie));
           break;
         }
         continue;

--- a/tests/bookmarks-db.test.ts
+++ b/tests/bookmarks-db.test.ts
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 import { mkdtemp, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
-import { buildIndex, searchBookmarks, getStats, formatSearchResults, getBookmarkById, sanitizeFtsQuery } from '../src/bookmarks-db.js';
+import { buildIndex, searchBookmarks, getStats, formatSearchResults, getBookmarkById, sanitizeFtsQuery, getCategoryCounts, sampleByCategory } from '../src/bookmarks-db.js';
 import { openDb, saveDb } from '../src/db.js';
 import { twitterBookmarksIndexPath } from '../src/paths.js';
 
@@ -127,6 +127,52 @@ test('getStats returns correct aggregate data', async () => {
     assert.equal(stats.topAuthors[0].count, 2);
     assert.equal(stats.languageBreakdown[0].language, 'en');
     assert.equal(stats.languageBreakdown[0].count, 3);
+  });
+});
+
+// Regression: buildIndex writes primary_category='unclassified' as a
+// placeholder for bookmarks that haven't been classified. getCategoryCounts
+// must NOT surface that placeholder — if it does, ft wiki's scan phase
+// queues an "unclassified" page whose sample set is always empty (the
+// sampler reads the `categories` column, which is NULL on unclassified
+// rows) and burns the LLM timeout on every compile. See
+// claude/fix-claude-auth-errors-at0Oi.
+test('getCategoryCounts excludes unclassified placeholder', async () => {
+  await withIsolatedDataDir(async () => {
+    await buildIndex();
+
+    // Fresh index: every row is primary_category='unclassified', categories=NULL.
+    const counts = await getCategoryCounts();
+    assert.ok(!('unclassified' in counts),
+      `getCategoryCounts should not return 'unclassified', got keys: ${JSON.stringify(Object.keys(counts))}`);
+
+    // Sanity: unclassified sampling is still empty (consistent with the
+    // column-mismatch we're working around, not something this fix changes).
+    const samples = await sampleByCategory('unclassified', 50);
+    assert.equal(samples.length, 0);
+  });
+});
+
+test('getCategoryCounts still returns real categories alongside the exclusion', async () => {
+  await withIsolatedDataDir(async () => {
+    await buildIndex();
+
+    // Classify two rows as 'tool' and leave the third as unclassified.
+    const dbPath = twitterBookmarksIndexPath();
+    const db = await openDb(dbPath);
+    try {
+      db.run(
+        `UPDATE bookmarks SET categories = ?, primary_category = ? WHERE id IN ('1', '2')`,
+        ['tool', 'tool'],
+      );
+      saveDb(db, dbPath);
+    } finally {
+      db.close();
+    }
+
+    const counts = await getCategoryCounts();
+    assert.equal(counts['tool'], 2, 'real category should be present');
+    assert.ok(!('unclassified' in counts), 'unclassified placeholder should still be excluded');
   });
 });
 

--- a/tests/engine.test.ts
+++ b/tests/engine.test.ts
@@ -475,3 +475,131 @@ sleep 30
     fs.rmSync(tmpDir, { recursive: true, force: true });
   }
 });
+
+// ── Secret redaction ──────────────────────────────────────────────────
+//
+// Defense-in-depth: child stderr can in principle contain a secret, and we
+// write stderr tails to ~/.ft-bookmarks/md/log.md. Redact high-confidence
+// shapes before they're stored on EngineInvocationError or logged.
+
+test('redactSecrets: masks provider-prefixed API keys', async () => {
+  const { redactSecrets } = await import('../src/engine.js');
+
+  const input = 'Error: invalid API key sk-proj-abcdef1234567890zyxwvu after retry';
+  const output = redactSecrets(input);
+  assert.ok(output.includes('sk-***REDACTED***'), `expected redaction, got: ${output}`);
+  assert.ok(!output.includes('abcdef1234567890'), `raw secret should not appear, got: ${output}`);
+});
+
+test('redactSecrets: masks GitHub-style prefixed tokens', async () => {
+  const { redactSecrets } = await import('../src/engine.js');
+
+  for (const prefix of ['ghp', 'gho', 'ghu', 'ghs', 'ghr']) {
+    const input = `token ${prefix}_abcdefghij1234567890ZZZZ expired`;
+    const output = redactSecrets(input);
+    assert.ok(output.includes(`${prefix}_***REDACTED***`), `expected ${prefix} redaction, got: ${output}`);
+    assert.ok(!output.includes('abcdefghij1234567890'), `raw secret should not appear, got: ${output}`);
+  }
+});
+
+test('redactSecrets: masks Bearer auth tokens', async () => {
+  const { redactSecrets } = await import('../src/engine.js');
+
+  const input = 'Request failed: Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6Ik';
+  const output = redactSecrets(input);
+  assert.ok(output.includes('Bearer ***REDACTED***'), `expected Bearer redaction, got: ${output}`);
+  assert.ok(!output.includes('eyJhbGci'), `raw token should not appear, got: ${output}`);
+});
+
+test('redactSecrets: leaves normal error text untouched', async () => {
+  const { redactSecrets } = await import('../src/engine.js');
+  const normal = 'rate limit exceeded, please wait a moment and try again';
+  assert.equal(redactSecrets(normal), normal);
+});
+
+test('invokeEngineAsync: stderr is bounded under STDERR_TAIL_BYTES and redacted before storage', async () => {
+  if (process.platform === 'win32') return;
+
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ft-engine-stderr-bound-'));
+  try {
+    // Spam ~100 KiB of stderr noise, then a "real" error line containing a
+    // fake secret. The stderr stored on the error should:
+    //   - be bounded (tailString clips to ~4 KiB + ellipsis)
+    //   - contain the tail (the error line at the end)
+    //   - have the fake secret redacted
+    const script = `#!/bin/sh
+yes 'noise noise noise noise noise noise noise noise noise noise' | head -c 102400 1>&2
+echo "Error: invalid sk-ant-abcdef1234567890zyxwvu9876 token" 1>&2
+exit 3
+`;
+    const engine = makeFakeEngine(tmpDir, script);
+    const { invokeEngineAsync, EngineInvocationError } = await import('../src/engine.js');
+
+    let caught: any = null;
+    try {
+      await invokeEngineAsync(engine, 'ignored', { timeout: 10_000 });
+    } catch (e) {
+      caught = e;
+    }
+
+    assert.ok(caught instanceof EngineInvocationError, `expected EngineInvocationError, got ${caught?.constructor?.name}`);
+    assert.equal(caught.reason, 'exit');
+    assert.equal(caught.code, 3);
+    // tailString bounds the stored stderr to ~4 KiB plus the ellipsis char.
+    assert.ok(caught.stderr.length < 5_000, `stderr should be clipped to tail, got ${caught.stderr.length} bytes`);
+    // The trailing error line should survive into the tail.
+    assert.ok(caught.stderr.includes('sk-***REDACTED***'), `expected redacted secret in tail, got: ${JSON.stringify(caught.stderr.slice(-300))}`);
+    assert.ok(!caught.stderr.includes('abcdef1234567890'), `raw secret should not appear in stored stderr`);
+    // And `.message` should not either, since it's built from the redacted stderr.
+    assert.ok(!caught.message.includes('abcdef1234567890'), `raw secret should not appear in .message`);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test('invokeEngineAsync: SIGTERM-resistant child is killed via SIGKILL escalation', async () => {
+  if (process.platform === 'win32') return;
+
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ft-engine-sigkill-'));
+  try {
+    // Child traps SIGTERM (prints a warning, otherwise ignores it) and
+    // sleeps. SIGTERM alone would leave it running; the SIGKILL escalation
+    // (after SIGKILL_GRACE_MS = 2s) should take it down. We assert that
+    // the close event lands within ~5s of the timeout, which is only
+    // possible if SIGKILL actually fires.
+    const script = `#!/bin/sh
+trap 'echo "ignoring SIGTERM" 1>&2' TERM
+# Loop so the trap has a chance to run between sleeps.
+i=0
+while [ $i -lt 60 ]; do sleep 1; i=$((i+1)); done
+`;
+    const engine = makeFakeEngine(tmpDir, script);
+    const { invokeEngineAsync, EngineInvocationError } = await import('../src/engine.js');
+
+    let caught: any = null;
+    const t0 = Date.now();
+    try {
+      // 500ms timeout triggers fail() → SIGTERM; SIGKILL fires 2s later.
+      // Total time to reject the promise should be ~500ms (reject happens
+      // at SIGTERM, not at SIGKILL — we don't wait for the child to close).
+      await invokeEngineAsync(engine, 'ignored', { timeout: 500 });
+    } catch (e) {
+      caught = e;
+    }
+    const elapsedReject = Date.now() - t0;
+
+    assert.ok(caught instanceof EngineInvocationError);
+    assert.equal(caught.reason, 'timeout');
+    assert.ok(elapsedReject < 3_000, `promise should reject at SIGTERM, not wait for grace: took ${elapsedReject}ms`);
+
+    // Give the escalation timer room to land SIGKILL (2s) plus OS slack.
+    // The child should be dead by the time this test exits — we can't
+    // directly observe the PID state, but if SIGKILL didn't fire, Node's
+    // event loop would stay alive holding the child and the test runner
+    // would not exit cleanly. Waiting here ensures the escalation has
+    // at least had a chance to run before the test harness tears down.
+    await new Promise((r) => setTimeout(r, 2_500));
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});

--- a/tests/engine.test.ts
+++ b/tests/engine.test.ts
@@ -280,3 +280,165 @@ test('ft model: direct set persists preference', async () => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   }
 });
+
+// ── invokeEngine / invokeEngineAsync: stdin handling + error shape ─────
+//
+// Regression tests for claude/fix-claude-auth-errors-at0Oi. These ensure:
+//   (a) the child's stdin is CLOSED (EOF immediately), not inherited from
+//       the parent — so `claude -p` never hangs waiting on an open pipe;
+//   (b) when the child exits non-zero, we throw a structured
+//       EngineInvocationError with the actual stderr, not a raw
+//       "Command failed: <whole prompt inlined>" string;
+//   (c) when the timeout fires, we classify it as reason='timeout' with
+//       killed=true — not as a generic exit failure that the md.ts log
+//       path would have to string-match on.
+
+function makeFakeEngine(tmpDir: string, script: string): { name: string; config: { bin: string; args: (p: string) => string[] } } {
+  const binPath = path.join(tmpDir, 'fake-engine');
+  fs.writeFileSync(binPath, script);
+  fs.chmodSync(binPath, 0o755);
+  return { name: 'fake', config: { bin: binPath, args: (p) => [p] } };
+}
+
+test('invokeEngineAsync: child stdin is closed with EOF (does not inherit parent)', async () => {
+  if (process.platform === 'win32') return;
+
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ft-engine-stdin-'));
+  try {
+    // Script reads stdin; if EOF comes within 1s it prints "eof"; if nothing
+    // arrives within 2s it prints "hang". We want "eof".
+    const script = `#!/bin/sh
+# Read up to 100 bytes with a 2s timeout. dd reads until EOF or 2s.
+read_result=""
+if data=$(dd bs=100 count=1 2>/dev/null); then
+  if [ -z "$data" ]; then
+    echo "eof"
+  else
+    echo "data:$data"
+  fi
+else
+  echo "read-failed"
+fi
+`;
+    const engine = makeFakeEngine(tmpDir, script);
+    const { invokeEngineAsync } = await import('../src/engine.js');
+
+    const start = Date.now();
+    const out = await invokeEngineAsync(engine, 'ignored', { timeout: 10_000 });
+    const elapsed = Date.now() - start;
+
+    assert.equal(out, 'eof', `expected 'eof', got ${JSON.stringify(out)}`);
+    assert.ok(elapsed < 1_500, `should return promptly on EOF, took ${elapsed}ms`);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test('invokeEngine (sync): child stdin is closed with EOF (does not inherit parent)', async () => {
+  if (process.platform === 'win32') return;
+
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ft-engine-stdin-sync-'));
+  try {
+    const script = `#!/bin/sh
+if data=$(dd bs=100 count=1 2>/dev/null); then
+  if [ -z "$data" ]; then echo "eof"; else echo "data:$data"; fi
+else
+  echo "read-failed"
+fi
+`;
+    const engine = makeFakeEngine(tmpDir, script);
+    const { invokeEngine } = await import('../src/engine.js');
+
+    const start = Date.now();
+    const out = invokeEngine(engine, 'ignored', { timeout: 10_000 });
+    const elapsed = Date.now() - start;
+
+    assert.equal(out, 'eof', `expected 'eof', got ${JSON.stringify(out)}`);
+    assert.ok(elapsed < 1_500, `should return promptly on EOF, took ${elapsed}ms`);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test('invokeEngineAsync: non-zero exit throws EngineInvocationError with stderr content', async () => {
+  if (process.platform === 'win32') return;
+
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ft-engine-err-'));
+  try {
+    const script = `#!/bin/sh
+echo "authentication expired, run 'claude /login'" 1>&2
+exit 7
+`;
+    const engine = makeFakeEngine(tmpDir, script);
+    const { invokeEngineAsync, EngineInvocationError } = await import('../src/engine.js');
+
+    let caught: any = null;
+    try {
+      await invokeEngineAsync(engine, 'x'.repeat(5000), { timeout: 5_000 });
+    } catch (e) {
+      caught = e;
+    }
+
+    assert.ok(caught, 'expected invocation to throw');
+    assert.ok(caught instanceof EngineInvocationError, `expected EngineInvocationError, got ${caught?.constructor?.name}`);
+    assert.equal(caught.reason, 'exit');
+    assert.equal(caught.code, 7);
+    assert.equal(caught.killed, false);
+    assert.ok(caught.stderr.includes('authentication expired'), `stderr should contain real error, got: ${JSON.stringify(caught.stderr)}`);
+    // The real regression: error.message must NOT contain the full inlined prompt.
+    assert.ok(!caught.message.includes('xxxxxxxxxxxxxxxxxxxxxxx'), `message should not inline the prompt, got: ${JSON.stringify(caught.message.slice(0, 200))}`);
+    assert.ok(caught.message.includes('authentication expired'), `message should surface stderr tail, got: ${JSON.stringify(caught.message)}`);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test('invokeEngineAsync: timeout throws EngineInvocationError with reason=timeout, killed=true', async () => {
+  if (process.platform === 'win32') return;
+
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ft-engine-timeout-'));
+  try {
+    // Sleep longer than the timeout. The parent MUST kill it (otherwise
+    // the test itself would hang waiting for sleep 30).
+    const script = `#!/bin/sh
+sleep 30
+echo "should not reach"
+`;
+    const engine = makeFakeEngine(tmpDir, script);
+    const { invokeEngineAsync, EngineInvocationError } = await import('../src/engine.js');
+
+    let caught: any = null;
+    const t0 = Date.now();
+    try {
+      await invokeEngineAsync(engine, 'x'.repeat(5000), { timeout: 500 });
+    } catch (e) {
+      caught = e;
+    }
+    const elapsed = Date.now() - t0;
+
+    assert.ok(caught instanceof EngineInvocationError, `expected EngineInvocationError, got ${caught?.constructor?.name}`);
+    assert.equal(caught.reason, 'timeout');
+    assert.equal(caught.killed, true);
+    assert.ok(elapsed < 5_000, `should die near the timeout, not wait 30s: took ${elapsed}ms`);
+    // And again: the prompt must not be in .message.
+    assert.ok(!caught.message.includes('xxxxxxxxxxxxxxxxxxxxxxx'), `timeout message should not inline prompt, got: ${JSON.stringify(caught.message.slice(0, 200))}`);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test('invokeEngineAsync: spawn failure (ENOENT) throws EngineInvocationError with reason=spawn', async () => {
+  const engine = { name: 'fake', config: { bin: '/definitely/not/a/real/binary/anywhere', args: (p: string) => [p] } };
+  const { invokeEngineAsync, EngineInvocationError } = await import('../src/engine.js');
+
+  let caught: any = null;
+  try {
+    await invokeEngineAsync(engine as any, 'hi', { timeout: 5_000 });
+  } catch (e) {
+    caught = e;
+  }
+
+  assert.ok(caught instanceof EngineInvocationError);
+  assert.equal(caught.reason, 'spawn');
+  assert.equal(caught.killed, false);
+});

--- a/tests/engine.test.ts
+++ b/tests/engine.test.ts
@@ -442,3 +442,36 @@ test('invokeEngineAsync: spawn failure (ENOENT) throws EngineInvocationError wit
   assert.equal(caught.reason, 'spawn');
   assert.equal(caught.killed, false);
 });
+
+test('invokeEngineAsync: stdout exceeding maxBuffer throws reason=maxbuffer and kills child', async () => {
+  if (process.platform === 'win32') return;
+
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ft-engine-maxbuf-'));
+  try {
+    // Emit a 64KiB burst of stdout, then sleep 30s. With maxBuffer=1024
+    // the very first chunk should trip the cap and we should reject with
+    // reason='maxbuffer' well before the sleep would otherwise complete.
+    const script = `#!/bin/sh
+yes x | head -c 65536
+sleep 30
+`;
+    const engine = makeFakeEngine(tmpDir, script);
+    const { invokeEngineAsync, EngineInvocationError } = await import('../src/engine.js');
+
+    let caught: any = null;
+    const t0 = Date.now();
+    try {
+      await invokeEngineAsync(engine, 'ignored', { timeout: 10_000, maxBuffer: 1024 });
+    } catch (e) {
+      caught = e;
+    }
+    const elapsed = Date.now() - t0;
+
+    assert.ok(caught instanceof EngineInvocationError, `expected EngineInvocationError, got ${caught?.constructor?.name}`);
+    assert.equal(caught.reason, 'maxbuffer');
+    assert.equal(caught.killed, true);
+    assert.ok(elapsed < 5_000, `should trip on first over-cap chunk, not wait for sleep: took ${elapsed}ms`);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

Root-causes issue #60's \"claude authentication\" errors, which were not auth errors at all — `claude -p` was hanging on an unclosed stdin pipe, running every page to its full timeout. Ships structured engine errors so log output surfaces real signal instead of an inlined prompt, and fixes a separate \"unclassified\" placeholder bug that was also burning timeouts on every compile.

## Why the old code hung

`claude -p` reads stdin when it's not a TTY and concatenates it with the `-p` arg. The old path used `execFile(callback, ...)`, which builds its own internal stdio and **silently ignores** any `stdio` option — so we couldn't close the child's stdin through the execFile API. Older `claude` versions block on `read()` forever; newer ones eat a 3s penalty per call. Brian's log in #60 (5 pages, timeouts of 120/174/142/132/152s, total 721s — every page hit its *full* timeout) is exactly what a hung-pipe cascade looks like.

## Commits

- **`fix(wiki): close child stdin so ft wiki stops hanging on claude -p`** — swap `execFile` → `spawn` + immediate `child.stdin.end()` (async) and `spawnSync` with `input: ''` (sync). Introduces `EngineInvocationError` with structured `{ engine, bin, stderr, killed, code, signal, reason }` fields where `reason` is `'timeout' | 'maxbuffer' | 'exit' | 'spawn'`. `src/md.ts` now logs reason-derived labels (`TIMEOUT`/`OVERFLOW`/`SPAWN-FAIL`/`ERROR`) and prefers stderr tail over `.message` so `log.md` actually shows why the child died. `engineFailureHint` tailors the breaker's advice per reason — a timeout cascade now reads \"ran to the full timeout on every page — usually a hung child, not auth. Upgrade `claude` and retry\" instead of a blanket auth guess. Also excludes `'unclassified'` from `getCategoryCounts` — it's a placeholder for unclassified rows, not a real category, and it was causing `ft wiki` to queue a 0-sample page and burn an LLM timeout on it every compile.

- **`test(engine): regression for invokeEngineAsync maxBuffer path`** — adds the one missing regression test: fake engine emits 64 KiB then `sleep 30`; asserts we trip `reason='maxbuffer'` in <5s with `killed=true`. The async variant implements maxBuffer by hand (no callback-level option), and it was the only new invokeEngineAsync branch without coverage.

## Test plan

- [x] `npm run build` — clean
- [x] `npm test` — 250/250 pass (was 249 + 1 new)
- [x] New stdin-EOF tests use real `dd`-based fake engine, would catch a regression
- [x] New timeout test uses `sleep 30` with 500ms cap, asserts death in <5s
- [x] New maxBuffer test uses 64 KiB burst + `sleep 30` with 1 KiB cap, asserts death in <5s
- [x] Non-zero exit test passes a 5000-char prompt and asserts `.message` does NOT inline it
- [ ] Manual verification against real `claude 2.1.108`: the \"no stdin data received in 3s\" warning is gone (reported in original commit message)

Closes #60