### PR TITLE
fix: prevent --rebuild from instantly terminating on stale page limits

### DIFF
--- a/src/graphql-bookmarks.ts
+++ b/src/graphql-bookmarks.ts
@@ -561,7 +561,10 @@ export async function syncBookmarksGraphQL(
     result.records.forEach((r) => allSeenIds.push(r.id));
     const reachedLatestStored = Boolean(newestKnownId) && result.records.some((record) => record.id === newestKnownId);
 
-    stalePages = added === 0 ? stalePages + 1 : 0;
+    // In incremental mode, a stale page is one that didn't add any *new* bookmarks.
+    // In rebuild mode, we expect added to be 0 (just merging), so a stale page is
+    // one that returned no records at all from the API.
+    stalePages = (incremental ? added === 0 : result.records.length === 0) ? stalePages + 1 : 0;
 
     options.onProgress?.({
       page,


### PR DESCRIPTION
 ### Issue: `ft sync --rebuild` terminates instantly on first page if bookmarks already exist

 **Describe the bug**
 When running `ft sync --rebuild` on an existing cache, the sync process instantly terminates with "caught up to
 newest stored bookmark". The `--rebuild` flag is supposed to crawl the entire timeline, but because no *new*
 bookmarks are added on the first page, the `stalePages` counter triggers and halts the loop.

 **To Reproduce**
 1. Sync some bookmarks so you have a local cache.
 2. Run `ft sync --rebuild`.
 3. The command exits almost immediately after fetching the first page.

 **Expected behavior**
 In `--rebuild` mode, the sync should only be considered "stale" if the API returns 0 total records on a page, not 0
 *new* records.

 **Suggested Fix**
 In `src/graphql-bookmarks.ts`, update the `stalePages` counter logic to differentiate between incremental and
 rebuild mode:

```typescript
// In incremental mode, a stale page is one that didn't add any *new* bookmarks.
// In rebuild mode, we expect added to be 0 (just merging), so a stale page is
// one that returned no records at all from the API.
stalePages = (incremental ? added === 0 : result.records.length === 0) ? stalePages + 1 : 0;
```
