### PR TITLE
fix(gaps): expand long-form note_tweets in ft sync and ft sync --gaps (v1.3.9)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,21 +1,21 @@
 {
-  "name": "ft-bookmarks",
-  "version": "1.3.8",
+  "name": "fieldtheory",
+  "version": "1.3.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "ft-bookmarks",
-      "version": "1.3.8",
+      "name": "fieldtheory",
+      "version": "1.3.9",
       "license": "MIT",
       "dependencies": {
         "commander": "^14.0.3",
         "dotenv": "^17.3.1",
         "sql.js": "^1.14.1",
-        "sql.js-fts5": "^1.4.0",
-        "zod": "^4.3.6"
+        "sql.js-fts5": "^1.4.0"
       },
       "bin": {
+        "fieldtheory": "bin/ft.mjs",
         "ft": "bin/ft.mjs"
       },
       "devDependencies": {
@@ -651,15 +651,6 @@
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/zod": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fieldtheory",
-  "version": "1.3.8",
+  "version": "1.3.9",
   "description": "Field Theory CLI. Self-custody for your X/Twitter bookmarks. Local sync, full-text search, classification, and terminal dashboards.",
   "type": "module",
   "bin": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -177,6 +177,11 @@ function showCachedUpdateNotice(): void {
 // ── What's new ────────────────────────────────────────────────────────────
 
 const WHATS_NEW: Record<string, string[]> = {
+  '1.3.9': [
+    'ft sync now captures full long-form note_tweets (Karpathy-style threads) instead of 275-char previews',
+    'ft sync --gaps backfills existing truncated note_tweets via an authenticated GraphQL path',
+    'ft sync --gaps is now idempotent \u2014 second runs print "No gaps found" instead of re-fetching forever',
+  ],
   '1.3.5': [
     'ft sync --folders \u2014 sync X bookmark folder tags (read-only mirror)',
     'ft sync --folder <name> \u2014 sync a single folder by name',
@@ -549,8 +554,24 @@ export function buildCli() {
             parts.push(`${elapsed}s`);
             return parts.join(' \u2502 ');
           });
+          // Parse --cookies <ct0> [auth_token] — variadic, gives us an array
+          let gapCsrfToken: string | undefined;
+          let gapCookieHeader: string | undefined;
+          if (options.cookies && Array.isArray(options.cookies) && options.cookies.length > 0) {
+            gapCsrfToken = String(options.cookies[0]);
+            const authToken = options.cookies.length > 1 ? String(options.cookies[1]) : undefined;
+            const parts = [`ct0=${gapCsrfToken}`];
+            if (authToken) parts.push(`auth_token=${authToken}`);
+            gapCookieHeader = parts.join('; ');
+          }
           const result = await runWithSpinner(spinner, () => syncGaps({
             delayMs: Number(options.delayMs) || 300,
+            browser: options.browser ? String(options.browser) : undefined,
+            chromeUserDataDir: options.chromeUserDataDir ? String(options.chromeUserDataDir) : undefined,
+            chromeProfileDirectory: options.chromeProfileDirectory ? String(options.chromeProfileDirectory) : undefined,
+            firefoxProfileDir: options.firefoxProfileDir ? String(options.firefoxProfileDir) : undefined,
+            csrfToken: gapCsrfToken,
+            cookieHeader: gapCookieHeader,
             onProgress: (progress: GapFillProgress) => {
               lastProgress = progress;
               spinner.update();

--- a/src/graphql-bookmarks.ts
+++ b/src/graphql-bookmarks.ts
@@ -17,6 +17,14 @@ const X_PUBLIC_BEARER =
 const BOOKMARKS_QUERY_ID = 'Z9GWmP0kP2dajyckAaDUBw';
 const BOOKMARKS_OPERATION = 'Bookmarks';
 
+// TweetResultByRestId — used by `--gaps` to re-fetch truncated note_tweets by
+// id. The queryId is hardcoded to match the bookmarks-feed convention; refresh
+// by searching for `operationName:"TweetResultByRestId"` inside the current
+// `abs.twimg.com/responsive-web/client-web/main.<hash>.js` bundle. Verified
+// working against Karpathy's 2039805659525644595 note_tweet on 2026-04-15.
+const TWEET_RESULT_BY_REST_ID_QUERY_ID = 'fHLDP3qFEjnTqhWBVvsREg';
+const TWEET_RESULT_BY_REST_ID_OPERATION = 'TweetResultByRestId';
+
 // ──────────────────────────────────────────────────────────────────────────
 // Folder endpoints — READ ONLY. We never POST/PUT/DELETE to X.
 // The folder feature makes exactly these two GraphQL GET calls, nothing else.
@@ -44,6 +52,7 @@ const GRAPHQL_FEATURES = {
   vibe_api_enabled: true,
   responsive_web_text_conversations_enabled: false,
   freedom_of_speech_not_reach_fetch_enabled: true,
+  longform_notetweets_consumption_enabled: true,
   longform_notetweets_rich_text_read_enabled: true,
   longform_notetweets_inline_media_enabled: true,
   responsive_web_enhance_cards_enabled: false,
@@ -290,9 +299,10 @@ export function convertTweetToRecord(tweetResult: any, now: string): BookmarkRec
       const qtUser = qtTweet?.core?.user_results?.result;
       const qtHandle = qtUser?.core?.screen_name ?? qtUser?.legacy?.screen_name;
       const qtMediaEntities = qtLegacy?.extended_entities?.media ?? qtLegacy?.entities?.media ?? [];
+      const qtNoteText = qtTweet?.note_tweet?.note_tweet_results?.result?.text;
       quotedTweet = {
         id: qtId,
-        text: qtLegacy.full_text ?? qtLegacy.text ?? '',
+        text: qtNoteText ?? qtLegacy.full_text ?? qtLegacy.text ?? '',
         authorHandle: qtHandle,
         authorName: qtUser?.core?.name ?? qtUser?.legacy?.name,
         authorProfileImageUrl:
@@ -1254,13 +1264,173 @@ export async function syncBookmarkFolders(
 
 const SYNDICATION_URL = 'https://cdn.syndication.twimg.com/tweet-result';
 
-interface SyndicationResult {
+// Features sent with TweetResultByRestId. The only one that actually matters
+// for the gap-fill bug is `longform_notetweets_consumption_enabled` — without
+// it, the response omits `note_tweet` entirely and long-form tweets come back
+// as a 275-char preview. The rest mirror what x.com's own web client sends so
+// X doesn't 400 the request for an unknown feature set.
+const TWEET_RESULT_FEATURES = {
+  creator_subscriptions_tweet_preview_api_enabled: true,
+  premium_content_api_read_enabled: true,
+  communities_web_enable_tweet_community_results_fetch: true,
+  c9s_tweet_anatomy_moderator_badge_enabled: true,
+  responsive_web_grok_analyze_button_fetch_trends_enabled: false,
+  responsive_web_grok_analyze_post_followups_enabled: false,
+  responsive_web_jetfuel_frame: false,
+  responsive_web_grok_share_attachment_enabled: false,
+  responsive_web_grok_annotations_enabled: false,
+  articles_preview_enabled: true,
+  responsive_web_edit_tweet_api_enabled: true,
+  graphql_is_translatable_rweb_tweet_is_translatable_enabled: true,
+  view_counts_everywhere_api_enabled: true,
+  longform_notetweets_consumption_enabled: true,
+  responsive_web_twitter_article_tweet_consumption_enabled: true,
+  content_disclosure_indicator_enabled: false,
+  content_disclosure_ai_generated_indicator_enabled: false,
+  responsive_web_grok_show_grok_translated_post: false,
+  responsive_web_grok_analysis_button_from_backend: false,
+  post_ctas_fetch_enabled: false,
+  rweb_cashtags_enabled: true,
+  freedom_of_speech_not_reach_fetch_enabled: true,
+  standardized_nudges_misinfo: true,
+  tweet_with_visibility_results_prefer_gql_limited_actions_policy_enabled: true,
+  longform_notetweets_rich_text_read_enabled: true,
+  longform_notetweets_inline_media_enabled: true,
+  profile_label_improvements_pcf_label_in_post_enabled: true,
+  responsive_web_profile_redirect_enabled: false,
+  rweb_tipjar_consumption_enabled: true,
+  verified_phone_label_enabled: false,
+  responsive_web_grok_image_annotation_enabled: false,
+  responsive_web_grok_imagine_annotation_enabled: false,
+  responsive_web_grok_community_note_auto_translation_is_enabled: false,
+  responsive_web_graphql_skip_user_profile_image_extensions_enabled: false,
+  responsive_web_graphql_timeline_navigation_enabled: true,
+  responsive_web_enhance_cards_enabled: false,
+};
+
+export type TweetFetchSource = 'graphql' | 'syndication';
+
+export interface TweetFetchResult {
   snapshot: QuotedTweetSnapshot | null;
   status: 'ok' | 'empty' | 'not_found' | 'forbidden' | 'rate_limited' | 'server_error' | 'error';
   httpStatus?: number;
+  /**
+   * Which backend produced this result. `'graphql'` is authoritative for
+   * note_tweet expansion; `'syndication'` cannot see note_tweet bodies and so
+   * a `'syndication'` + `'ok'` result with a 275-char preview must not be
+   * treated as settling Gap 2.
+   */
+  source?: TweetFetchSource;
 }
 
-async function fetchTweetViaSyndication(tweetId: string): Promise<SyndicationResult> {
+export function parseTweetResultByRestId(json: any, tweetId: string): QuotedTweetSnapshot | null {
+  const result = json?.data?.tweetResult?.result;
+  if (!result) return null;
+  // X may wrap the tweet inside a TweetWithVisibilityResults / TweetTombstone.
+  // Unwrap the same way the bookmarks parser does in convertTweetToRecord.
+  const tweet = result.tweet ?? result;
+  const legacy = tweet?.legacy;
+  if (!legacy) return null;
+
+  const noteText = tweet?.note_tweet?.note_tweet_results?.result?.text;
+  const text = noteText ?? legacy.full_text ?? legacy.text ?? '';
+  if (!text) return null;
+
+  const userResult = tweet?.core?.user_results?.result;
+  const handle = userResult?.core?.screen_name ?? userResult?.legacy?.screen_name;
+  const mediaEntities: any[] = legacy?.extended_entities?.media ?? legacy?.entities?.media ?? [];
+  const resolvedId = String(legacy.id_str ?? tweet?.rest_id ?? tweetId);
+
+  return {
+    id: resolvedId,
+    text,
+    authorHandle: handle,
+    authorName: userResult?.core?.name ?? userResult?.legacy?.name,
+    authorProfileImageUrl:
+      userResult?.avatar?.image_url ?? userResult?.legacy?.profile_image_url_https,
+    postedAt: legacy.created_at ?? null,
+    media: mediaEntities.map((m: any) => m.media_url_https ?? m.media_url).filter(Boolean),
+    mediaObjects: mediaEntities.map((m: any) => ({
+      type: m.type,
+      url: m.media_url_https ?? m.media_url,
+      expandedUrl: m.expanded_url,
+      width: m.original_info?.width,
+      height: m.original_info?.height,
+    })),
+    url: `https://x.com/${handle ?? '_'}/status/${resolvedId}`,
+  };
+}
+
+function buildTweetResultByRestIdUrl(tweetId: string): string {
+  const variables = {
+    tweetId,
+    withCommunity: false,
+    includePromotedContent: false,
+    withVoice: false,
+  };
+  const params = new URLSearchParams({
+    variables: JSON.stringify(variables),
+    features: JSON.stringify(TWEET_RESULT_FEATURES),
+  });
+  return `https://x.com/i/api/graphql/${TWEET_RESULT_BY_REST_ID_QUERY_ID}/${TWEET_RESULT_BY_REST_ID_OPERATION}?${params}`;
+}
+
+export async function fetchTweetByIdViaGraphQL(
+  tweetId: string,
+  csrfToken: string,
+  cookieHeader?: string,
+): Promise<TweetFetchResult> {
+  for (let attempt = 0; attempt < 4; attempt++) {
+    let response: Response;
+    try {
+      response = await fetch(buildTweetResultByRestIdUrl(tweetId), {
+        headers: buildHeaders(csrfToken, cookieHeader),
+      });
+    } catch {
+      await new Promise((r) => setTimeout(r, 2000 * (attempt + 1)));
+      continue;
+    }
+
+    if (response.ok) {
+      let json: any;
+      try {
+        json = await response.json();
+      } catch {
+        return { snapshot: null, status: 'error', source: 'graphql' };
+      }
+      // Tombstoned / deleted tweets come back with a result.__typename like
+      // TweetTombstone or TweetUnavailable and no legacy block.
+      const result = json?.data?.tweetResult?.result;
+      const typename = result?.__typename;
+      if (!result || typename === 'TweetTombstone' || typename === 'TweetUnavailable') {
+        return { snapshot: null, status: 'not_found', source: 'graphql' };
+      }
+      const snapshot = parseTweetResultByRestId(json, tweetId);
+      if (!snapshot) return { snapshot: null, status: 'empty', source: 'graphql' };
+      return { snapshot, status: 'ok', source: 'graphql' };
+    }
+
+    if (response.status === 429) {
+      await new Promise((r) => setTimeout(r, Math.min(15 * Math.pow(2, attempt), 120) * 1000));
+      continue;
+    }
+    if (response.status >= 500) {
+      await new Promise((r) => setTimeout(r, 5000 * (attempt + 1)));
+      continue;
+    }
+    if (response.status === 404) {
+      return { snapshot: null, status: 'not_found', httpStatus: 404, source: 'graphql' };
+    }
+    if (response.status === 401 || response.status === 403) {
+      return { snapshot: null, status: 'forbidden', httpStatus: response.status, source: 'graphql' };
+    }
+    // Other 4xx (400 usually means X rotated feature flags / queryId) — don't retry.
+    return { snapshot: null, status: 'error', httpStatus: response.status, source: 'graphql' };
+  }
+  return { snapshot: null, status: 'rate_limited', source: 'graphql' };
+}
+
+async function fetchTweetViaSyndication(tweetId: string): Promise<TweetFetchResult> {
   for (let attempt = 0; attempt < 4; attempt++) {
     const response = await fetch(`${SYNDICATION_URL}?id=${tweetId}&token=x`, {
       headers: {
@@ -1270,11 +1440,12 @@ async function fetchTweetViaSyndication(tweetId: string): Promise<SyndicationRes
 
     if (response.ok) {
       const data = await response.json() as any;
-      if (!data?.text) return { snapshot: null, status: 'empty' };
+      if (!data?.text) return { snapshot: null, status: 'empty', source: 'syndication' };
       const handle = data.user?.screen_name;
       const mediaEntities: any[] = data.mediaDetails ?? [];
       return {
         status: 'ok',
+        source: 'syndication',
         snapshot: {
           id: String(data.id_str ?? tweetId),
           text: data.text,
@@ -1304,13 +1475,22 @@ async function fetchTweetViaSyndication(tweetId: string): Promise<SyndicationRes
     }
     // 404/403 — tweet unavailable, don't retry
     const status = response.status === 404 ? 'not_found' as const : 'forbidden' as const;
-    return { snapshot: null, status, httpStatus: response.status };
+    return { snapshot: null, status, httpStatus: response.status, source: 'syndication' };
   }
-  return { snapshot: null, status: 'rate_limited' };
+  return { snapshot: null, status: 'rate_limited', source: 'syndication' };
 }
 
 // Text >= 275 chars may be truncated by Twitter's legacy.full_text limit
 const TRUNCATION_THRESHOLD = 275;
+
+const GAP_FILL_FAILURE_REASONS: Record<string, string> = {
+  empty: 'tweet exists but has no text content',
+  not_found: 'deleted or does not exist',
+  forbidden: 'private or suspended account',
+  rate_limited: 'rate limited after 4 retries',
+  server_error: 'X server error after 4 retries',
+  error: 'X GraphQL rejected the request (likely rotated queryId or feature flags)',
+};
 
 export interface GapFillProgress {
   done: number;
@@ -1338,21 +1518,80 @@ export interface GapFillResult {
   total: number;
 }
 
-export async function syncGaps(options?: {
+type TweetFetcher = (tweetId: string) => Promise<TweetFetchResult>;
+
+export interface SyncGapsOptions {
   onProgress?: (progress: GapFillProgress) => void;
   delayMs?: number;
-}): Promise<GapFillResult> {
-  const delayMs = options?.delayMs ?? 300;
+  /** Browser id (e.g. 'chrome', 'firefox') for cookie extraction. */
+  browser?: string;
+  chromeUserDataDir?: string;
+  chromeProfileDirectory?: string;
+  firefoxProfileDir?: string;
+  /** Direct csrf token override; skips cookie extraction. */
+  csrfToken?: string;
+  /** Direct cookie header override; skips cookie extraction. */
+  cookieHeader?: string;
+  /**
+   * Injected fetcher, used by tests. Production code should not set this —
+   * when omitted, gap-fill resolves cookies and uses TweetResultByRestId with
+   * syndication as a fallback.
+   */
+  tweetFetcher?: TweetFetcher;
+}
+
+function resolveGapFillCookies(options: SyncGapsOptions): { csrfToken?: string; cookieHeader?: string } {
+  if (options.csrfToken) {
+    return { csrfToken: options.csrfToken, cookieHeader: options.cookieHeader };
+  }
+  try {
+    const config = loadChromeSessionConfig({ browserId: options.browser });
+    if (config.browser.cookieBackend === 'firefox') {
+      const cookies = extractFirefoxXCookies(options.firefoxProfileDir);
+      return { csrfToken: cookies.csrfToken, cookieHeader: cookies.cookieHeader };
+    }
+    const chromeDir = options.chromeUserDataDir ?? config.chromeUserDataDir;
+    const chromeProfile = options.chromeProfileDirectory ?? config.chromeProfileDirectory;
+    const cookies = extractChromeXCookies(chromeDir, chromeProfile, config.browser);
+    return { csrfToken: cookies.csrfToken, cookieHeader: cookies.cookieHeader };
+  } catch {
+    // No cookies available (e.g. no browser install) — gap-fill degrades to
+    // syndication-only, which still backfills quoted-tweet metadata but cannot
+    // expand truncated note_tweets.
+    return {};
+  }
+}
+
+export async function syncGaps(options: SyncGapsOptions = {}): Promise<GapFillResult> {
+  const delayMs = options.delayMs ?? 300;
   const cachePath = twitterBookmarksCachePath();
   const loaded = sanitizeRecords(await readJsonLines<BookmarkRecord>(cachePath));
   const records = loaded.records;
 
-  // Gap 1: missing quoted tweets
-  const needsQuotedTweet = records.filter((r) => r.quotedStatusId && !r.quotedTweet);
+  const cookies = options.tweetFetcher ? {} : resolveGapFillCookies(options);
+  const fetcher: TweetFetcher = options.tweetFetcher
+    ?? (async (tweetId) => {
+      if (cookies.csrfToken) {
+        const graphqlResult = await fetchTweetByIdViaGraphQL(tweetId, cookies.csrfToken, cookies.cookieHeader);
+        // Permanent GraphQL outcomes (ok, not_found, empty) are authoritative.
+        // Transient failures (auth drift, rate limit, network) fall through to
+        // syndication so at least quoted-tweet metadata can be backfilled.
+        if (graphqlResult.status === 'ok' || graphqlResult.status === 'not_found' || graphqlResult.status === 'empty') {
+          return graphqlResult;
+        }
+      }
+      return fetchTweetViaSyndication(tweetId);
+    });
+
+  // Gap 1: missing quoted tweets. Skip records where a previous gap-fill run
+  // already tried and failed — otherwise dead tweets get re-fetched forever.
+  const needsQuotedTweet = records.filter((r) => r.quotedStatusId && !r.quotedTweet && !r.quotedTweetFailedAt);
   const quotedIds = new Set(needsQuotedTweet.map((r) => r.quotedStatusId!));
 
-  // Gap 2: potentially truncated text (articles/long notes cut off by legacy.full_text)
-  const maybeTruncated = records.filter((r) => (r.text?.length ?? 0) >= TRUNCATION_THRESHOLD);
+  // Gap 2: potentially truncated text. Skip records we've already attempted
+  // to expand — `textExpandedAt` is set regardless of outcome, so a note_tweet
+  // that's already full-length won't be re-fetched on every run.
+  const maybeTruncated = records.filter((r) => (r.text?.length ?? 0) >= TRUNCATION_THRESHOLD && !r.textExpandedAt);
   const truncatedIds = new Set(maybeTruncated.map((r) => r.tweetId));
 
   // Build lookup indexes for applying results
@@ -1383,22 +1622,20 @@ export async function syncGaps(options?: {
   // Fetch and apply incrementally
   for (let i = 0; i < allFetchIds.length; i++) {
     const tweetId = allFetchIds[i];
+    const now = new Date().toISOString();
     let snapshot: QuotedTweetSnapshot | null = null;
+    let resultStatus: TweetFetchResult['status'] = 'error';
+    let resultSource: TweetFetchSource | undefined;
     try {
-      const result = await fetchTweetViaSyndication(tweetId);
+      const result = await fetcher(tweetId);
       snapshot = result.snapshot;
+      resultStatus = result.status;
+      resultSource = result.source;
       if (!snapshot) {
         failed++;
-        const reasons: Record<string, string> = {
-          empty: 'tweet exists but has no text content',
-          not_found: 'deleted or does not exist',
-          forbidden: 'private or suspended account',
-          rate_limited: 'rate limited after 4 retries',
-          server_error: 'X server error after 4 retries',
-        };
         failures.push({
           tweetId,
-          reason: reasons[result.status] ?? result.status,
+          reason: GAP_FILL_FAILURE_REASONS[result.status] ?? result.status,
           url: `https://x.com/_/status/${tweetId}`,
         });
       }
@@ -1411,23 +1648,40 @@ export async function syncGaps(options?: {
       });
     }
 
-    // Apply immediately so progress is accurate
-    if (snapshot) {
-      // Quoted tweet gap
-      for (const record of recordsByQuotedId.get(tweetId) ?? []) {
-        if (!record.quotedTweet) {
-          record.quotedTweet = snapshot;
-          dbQuotedUpdates.push({ id: record.id, quotedTweet: snapshot });
-          quotedFetched++;
-        }
+    // A permanent negative result (deleted / forbidden / empty body) should
+    // stop re-trying the same id; transient ones (rate_limited, network) should
+    // not mark the record so the next run can retry.
+    const isPermanentFailure = resultStatus === 'not_found' || resultStatus === 'forbidden' || resultStatus === 'empty';
+
+    // Gap 1 (quoted tweet): syndication snapshots are fine here — they carry
+    // enough metadata (author, media, preview text) to make the quoted tweet
+    // useful in the UI even if a note_tweet body is cut off.
+    for (const record of recordsByQuotedId.get(tweetId) ?? []) {
+      if (snapshot && !record.quotedTweet) {
+        record.quotedTweet = snapshot;
+        dbQuotedUpdates.push({ id: record.id, quotedTweet: snapshot });
+        quotedFetched++;
+      } else if (!snapshot && isPermanentFailure) {
+        record.quotedTweetFailedAt = now;
       }
-      // Truncated text gap
-      for (const record of recordsByTweetId.get(tweetId) ?? []) {
-        if (snapshot.text.length > (record.text?.length ?? 0)) {
-          record.text = snapshot.text;
-          dbTextUpdates.push({ id: record.id, text: snapshot.text });
-          textExpanded++;
-        }
+    }
+
+    // Gap 2 (truncated text): only GraphQL can expose note_tweet bodies, so a
+    // syndication-only `ok` response with the 275-char preview must NOT mark
+    // the record as checked — otherwise a user with expired cookies (or after
+    // X rotates the queryId) permanently locks every long-form tweet into its
+    // truncated form. Mark only when GraphQL settled the question, when we
+    // genuinely expanded the text, or when the tweet is permanently gone.
+    const graphqlSettled = resultSource === 'graphql' && snapshot != null;
+    for (const record of recordsByTweetId.get(tweetId) ?? []) {
+      const didExpand = snapshot != null && snapshot.text.length > (record.text?.length ?? 0);
+      if (didExpand) {
+        record.text = snapshot!.text;
+        dbTextUpdates.push({ id: record.id, text: snapshot!.text });
+        textExpanded++;
+      }
+      if (didExpand || graphqlSettled || isPermanentFailure) {
+        record.textExpandedAt = now;
       }
     }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -83,6 +83,19 @@ export interface BookmarkRecord {
   /** Parallel arrays of folder IDs and display names this bookmark is in on X. */
   folderIds?: string[];
   folderNames?: string[];
+  /**
+   * Set once `ft sync --gaps` has attempted to expand long-form text for this
+   * record. Present regardless of whether expansion actually lengthened the
+   * stored text — its purpose is to keep the gap-fill selector idempotent so
+   * subsequent runs don't re-fetch the same records forever.
+   */
+  textExpandedAt?: string;
+  /**
+   * Set when gap-fill tried to backfill the quoted tweet for this record and
+   * failed permanently (deleted, forbidden, empty body). Prevents retrying the
+   * same dead tweet on every run.
+   */
+  quotedTweetFailedAt?: string;
 }
 
 export interface BookmarkFolder {

--- a/tests/fixtures/bookmark-feed-note-tweet.json
+++ b/tests/fixtures/bookmark-feed-note-tweet.json
@@ -1,0 +1,88 @@
+{
+  "data": {
+    "bookmark_timeline_v2": {
+      "timeline": {
+        "instructions": [
+          {
+            "type": "TimelineAddEntries",
+            "entries": [
+              {
+                "entryId": "tweet-2039805659525644595",
+                "sortIndex": "1825000000000000000",
+                "content": {
+                  "entryType": "TimelineTimelineItem",
+                  "itemContent": {
+                    "itemType": "TimelineTweet",
+                    "tweet_results": {
+                      "result": {
+                        "__typename": "Tweet",
+                        "rest_id": "2039805659525644595",
+                        "core": {
+                          "user_results": {
+                            "result": {
+                              "rest_id": "33836629",
+                              "core": {
+                                "created_at": "Tue Apr 21 06:49:15 +0000 2009",
+                                "name": "Andrej Karpathy",
+                                "screen_name": "karpathy"
+                              },
+                              "avatar": {
+                                "image_url": "https://pbs.twimg.com/profile_images/1296667294148382721/9Pr6XrPB_normal.jpg"
+                              },
+                              "legacy": {}
+                            }
+                          }
+                        },
+                        "note_tweet": {
+                          "is_expandable": true,
+                          "note_tweet_results": {
+                            "result": {
+                              "id": "Tm90ZVR3ZWV0OjIwMzk4MDU2NTkxOTg0MzUzMjg=",
+                              "text": "LLM Knowledge Bases\n\nSomething I'm finding very useful recently: using LLMs to build personal knowledge bases for various topics of research interest. In this way, a large fraction of my recent token throughput is going less into manipulating code, and more into manipulating knowledge (stored as markdown and images). The latest LLMs are quite good at it. So:\n\nData ingest:\nI index source documents (articles, papers, repos, datasets, images, etc.) into a raw/ directory, then I use an LLM to incrementally \"compile\" a wiki, which is just a collection of .md files in a directory structure. The wiki includes summaries of all the data in raw/, backlinks, and then it categorizes data into concepts, writes articles for them, and links them all. To convert web articles into .md files I like to use the Obsidian Web Clipper extension, and then I also use a hotkey to download all the related images to local so that my LLM can easily reference them.\n\nIDE:\nI use Obsidian as the IDE \"frontend\" where I can view the raw data, the the compiled wiki, and the derived visualizations. Important to note that the LLM writes and maintains all of the data of the wiki, I rarely touch it directly. I've played with a few Obsidian plugins to render and view data in other ways (e.g. Marp for slides).\n\nQ&A:\nWhere things get interesting is that once your wiki is big enough (e.g. mine on some recent research is ~100 articles and ~400K words), you can ask your LLM agent all kinds of complex questions against the wiki, and it will go off, research the answers, etc. I thought I had to reach for fancy RAG, but the LLM has been pretty good about auto-maintaining index files and brief summaries of all the documents and it reads all the important related data fairly easily at this ~small scale.\n\nOutput:\nInstead of getting answers in text/terminal, I like to have it render markdown files for me, or slide shows (Marp format), or matplotlib images, all of which I then view again in Obsidian. You can imagine many other visual output formats depending on the query. Often, I end up \"filing\" the outputs back into the wiki to enhance it for further queries. So my own explorations and queries always \"add up\" in the knowledge base.\n\nLinting:\nI've run some LLM \"health checks\" over the wiki to e.g. find inconsistent data, impute missing data (with web searchers), find interesting connections for new article candidates, etc., to incrementally clean up the wiki and enhance its overall data integrity. The LLMs are quite good at suggesting further questions to ask and look into.\n\nExtra tools:\nI find myself developing additional tools to process the data, e.g. I vibe coded a small and naive search engine over the wiki, which I both use directly (in a web ui), but more often I want to hand it off to an LLM via CLI as a tool for larger queries. \n\nFurther explorations:\nAs the repo grows, the natural desire is to also think about synthetic data generation + finetuning to have your LLM \"know\" the data in its weights instead of just context windows.\n\nTLDR: raw data from a given number of sources is collected, then compiled by an LLM into a .md wiki, then operated on by various CLIs by the LLM to do Q&A and to incrementally enhance the wiki, and all of it viewable in Obsidian. You rarely ever write or edit the wiki manually, it's the domain of the LLM. I think there is room here for an incredible new product instead of a hacky collection of scripts.",
+                              "entity_set": {
+                                "hashtags": [],
+                                "symbols": [],
+                                "urls": [],
+                                "user_mentions": []
+                              }
+                            }
+                          }
+                        },
+                        "legacy": {
+                          "id_str": "2039805659525644595",
+                          "full_text": "LLM Knowledge Bases\n\nSomething I'm finding very useful recently: using LLMs to build personal knowledge bases for various topics of research interest. In this way, a large fraction of my recent token throughput is going less into manipulating code, and more into manipulating",
+                          "created_at": "Thu Apr 02 20:42:21 +0000 2026",
+                          "lang": "en",
+                          "favorite_count": 56029,
+                          "retweet_count": 6674,
+                          "reply_count": 2759,
+                          "quote_count": 1966,
+                          "bookmark_count": 101751,
+                          "conversation_id_str": "2039805659525644595",
+                          "entities": {
+                            "urls": [],
+                            "user_mentions": []
+                          }
+                        },
+                        "views": {
+                          "count": "19897360",
+                          "state": "EnabledWithCount"
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "entryId": "cursor-bottom-xyz",
+                "content": {
+                  "value": "DAACCgACEgUT6sAAKgAA"
+                }
+              }
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/tests/fixtures/tweet-result-by-rest-id-note-tweet.json
+++ b/tests/fixtures/tweet-result-by-rest-id-note-tweet.json
@@ -1,0 +1,61 @@
+{
+  "data": {
+    "tweetResult": {
+      "result": {
+        "__typename": "Tweet",
+        "rest_id": "2039805659525644595",
+        "core": {
+          "user_results": {
+            "result": {
+              "rest_id": "33836629",
+              "core": {
+                "created_at": "Tue Apr 21 06:49:15 +0000 2009",
+                "name": "Andrej Karpathy",
+                "screen_name": "karpathy"
+              },
+              "avatar": {
+                "image_url": "https://pbs.twimg.com/profile_images/1296667294148382721/9Pr6XrPB_normal.jpg"
+              },
+              "legacy": {}
+            }
+          }
+        },
+        "note_tweet": {
+          "is_expandable": true,
+          "note_tweet_results": {
+            "result": {
+              "id": "Tm90ZVR3ZWV0OjIwMzk4MDU2NTkxOTg0MzUzMjg=",
+              "text": "LLM Knowledge Bases\n\nSomething I'm finding very useful recently: using LLMs to build personal knowledge bases for various topics of research interest. In this way, a large fraction of my recent token throughput is going less into manipulating code, and more into manipulating knowledge (stored as markdown and images). The latest LLMs are quite good at it. So:\n\nData ingest:\nI index source documents (articles, papers, repos, datasets, images, etc.) into a raw/ directory, then I use an LLM to incrementally \"compile\" a wiki, which is just a collection of .md files in a directory structure. The wiki includes summaries of all the data in raw/, backlinks, and then it categorizes data into concepts, writes articles for them, and links them all. To convert web articles into .md files I like to use the Obsidian Web Clipper extension, and then I also use a hotkey to download all the related images to local so that my LLM can easily reference them.\n\nIDE:\nI use Obsidian as the IDE \"frontend\" where I can view the raw data, the the compiled wiki, and the derived visualizations. Important to note that the LLM writes and maintains all of the data of the wiki, I rarely touch it directly. I've played with a few Obsidian plugins to render and view data in other ways (e.g. Marp for slides).\n\nQ&A:\nWhere things get interesting is that once your wiki is big enough (e.g. mine on some recent research is ~100 articles and ~400K words), you can ask your LLM agent all kinds of complex questions against the wiki, and it will go off, research the answers, etc. I thought I had to reach for fancy RAG, but the LLM has been pretty good about auto-maintaining index files and brief summaries of all the documents and it reads all the important related data fairly easily at this ~small scale.\n\nOutput:\nInstead of getting answers in text/terminal, I like to have it render markdown files for me, or slide shows (Marp format), or matplotlib images, all of which I then view again in Obsidian. You can imagine many other visual output formats depending on the query. Often, I end up \"filing\" the outputs back into the wiki to enhance it for further queries. So my own explorations and queries always \"add up\" in the knowledge base.\n\nLinting:\nI've run some LLM \"health checks\" over the wiki to e.g. find inconsistent data, impute missing data (with web searchers), find interesting connections for new article candidates, etc., to incrementally clean up the wiki and enhance its overall data integrity. The LLMs are quite good at suggesting further questions to ask and look into.\n\nExtra tools:\nI find myself developing additional tools to process the data, e.g. I vibe coded a small and naive search engine over the wiki, which I both use directly (in a web ui), but more often I want to hand it off to an LLM via CLI as a tool for larger queries. \n\nFurther explorations:\nAs the repo grows, the natural desire is to also think about synthetic data generation + finetuning to have your LLM \"know\" the data in its weights instead of just context windows.\n\nTLDR: raw data from a given number of sources is collected, then compiled by an LLM into a .md wiki, then operated on by various CLIs by the LLM to do Q&A and to incrementally enhance the wiki, and all of it viewable in Obsidian. You rarely ever write or edit the wiki manually, it's the domain of the LLM. I think there is room here for an incredible new product instead of a hacky collection of scripts.",
+              "entity_set": {
+                "hashtags": [],
+                "symbols": [],
+                "urls": [],
+                "user_mentions": []
+              }
+            }
+          }
+        },
+        "legacy": {
+          "id_str": "2039805659525644595",
+          "full_text": "LLM Knowledge Bases\n\nSomething I'm finding very useful recently: using LLMs to build personal knowledge bases for various topics of research interest. In this way, a large fraction of my recent token throughput is going less into manipulating code, and more into manipulating",
+          "created_at": "Thu Apr 02 20:42:21 +0000 2026",
+          "lang": "en",
+          "favorite_count": 56029,
+          "retweet_count": 6674,
+          "reply_count": 2759,
+          "quote_count": 1966,
+          "bookmark_count": 101751,
+          "conversation_id_str": "2039805659525644595",
+          "entities": {
+            "urls": [],
+            "user_mentions": []
+          }
+        },
+        "views": {
+          "count": "19897360",
+          "state": "EnabledWithCount"
+        }
+      }
+    }
+  }
+}

--- a/tests/graphql-bookmarks.test.ts
+++ b/tests/graphql-bookmarks.test.ts
@@ -1,9 +1,15 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import { mkdtemp, readFile, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
 import {
   convertTweetToRecord,
   parseBookmarksResponse,
   parseFolderTimelineResponse,
+  parseTweetResultByRestId,
   sanitizeBookmarkedAt,
   scoreRecord,
   mergeBookmarkRecord,
@@ -11,9 +17,16 @@ import {
   applyFolderMirror,
   clearFolderEverywhere,
   formatSyncResult,
+  syncGaps,
 } from '../src/graphql-bookmarks.js';
+import { buildIndex, getBookmarkById } from '../src/bookmarks-db.js';
 import { resolveFolder, formatFolderMirrorStats } from '../src/cli.js';
 import type { BookmarkFolder, BookmarkRecord } from '../src/types.js';
+
+const FIXTURES_DIR = path.join(path.dirname(fileURLToPath(import.meta.url)), 'fixtures');
+function loadFixture(name: string): any {
+  return JSON.parse(readFileSync(path.join(FIXTURES_DIR, name), 'utf8'));
+}
 
 const NOW = '2026-03-28T00:00:00.000Z';
 
@@ -300,6 +313,312 @@ test('convertTweetToRecord: handles missing quoted tweet gracefully', () => {
   assert.ok(result);
   assert.equal(result.quotedStatusId, '7777777');
   assert.equal(result.quotedTweet, undefined);
+});
+
+test('convertTweetToRecord: quoted tweet prefers note_tweet body over legacy full_text', () => {
+  const tr = makeTweetResult({
+    legacy: { quoted_status_id_str: '8888888' },
+    tweet: {
+      quoted_status_result: {
+        result: {
+          rest_id: '8888888',
+          note_tweet: {
+            note_tweet_results: {
+              result: {
+                text: 'Full long-form quoted body that would be truncated in legacy.full_text',
+              },
+            },
+          },
+          legacy: {
+            id_str: '8888888',
+            full_text: 'Full long-form quoted body that would be truncated in',
+            created_at: 'Mon Apr 13 10:00:00 +0000 2026',
+            entities: { urls: [] },
+          },
+          core: {
+            user_results: {
+              result: {
+                rest_id: '9999',
+                core: { screen_name: 'longform', name: 'Long Form' },
+                legacy: {},
+              },
+            },
+          },
+        },
+      },
+    },
+  });
+  const result = convertTweetToRecord(tr, NOW);
+  assert.ok(result);
+  assert.equal(
+    result.quotedTweet!.text,
+    'Full long-form quoted body that would be truncated in legacy.full_text',
+  );
+});
+
+test('parseBookmarksResponse: captures full note_tweet body from live bookmarks-feed fixture', () => {
+  const fixture = loadFixture('bookmark-feed-note-tweet.json');
+  const { records } = parseBookmarksResponse(fixture, NOW);
+  assert.equal(records.length, 1);
+  const record = records[0];
+  assert.equal(record.tweetId, '2039805659525644595');
+  assert.equal(record.authorHandle, 'karpathy');
+  // The whole point of the feature-flag fix: a long note_tweet must land in
+  // `text` as the full body, not the 275-char preview from legacy.full_text.
+  assert.equal(record.text.length, 3447);
+  assert.ok(record.text.startsWith('LLM Knowledge Bases'));
+  assert.ok(record.text.endsWith('hacky collection of scripts.'));
+});
+
+test('parseTweetResultByRestId: extracts note_tweet body from live TweetResultByRestId fixture', () => {
+  const fixture = loadFixture('tweet-result-by-rest-id-note-tweet.json');
+  const snapshot = parseTweetResultByRestId(fixture, '2039805659525644595');
+  assert.ok(snapshot);
+  assert.equal(snapshot.id, '2039805659525644595');
+  assert.equal(snapshot.authorHandle, 'karpathy');
+  assert.equal(snapshot.text.length, 3447);
+  assert.ok(snapshot.text.startsWith('LLM Knowledge Bases'));
+});
+
+test('parseTweetResultByRestId: returns null on tombstone / unavailable tweets', () => {
+  assert.equal(
+    parseTweetResultByRestId({ data: { tweetResult: { result: { __typename: 'TweetTombstone' } } } }, '123'),
+    null,
+  );
+});
+
+async function withIsolatedGapFillDataDir(
+  fn: () => Promise<void>,
+  fixtures: BookmarkRecord[],
+): Promise<void> {
+  const dir = await mkdtemp(path.join(tmpdir(), 'ft-gaps-test-'));
+  const jsonl = fixtures.map((r) => JSON.stringify(r)).join('\n') + '\n';
+  await writeFile(path.join(dir, 'bookmarks.jsonl'), jsonl);
+  const savedDataDir = process.env.FT_DATA_DIR;
+  const savedChromeDir = process.env.FT_CHROME_USER_DATA_DIR;
+  process.env.FT_DATA_DIR = dir;
+  // Point Chrome extraction at an empty path so resolveGapFillCookies fails
+  // fast and the fetcher falls back cleanly when we aren't injecting one.
+  process.env.FT_CHROME_USER_DATA_DIR = path.join(dir, '__no_chrome__');
+  try {
+    await fn();
+  } finally {
+    if (savedDataDir !== undefined) process.env.FT_DATA_DIR = savedDataDir;
+    else delete process.env.FT_DATA_DIR;
+    if (savedChromeDir !== undefined) process.env.FT_CHROME_USER_DATA_DIR = savedChromeDir;
+    else delete process.env.FT_CHROME_USER_DATA_DIR;
+  }
+}
+
+test('syncGaps: expands truncated note_tweet and stamps textExpandedAt', async () => {
+  const fixture = loadFixture('tweet-result-by-rest-id-note-tweet.json');
+  const legacyPreview: string = fixture.data.tweetResult.result.legacy.full_text;
+  const fullBody: string = fixture.data.tweetResult.result.note_tweet.note_tweet_results.result.text;
+
+  const truncated: BookmarkRecord = {
+    id: '2039805659525644595',
+    tweetId: '2039805659525644595',
+    url: 'https://x.com/karpathy/status/2039805659525644595',
+    text: legacyPreview,
+    authorHandle: 'karpathy',
+    syncedAt: NOW,
+    postedAt: '2026-04-02T20:42:21.000Z',
+    language: 'en',
+    tags: [],
+    ingestedVia: 'graphql',
+  };
+
+  await withIsolatedGapFillDataDir(async () => {
+    await buildIndex();
+    let fetchCalls = 0;
+    const result = await syncGaps({
+      tweetFetcher: async (tweetId) => {
+        fetchCalls += 1;
+        assert.equal(tweetId, '2039805659525644595');
+        return { snapshot: parseTweetResultByRestId(fixture, tweetId), status: 'ok', source: 'graphql' };
+      },
+    });
+
+    assert.equal(fetchCalls, 1);
+    assert.equal(result.textExpanded, 1);
+    assert.equal(result.failed, 0);
+
+    const refreshed = await getBookmarkById('2039805659525644595');
+    assert.ok(refreshed);
+    assert.equal(refreshed.text.length, fullBody.length);
+    assert.ok(refreshed.text.startsWith('LLM Knowledge Bases'));
+
+    // Marker should land in the JSONL so the next run skips this record.
+    const jsonl = await readFile(path.join(process.env.FT_DATA_DIR!, 'bookmarks.jsonl'), 'utf8');
+    const stored = JSON.parse(jsonl.trim().split('\n').pop()!);
+    assert.ok(stored.textExpandedAt, 'textExpandedAt should be set after expansion');
+    assert.equal(stored.text.length, fullBody.length);
+  }, [truncated]);
+});
+
+test('syncGaps: skips records that already have textExpandedAt set', async () => {
+  const alreadyChecked: BookmarkRecord = {
+    id: '111',
+    tweetId: '111',
+    url: 'https://x.com/user/status/111',
+    text: 'x'.repeat(280),
+    syncedAt: NOW,
+    tags: [],
+    ingestedVia: 'graphql',
+    textExpandedAt: '2026-04-14T00:00:00.000Z',
+  };
+
+  await withIsolatedGapFillDataDir(async () => {
+    let fetchCalls = 0;
+    const result = await syncGaps({
+      tweetFetcher: async () => {
+        fetchCalls += 1;
+        return { snapshot: null, status: 'ok' };
+      },
+    });
+    assert.equal(fetchCalls, 0, 'fetcher should not run when all records are already marked');
+    assert.equal(result.textExpanded, 0);
+    assert.equal(result.failed, 0);
+    assert.equal(result.total, 0, 'empty gap-fill should report total=0 so CLI prints "No gaps found"');
+  }, [alreadyChecked]);
+});
+
+test('syncGaps: syndication "ok" with truncated preview does NOT stamp textExpandedAt', async () => {
+  // Regression for the bug where a user with expired cookies (graphql falls
+  // through to syndication) would have every long note_tweet permanently
+  // marked as checked even though syndication can't see note_tweet bodies.
+  const truncated: BookmarkRecord = {
+    id: '444',
+    tweetId: '444',
+    url: 'https://x.com/user/status/444',
+    text: 'z'.repeat(280),
+    syncedAt: NOW,
+    tags: [],
+    ingestedVia: 'graphql',
+  };
+
+  await withIsolatedGapFillDataDir(async () => {
+    const result = await syncGaps({
+      tweetFetcher: async () => ({
+        snapshot: {
+          id: '444',
+          text: 'z'.repeat(280),
+          url: 'https://x.com/user/status/444',
+        },
+        status: 'ok',
+        source: 'syndication',
+      }),
+    });
+    assert.equal(result.textExpanded, 0);
+
+    const jsonl = await readFile(path.join(process.env.FT_DATA_DIR!, 'bookmarks.jsonl'), 'utf8');
+    const stored = JSON.parse(jsonl.trim().split('\n').pop()!);
+    assert.equal(
+      stored.textExpandedAt,
+      undefined,
+      'syndication cannot settle Gap 2 — record must remain unmarked so graphql can try next run',
+    );
+  }, [truncated]);
+});
+
+test('syncGaps: syndication snapshot with genuinely longer text still expands and stamps', async () => {
+  // Defensive corner: if syndication somehow returns a longer text than what
+  // we had cached (non-note_tweet edge case), that IS real new information —
+  // apply it and mark checked.
+  const stale: BookmarkRecord = {
+    id: '555',
+    tweetId: '555',
+    url: 'https://x.com/user/status/555',
+    text: 'short cached preview that is exactly 275 characters long '.repeat(5).slice(0, 275),
+    syncedAt: NOW,
+    tags: [],
+    ingestedVia: 'graphql',
+  };
+
+  await withIsolatedGapFillDataDir(async () => {
+    await buildIndex();
+    const longer = 'x'.repeat(400);
+    const result = await syncGaps({
+      tweetFetcher: async () => ({
+        snapshot: { id: '555', text: longer, url: 'https://x.com/user/status/555' },
+        status: 'ok',
+        source: 'syndication',
+      }),
+    });
+    assert.equal(result.textExpanded, 1);
+
+    const jsonl = await readFile(path.join(process.env.FT_DATA_DIR!, 'bookmarks.jsonl'), 'utf8');
+    const stored = JSON.parse(jsonl.trim().split('\n').pop()!);
+    assert.equal(stored.text.length, 400);
+    assert.ok(stored.textExpandedAt);
+  }, [stale]);
+});
+
+test('syncGaps: transient failure does NOT stamp textExpandedAt so next run retries', async () => {
+  const truncated: BookmarkRecord = {
+    id: '333',
+    tweetId: '333',
+    url: 'https://x.com/user/status/333',
+    text: 'y'.repeat(300),
+    syncedAt: NOW,
+    tags: [],
+    ingestedVia: 'graphql',
+  };
+
+  await withIsolatedGapFillDataDir(async () => {
+    const result = await syncGaps({
+      tweetFetcher: async () => ({ snapshot: null, status: 'rate_limited' }),
+    });
+    assert.equal(result.failed, 1);
+
+    const jsonl = await readFile(path.join(process.env.FT_DATA_DIR!, 'bookmarks.jsonl'), 'utf8');
+    const stored = JSON.parse(jsonl.trim().split('\n').pop()!);
+    assert.equal(
+      stored.textExpandedAt,
+      undefined,
+      'transient failures must not mark the record so the next run can retry',
+    );
+  }, [truncated]);
+});
+
+test('syncGaps: permanent quoted-tweet failure stamps quotedTweetFailedAt so reruns skip it', async () => {
+  const deadQuoted: BookmarkRecord = {
+    id: '222',
+    tweetId: '222',
+    url: 'https://x.com/user/status/222',
+    text: 'Check out this tweet',
+    syncedAt: NOW,
+    tags: [],
+    ingestedVia: 'graphql',
+    quotedStatusId: '999999999',
+  };
+
+  await withIsolatedGapFillDataDir(async () => {
+    let fetchCalls = 0;
+    const firstRun = await syncGaps({
+      tweetFetcher: async () => {
+        fetchCalls += 1;
+        return { snapshot: null, status: 'not_found' };
+      },
+    });
+    assert.equal(fetchCalls, 1);
+    assert.equal(firstRun.failed, 1);
+
+    const jsonl = await readFile(path.join(process.env.FT_DATA_DIR!, 'bookmarks.jsonl'), 'utf8');
+    const stored = JSON.parse(jsonl.trim().split('\n').pop()!);
+    assert.ok(stored.quotedTweetFailedAt, 'quotedTweetFailedAt should be set after permanent failure');
+
+    // Second run should not touch the fetcher for this record.
+    const secondCalls = { n: 0 };
+    const secondRun = await syncGaps({
+      tweetFetcher: async () => {
+        secondCalls.n += 1;
+        return { snapshot: null, status: 'not_found' };
+      },
+    });
+    assert.equal(secondCalls.n, 0, 'second run must not retry permanent failures');
+    assert.equal(secondRun.total, 0);
+  }, [deadQuoted]);
 });
 
 test('parseBookmarksResponse: preserves sortIndex for bookmark ordering without fabricating bookmarkedAt', () => {


### PR DESCRIPTION
## Summary

- `ft sync` now captures full long-form note_tweets instead of 275-char previews (missing `longform_notetweets_consumption_enabled` feature flag)
- `ft sync --gaps` backfills existing truncated records via authenticated GraphQL (`TweetResultByRestId`), with syndication as a fallback
- `ft sync --gaps` is now idempotent — second runs skip already-checked records instead of re-fetching forever

## Details

- Quoted-tweet extraction also reads `note_tweet` body, symmetric with main-tweet path
- New `textExpandedAt` / `quotedTweetFailedAt` markers on `BookmarkRecord` (JSONL-only, additive) prevent re-processing
- Syndication returning a 275-char preview no longer falsely marks a record as checked — only GraphQL results are authoritative for text expansion
- CLI `--browser` / `--cookies` / profile options now thread through to `--gaps`
- 10 new tests, 266/266 passing

## Test plan

- [ ] `npm test`
- [ ] `ft sync` captures full note_tweets on new syncs
- [ ] `ft sync --gaps` expands existing truncated records
- [ ] `ft sync --gaps` again prints "No gaps found"