### PR TITLE
fix: expand t.co links in bookmark text using display_url

### DIFF
--- a/src/graphql-bookmarks.ts
+++ b/src/graphql-bookmarks.ts
@@ -313,7 +313,14 @@ export function convertTweetToRecord(tweetResult: any, now: string): BookmarkRec
 
   // X Articles / long-form note tweets store full text separately
   const noteTweetText = tweet?.note_tweet?.note_tweet_results?.result?.text;
-  const text = noteTweetText ?? legacy.full_text ?? legacy.text ?? '';
+  let text = noteTweetText ?? legacy.full_text ?? legacy.text ?? '';
+
+  // Expand t.co links in the text using display_url
+  for (const u of urlEntities) {
+    if (u.url && u.display_url) {
+      text = text.split(u.url).join(u.display_url);
+    }
+  }
 
   return {
     id: tweetId,

--- a/tests/graphql-bookmarks.test.ts
+++ b/tests/graphql-bookmarks.test.ts
@@ -568,6 +568,24 @@ test('sanitizeBookmarkedAt: clears GraphQL bookmark dates even when they look pl
   assert.equal(result.bookmarkedAt, null);
 });
 
+test('convertTweetToRecord: expands t.co links in full_text using display_url', () => {
+  const tr = {
+    rest_id: '1',
+    legacy: {
+      id_str: '1',
+      full_text: 'Check this: https://t.co/abc and this: https://t.co/def',
+      entities: {
+        urls: [
+          { url: 'https://t.co/abc', display_url: 'example.com/foo' },
+          { url: 'https://t.co/def', display_url: 'tools.exec.security' },
+        ],
+      },
+    },
+  };
+  const result = convertTweetToRecord(tr, NOW)!;
+  assert.equal(result.text, 'Check this: example.com/foo and this: tools.exec.security');
+});
+
 test('formatSyncResult: formats all fields', () => {
   const result = formatSyncResult({
     added: 50,


### PR DESCRIPTION
 ### Issue: Raw `t.co` links cluttering bookmark text

   **Describe the bug**
   Twitter automatically linkifies text that looks like a domain. The CLI saves the `full_text` from the API which
   contains these opaque `https://t.co/...` shortlinks instead of the actual URL the user wrote (e.g., `github.com`).
   This makes reading the text in `ft show` or `ft browse` ugly and hides the true destination.

   **To Reproduce**
   1. Bookmark a tweet that contains a raw URL like `tools.exec.security`.
   2. Run `ft sync` and then `ft show <id>`.
   3. The text shows `Check this: https://t.co/abc` instead of `Check this: tools.exec.security`.

   **Expected behavior**
   The CLI should replace `t.co` links in the tweet text with their `display_url` equivalent provided in the GraphQL
   entities payload.

   **Suggested Fix**
   In `convertTweetToRecord` (`src/graphql-bookmarks.ts`), before saving the text, map over `entities.urls` and replace the `t.co` strings with `display_url`:
```
  let text = noteTweetText ?? legacy.full_text ?? legacy.text ?? '';

  // Expand t.co links in the text using display_url
  for (const u of urlEntities) {
    if (u.url && u.display_url) {
      text = text.split(u.url).join(u.display_url);
    }
  }
```