### PR TITLE
fix: surface classification progress in ft status

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ On first run, `ft sync` extracts your X session from Chrome and downloads your b
 |---------|-------------|
 | `ft index` | Rebuild search index from JSONL cache (preserves classifications) |
 | `ft fetch-media` | Download media assets (static images only) |
-| `ft status` | Show sync status and data location |
+| `ft status` | Show sync status, classification progress, and data location |
 | `ft path` | Print data directory path |
 
 ## Agent integration

--- a/src/bookmark-classify-llm.ts
+++ b/src/bookmark-classify-llm.ts
@@ -20,6 +20,11 @@ export interface ClassificationLock {
   startedAt: string;
 }
 
+type ClassificationLockReadResult =
+  | { state: 'missing' }
+  | { state: 'initializing' }
+  | { state: 'active'; lock: ClassificationLock };
+
 interface UnclassifiedBookmark {
   id: string;
   text: string;
@@ -116,6 +121,8 @@ export interface LlmClassifyResult {
   batches: number;
 }
 
+const CLASSIFICATION_LOCK_PARSE_GRACE_MS = 5_000;
+
 function isProcessAlive(pid: number): boolean {
   if (!Number.isInteger(pid) || pid <= 0) return false;
   try {
@@ -126,9 +133,9 @@ function isProcessAlive(pid: number): boolean {
   }
 }
 
-export function readClassificationLock(): ClassificationLock | null {
+function readClassificationLockState(): ClassificationLockReadResult {
   const lockPath = classificationLockPath();
-  if (!fs.existsSync(lockPath)) return null;
+  if (!fs.existsSync(lockPath)) return { state: 'missing' };
 
   try {
     const raw = JSON.parse(fs.readFileSync(lockPath, 'utf8')) as Partial<ClassificationLock>;
@@ -137,24 +144,40 @@ export function readClassificationLock(): ClassificationLock | null {
       (raw.kind !== 'classify' && raw.kind !== 'classify-domains') ||
       typeof raw.startedAt !== 'string'
     ) {
+      const ageMs = Date.now() - fs.statSync(lockPath).mtimeMs;
+      if (ageMs <= CLASSIFICATION_LOCK_PARSE_GRACE_MS) {
+        return { state: 'initializing' };
+      }
       fs.rmSync(lockPath, { force: true });
-      return null;
+      return { state: 'missing' };
     }
 
     if (!isProcessAlive(raw.pid)) {
       fs.rmSync(lockPath, { force: true });
-      return null;
+      return { state: 'missing' };
     }
 
     return {
-      pid: raw.pid,
-      kind: raw.kind,
-      startedAt: raw.startedAt,
+      state: 'active',
+      lock: {
+        pid: raw.pid,
+        kind: raw.kind,
+        startedAt: raw.startedAt,
+      },
     };
   } catch {
+    const ageMs = Date.now() - fs.statSync(lockPath).mtimeMs;
+    if (ageMs <= CLASSIFICATION_LOCK_PARSE_GRACE_MS) {
+      return { state: 'initializing' };
+    }
     fs.rmSync(lockPath, { force: true });
-    return null;
+    return { state: 'missing' };
   }
+}
+
+export function readClassificationLock(): ClassificationLock | null {
+  const result = readClassificationLockState();
+  return result.state === 'active' ? result.lock : null;
 }
 
 function removeClassificationLock(lock: ClassificationLock): void {
@@ -197,9 +220,12 @@ export async function withClassificationLock<T>(
         throw error;
       }
 
-      const existing = readClassificationLock();
-      if (existing) {
-        throw new Error(`Classification already running (${existing.kind}, pid ${existing.pid})`);
+      const existing = readClassificationLockState();
+      if (existing.state === 'active') {
+        throw new Error(`Classification already running (${existing.lock.kind}, pid ${existing.lock.pid})`);
+      }
+      if (existing.state === 'initializing') {
+        throw new Error('Classification already running (lock file initializing)');
       }
 
       fs.rmSync(classificationLockPath(), { force: true });

--- a/src/bookmark-classify-llm.ts
+++ b/src/bookmark-classify-llm.ts
@@ -6,12 +6,19 @@
  * No API keys needed. No local models. Just a logged-in Claude or Codex CLI.
  */
 
+import fs from 'node:fs';
 import { openDb, saveDb } from './db.js';
-import { twitterBookmarksIndexPath } from './paths.js';
+import { classificationLockPath, ensureDataDir, twitterBookmarksIndexPath } from './paths.js';
 import type { ResolvedEngine } from './engine.js';
 import { invokeEngine } from './engine.js';
 
 const BATCH_SIZE = 50;
+
+export interface ClassificationLock {
+  pid: number;
+  kind: 'classify' | 'classify-domains';
+  startedAt: string;
+}
 
 interface UnclassifiedBookmark {
   id: string;
@@ -107,6 +114,101 @@ export interface LlmClassifyResult {
   classified: number;
   failed: number;
   batches: number;
+}
+
+function isProcessAlive(pid: number): boolean {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function readClassificationLock(): ClassificationLock | null {
+  const lockPath = classificationLockPath();
+  if (!fs.existsSync(lockPath)) return null;
+
+  try {
+    const raw = JSON.parse(fs.readFileSync(lockPath, 'utf8')) as Partial<ClassificationLock>;
+    if (
+      typeof raw.pid !== 'number' ||
+      (raw.kind !== 'classify' && raw.kind !== 'classify-domains') ||
+      typeof raw.startedAt !== 'string'
+    ) {
+      fs.rmSync(lockPath, { force: true });
+      return null;
+    }
+
+    if (!isProcessAlive(raw.pid)) {
+      fs.rmSync(lockPath, { force: true });
+      return null;
+    }
+
+    return {
+      pid: raw.pid,
+      kind: raw.kind,
+      startedAt: raw.startedAt,
+    };
+  } catch {
+    fs.rmSync(lockPath, { force: true });
+    return null;
+  }
+}
+
+function removeClassificationLock(lock: ClassificationLock): void {
+  const current = readClassificationLock();
+  if (
+    current?.pid === lock.pid &&
+    current.kind === lock.kind &&
+    current.startedAt === lock.startedAt
+  ) {
+    fs.rmSync(classificationLockPath(), { force: true });
+  }
+}
+
+function tryWriteClassificationLock(lock: ClassificationLock): void {
+  ensureDataDir();
+  const fd = fs.openSync(classificationLockPath(), 'wx', 0o600);
+  try {
+    fs.writeFileSync(fd, `${JSON.stringify(lock, null, 2)}\n`, 'utf8');
+  } finally {
+    fs.closeSync(fd);
+  }
+}
+
+export async function withClassificationLock<T>(
+  kind: 'classify' | 'classify-domains',
+  fn: () => Promise<T>,
+): Promise<T> {
+  const lock: ClassificationLock = {
+    pid: process.pid,
+    kind,
+    startedAt: new Date().toISOString(),
+  };
+
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    try {
+      tryWriteClassificationLock(lock);
+      return await fn();
+    } catch (error: any) {
+      if (error?.code !== 'EEXIST') {
+        throw error;
+      }
+
+      const existing = readClassificationLock();
+      if (existing) {
+        throw new Error(`Classification already running (${existing.kind}, pid ${existing.pid})`);
+      }
+
+      fs.rmSync(classificationLockPath(), { force: true });
+    } finally {
+      removeClassificationLock(lock);
+    }
+  }
+
+  throw new Error('Unable to acquire classification lock');
 }
 
 export async function classifyWithLlm(

--- a/src/bookmark-classify-llm.ts
+++ b/src/bookmark-classify-llm.ts
@@ -6,7 +6,9 @@
  * No API keys needed. No local models. Just a logged-in Claude or Codex CLI.
  */
 
+import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
+import winPath from 'node:path/win32';
 import { openDb, saveDb } from './db.js';
 import { classificationLockPath, ensureDataDir, twitterBookmarksIndexPath } from './paths.js';
 import type { ResolvedEngine } from './engine.js';
@@ -18,6 +20,7 @@ export interface ClassificationLock {
   pid: number;
   kind: 'classify' | 'classify-domains';
   startedAt: string;
+  processStartedAt: string;
 }
 
 type ClassificationLockReadResult =
@@ -123,6 +126,68 @@ export interface LlmClassifyResult {
 
 const CLASSIFICATION_LOCK_PARSE_GRACE_MS = 5_000;
 
+function toIsoSecond(timestampMs: number): string {
+  return new Date(Math.floor(timestampMs / 1000) * 1000).toISOString();
+}
+
+function currentProcessStartedAt(): string {
+  return toIsoSecond(Date.now() - (process.uptime() * 1000));
+}
+
+function safeLockAgeMs(lockPath: string): number | null {
+  try {
+    return Date.now() - fs.statSync(lockPath).mtimeMs;
+  } catch {
+    return null;
+  }
+}
+
+function windowsPowerShellCandidates(env: NodeJS.ProcessEnv = process.env): string[] {
+  const systemRoot = env.SystemRoot || env.WINDIR;
+  if (!systemRoot || !winPath.isAbsolute(systemRoot)) {
+    return [];
+  }
+
+  const candidates = [
+    winPath.join(systemRoot, 'System32', 'WindowsPowerShell', 'v1.0', 'powershell.exe'),
+    winPath.join(systemRoot, 'Sysnative', 'WindowsPowerShell', 'v1.0', 'powershell.exe'),
+  ];
+
+  return [...new Set(candidates.filter(candidate => fs.existsSync(candidate)))];
+}
+
+function processStartedAt(pid: number): string | null {
+  try {
+    if (process.platform === 'win32') {
+      const script = `(Get-Process -Id ${pid}).StartTime.ToUniversalTime().ToString('o')`;
+      for (const command of windowsPowerShellCandidates()) {
+        try {
+          const output = execFileSync(
+            command,
+            ['-NonInteractive', '-NoProfile', '-Command', script],
+            { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'], windowsHide: true },
+          ).trim();
+          if (output) return output;
+        } catch {
+          continue;
+        }
+      }
+      return null;
+    }
+
+    const output = execFileSync(
+      'ps',
+      ['-p', String(pid), '-o', 'lstart='],
+      { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] },
+    ).trim();
+    if (!output) return null;
+    const parsed = Date.parse(output);
+    return Number.isNaN(parsed) ? null : toIsoSecond(parsed);
+  } catch {
+    return null;
+  }
+}
+
 function isProcessAlive(pid: number): boolean {
   if (!Number.isInteger(pid) || pid <= 0) return false;
   try {
@@ -142,10 +207,11 @@ function readClassificationLockState(): ClassificationLockReadResult {
     if (
       typeof raw.pid !== 'number' ||
       (raw.kind !== 'classify' && raw.kind !== 'classify-domains') ||
-      typeof raw.startedAt !== 'string'
+      typeof raw.startedAt !== 'string' ||
+      typeof raw.processStartedAt !== 'string'
     ) {
-      const ageMs = Date.now() - fs.statSync(lockPath).mtimeMs;
-      if (ageMs <= CLASSIFICATION_LOCK_PARSE_GRACE_MS) {
+      const ageMs = safeLockAgeMs(lockPath);
+      if (ageMs !== null && ageMs <= CLASSIFICATION_LOCK_PARSE_GRACE_MS) {
         return { state: 'initializing' };
       }
       fs.rmSync(lockPath, { force: true });
@@ -157,17 +223,24 @@ function readClassificationLockState(): ClassificationLockReadResult {
       return { state: 'missing' };
     }
 
+    const liveProcessStartedAt = processStartedAt(raw.pid);
+    if (liveProcessStartedAt && liveProcessStartedAt !== raw.processStartedAt) {
+      fs.rmSync(lockPath, { force: true });
+      return { state: 'missing' };
+    }
+
     return {
       state: 'active',
       lock: {
         pid: raw.pid,
         kind: raw.kind,
         startedAt: raw.startedAt,
+        processStartedAt: raw.processStartedAt,
       },
     };
   } catch {
-    const ageMs = Date.now() - fs.statSync(lockPath).mtimeMs;
-    if (ageMs <= CLASSIFICATION_LOCK_PARSE_GRACE_MS) {
+    const ageMs = safeLockAgeMs(lockPath);
+    if (ageMs !== null && ageMs <= CLASSIFICATION_LOCK_PARSE_GRACE_MS) {
       return { state: 'initializing' };
     }
     fs.rmSync(lockPath, { force: true });
@@ -209,12 +282,12 @@ export async function withClassificationLock<T>(
     pid: process.pid,
     kind,
     startedAt: new Date().toISOString(),
+    processStartedAt: currentProcessStartedAt(),
   };
 
   for (let attempt = 0; attempt < 2; attempt += 1) {
     try {
       tryWriteClassificationLock(lock);
-      return await fn();
     } catch (error: any) {
       if (error?.code !== 'EEXIST') {
         throw error;
@@ -229,6 +302,11 @@ export async function withClassificationLock<T>(
       }
 
       fs.rmSync(classificationLockPath(), { force: true });
+      continue;
+    }
+
+    try {
+      return await fn();
     } finally {
       removeClassificationLock(lock);
     }

--- a/src/bookmark-classify-llm.ts
+++ b/src/bookmark-classify-llm.ts
@@ -130,6 +130,11 @@ function toIsoSecond(timestampMs: number): string {
   return new Date(Math.floor(timestampMs / 1000) * 1000).toISOString();
 }
 
+function normalizeProcessStartedAt(value: string): string | null {
+  const parsed = Date.parse(value);
+  return Number.isNaN(parsed) ? null : toIsoSecond(parsed);
+}
+
 function currentProcessStartedAt(): string {
   return toIsoSecond(Date.now() - (process.uptime() * 1000));
 }
@@ -167,7 +172,7 @@ function processStartedAt(pid: number): string | null {
             ['-NonInteractive', '-NoProfile', '-Command', script],
             { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'], windowsHide: true },
           ).trim();
-          if (output) return output;
+          if (output) return normalizeProcessStartedAt(output);
         } catch {
           continue;
         }
@@ -180,9 +185,7 @@ function processStartedAt(pid: number): string | null {
       ['-p', String(pid), '-o', 'lstart='],
       { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] },
     ).trim();
-    if (!output) return null;
-    const parsed = Date.parse(output);
-    return Number.isNaN(parsed) ? null : toIsoSecond(parsed);
+    return output ? normalizeProcessStartedAt(output) : null;
   } catch {
     return null;
   }
@@ -198,34 +201,64 @@ function isProcessAlive(pid: number): boolean {
   }
 }
 
+function removeLockFileIfContentsMatch(lockPath: string, expectedContents: string): void {
+  try {
+    if (fs.readFileSync(lockPath, 'utf8') !== expectedContents) {
+      return;
+    }
+    fs.rmSync(lockPath, { force: true });
+  } catch (error: any) {
+    if (error?.code === 'ENOENT') {
+      return;
+    }
+    throw error;
+  }
+}
+
 function readClassificationLockState(): ClassificationLockReadResult {
   const lockPath = classificationLockPath();
   if (!fs.existsSync(lockPath)) return { state: 'missing' };
 
+  let contents: string;
   try {
-    const raw = JSON.parse(fs.readFileSync(lockPath, 'utf8')) as Partial<ClassificationLock>;
+    contents = fs.readFileSync(lockPath, 'utf8');
+  } catch (error: any) {
+    if (error?.code === 'ENOENT') {
+      return { state: 'missing' };
+    }
+    throw error;
+  }
+
+  try {
+    const raw = JSON.parse(contents) as Partial<ClassificationLock>;
+    const normalizedProcessStartedAt = typeof raw.processStartedAt === 'string'
+      ? normalizeProcessStartedAt(raw.processStartedAt)
+      : null;
     if (
       typeof raw.pid !== 'number' ||
       (raw.kind !== 'classify' && raw.kind !== 'classify-domains') ||
       typeof raw.startedAt !== 'string' ||
-      typeof raw.processStartedAt !== 'string'
+      normalizedProcessStartedAt === null
     ) {
       const ageMs = safeLockAgeMs(lockPath);
-      if (ageMs !== null && ageMs <= CLASSIFICATION_LOCK_PARSE_GRACE_MS) {
+      if (ageMs === null) {
+        return { state: 'missing' };
+      }
+      if (ageMs <= CLASSIFICATION_LOCK_PARSE_GRACE_MS) {
         return { state: 'initializing' };
       }
-      fs.rmSync(lockPath, { force: true });
+      removeLockFileIfContentsMatch(lockPath, contents);
       return { state: 'missing' };
     }
 
     if (!isProcessAlive(raw.pid)) {
-      fs.rmSync(lockPath, { force: true });
+      removeLockFileIfContentsMatch(lockPath, contents);
       return { state: 'missing' };
     }
 
     const liveProcessStartedAt = processStartedAt(raw.pid);
-    if (liveProcessStartedAt && liveProcessStartedAt !== raw.processStartedAt) {
-      fs.rmSync(lockPath, { force: true });
+    if (liveProcessStartedAt && liveProcessStartedAt !== normalizedProcessStartedAt) {
+      removeLockFileIfContentsMatch(lockPath, contents);
       return { state: 'missing' };
     }
 
@@ -235,15 +268,18 @@ function readClassificationLockState(): ClassificationLockReadResult {
         pid: raw.pid,
         kind: raw.kind,
         startedAt: raw.startedAt,
-        processStartedAt: raw.processStartedAt,
+        processStartedAt: normalizedProcessStartedAt,
       },
     };
   } catch {
     const ageMs = safeLockAgeMs(lockPath);
-    if (ageMs !== null && ageMs <= CLASSIFICATION_LOCK_PARSE_GRACE_MS) {
+    if (ageMs === null) {
+      return { state: 'missing' };
+    }
+    if (ageMs <= CLASSIFICATION_LOCK_PARSE_GRACE_MS) {
       return { state: 'initializing' };
     }
-    fs.rmSync(lockPath, { force: true });
+    removeLockFileIfContentsMatch(lockPath, contents);
     return { state: 'missing' };
   }
 }
@@ -301,7 +337,6 @@ export async function withClassificationLock<T>(
         throw new Error('Classification already running (lock file initializing)');
       }
 
-      fs.rmSync(classificationLockPath(), { force: true });
       continue;
     }
 

--- a/src/bookmarks-db.ts
+++ b/src/bookmarks-db.ts
@@ -938,7 +938,17 @@ export async function getCategoryCounts(existingDb?: Database): Promise<Record<s
 
 export async function getClassificationProgress(): Promise<BookmarkClassificationProgress> {
   const dbPath = twitterBookmarksIndexPath();
-  const db = await openDb(dbPath);
+  let db: Database;
+  try {
+    db = await openDb(dbPath);
+  } catch {
+    return {
+      total: 0,
+      categoriesDone: 0,
+      domainsDone: 0,
+    };
+  }
+
   try {
     ensureMigrations(db);
     const row = db.exec(

--- a/src/bookmarks-db.ts
+++ b/src/bookmarks-db.ts
@@ -69,6 +69,12 @@ export interface BookmarkTimelineFilters {
   offset?: number;
 }
 
+export interface BookmarkClassificationProgress {
+  total: number;
+  categoriesDone: number;
+  domainsDone: number;
+}
+
 function parseJsonArray(value: unknown): string[] {
   if (typeof value !== 'string' || !value.trim()) return [];
   try {
@@ -927,6 +933,35 @@ export async function getCategoryCounts(existingDb?: Database): Promise<Record<s
     return counts;
   } finally {
     if (!existingDb) db.close();
+  }
+}
+
+export async function getClassificationProgress(): Promise<BookmarkClassificationProgress> {
+  const dbPath = twitterBookmarksIndexPath();
+  const db = await openDb(dbPath);
+  try {
+    ensureMigrations(db);
+    const row = db.exec(
+      `SELECT
+        COUNT(*) as total,
+        SUM(CASE WHEN primary_category IS NOT NULL AND primary_category <> '' AND primary_category <> 'unclassified' THEN 1 ELSE 0 END) as categories_done,
+        SUM(CASE WHEN primary_domain IS NOT NULL AND primary_domain <> '' THEN 1 ELSE 0 END) as domains_done
+       FROM bookmarks`
+    )[0]?.values?.[0];
+
+    return {
+      total: Number(row?.[0] ?? 0),
+      categoriesDone: Number(row?.[1] ?? 0),
+      domainsDone: Number(row?.[2] ?? 0),
+    };
+  } catch {
+    return {
+      total: 0,
+      categoriesDone: 0,
+      domainsDone: 0,
+    };
+  } finally {
+    db.close();
   }
 }
 

--- a/src/bookmarks-service.ts
+++ b/src/bookmarks-service.ts
@@ -1,5 +1,6 @@
 import { getTwitterBookmarksStatus, latestBookmarkSyncAt } from './bookmarks.js';
-import { buildIndex } from './bookmarks-db.js';
+import { readClassificationLock, type ClassificationLock } from './bookmark-classify-llm.js';
+import { buildIndex, getClassificationProgress } from './bookmarks-db.js';
 import { loadTwitterOAuthToken } from './xauth.js';
 import { syncBookmarksGraphQL, type SyncProgress } from './graphql-bookmarks.js';
 
@@ -14,6 +15,9 @@ export interface BookmarkEnableResult {
 export interface BookmarkStatusView {
   connected: boolean;
   bookmarkCount: number;
+  categoriesDone: number;
+  domainsDone: number;
+  classificationJob: ClassificationLock | null;
   lastUpdated: string | null;
   mode: string;
   cachePath: string;
@@ -49,9 +53,13 @@ export async function enableBookmarks(): Promise<BookmarkEnableResult> {
 export async function getBookmarkStatusView(): Promise<BookmarkStatusView> {
   const token = await loadTwitterOAuthToken();
   const status = await getTwitterBookmarksStatus();
+  const progress = await getClassificationProgress();
   return {
     connected: Boolean(token?.access_token),
     bookmarkCount: status.totalBookmarks,
+    categoriesDone: progress.categoriesDone,
+    domainsDone: progress.domainsDone,
+    classificationJob: readClassificationLock(),
     lastUpdated: latestBookmarkSyncAt(status),
     mode: token?.access_token ? 'Incremental by default (GraphQL + API available)' : 'Incremental by default (GraphQL)',
     cachePath: status.cachePath,
@@ -62,6 +70,11 @@ export function formatBookmarkStatus(view: BookmarkStatusView): string {
   return [
     'Bookmarks',
     `  bookmarks: ${view.bookmarkCount}`,
+    `  categories: ${view.categoriesDone}/${view.bookmarkCount}`,
+    `  domains: ${view.domainsDone}/${view.bookmarkCount}`,
+    ...(view.classificationJob
+      ? [`  classification: running (${view.classificationJob.kind}, pid ${view.classificationJob.pid})`]
+      : []),
     `  last updated: ${view.lastUpdated ?? 'never'}`,
     `  sync mode: ${view.mode}`,
     `  cache: ${view.cachePath}`,
@@ -69,5 +82,8 @@ export function formatBookmarkStatus(view: BookmarkStatusView): string {
 }
 
 export function formatBookmarkSummary(view: BookmarkStatusView): string {
-  return `bookmarks=${view.bookmarkCount} updated=${view.lastUpdated ?? 'never'} mode="${view.mode}"`;
+  const classification = view.classificationJob
+    ? ` classification=${view.classificationJob.kind}:${view.classificationJob.pid}`
+    : '';
+  return `bookmarks=${view.bookmarkCount} categories=${view.categoriesDone}/${view.bookmarkCount} domains=${view.domainsDone}/${view.bookmarkCount}${classification} updated=${view.lastUpdated ?? 'never'} mode="${view.mode}"`;
 }

--- a/src/bookmarks-service.ts
+++ b/src/bookmarks-service.ts
@@ -15,6 +15,7 @@ export interface BookmarkEnableResult {
 export interface BookmarkStatusView {
   connected: boolean;
   bookmarkCount: number;
+  classificationTotal: number;
   categoriesDone: number;
   domainsDone: number;
   classificationJob: ClassificationLock | null;
@@ -57,6 +58,7 @@ export async function getBookmarkStatusView(): Promise<BookmarkStatusView> {
   return {
     connected: Boolean(token?.access_token),
     bookmarkCount: status.totalBookmarks,
+    classificationTotal: progress.total,
     categoriesDone: progress.categoriesDone,
     domainsDone: progress.domainsDone,
     classificationJob: readClassificationLock(),
@@ -66,12 +68,17 @@ export async function getBookmarkStatusView(): Promise<BookmarkStatusView> {
   };
 }
 
+function classificationDenominator(view: BookmarkStatusView): number {
+  return view.classificationTotal;
+}
+
 export function formatBookmarkStatus(view: BookmarkStatusView): string {
+  const classificationTotal = classificationDenominator(view);
   return [
     'Bookmarks',
     `  bookmarks: ${view.bookmarkCount}`,
-    `  categories: ${view.categoriesDone}/${view.bookmarkCount}`,
-    `  domains: ${view.domainsDone}/${view.bookmarkCount}`,
+    `  categories: ${view.categoriesDone}/${classificationTotal}`,
+    `  domains: ${view.domainsDone}/${classificationTotal}`,
     ...(view.classificationJob
       ? [`  classification: running (${view.classificationJob.kind}, pid ${view.classificationJob.pid})`]
       : []),
@@ -82,8 +89,9 @@ export function formatBookmarkStatus(view: BookmarkStatusView): string {
 }
 
 export function formatBookmarkSummary(view: BookmarkStatusView): string {
+  const classificationTotal = classificationDenominator(view);
   const classification = view.classificationJob
     ? ` classification=${view.classificationJob.kind}:${view.classificationJob.pid}`
     : '';
-  return `bookmarks=${view.bookmarkCount} categories=${view.categoriesDone}/${view.bookmarkCount} domains=${view.domainsDone}/${view.bookmarkCount}${classification} updated=${view.lastUpdated ?? 'never'} mode="${view.mode}"`;
+  return `bookmarks=${view.bookmarkCount} categories=${view.categoriesDone}/${classificationTotal} domains=${view.domainsDone}/${classificationTotal}${classification} updated=${view.lastUpdated ?? 'never'} mode="${view.mode}"`;
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -21,7 +21,7 @@ import {
   getBookmarkById,
 } from './bookmarks-db.js';
 import { formatClassificationSummary } from './bookmark-classify.js';
-import { classifyWithLlm, classifyDomainsWithLlm } from './bookmark-classify-llm.js';
+import { classifyWithLlm, classifyDomainsWithLlm, withClassificationLock } from './bookmark-classify-llm.js';
 import { resolveEngine, detectAvailableEngines } from './engine.js';
 import { loadPreferences, savePreferences } from './preferences.js';
 import { compileMd } from './md.js';
@@ -435,35 +435,36 @@ export function buildCli() {
 
   async function classifyNew(override?: string): Promise<void> {
     const engine = await resolveEngine({ override });
+    await withClassificationLock('classify', async () => {
+      const start = Date.now();
+      process.stderr.write('  Classifying new bookmarks (categories)...\n');
+      const catResult = await classifyWithLlm({
+        engine,
+        onBatch: (done: number, total: number) => {
+          const pct = total > 0 ? Math.round((done / total) * 100) : 0;
+          const elapsed = Math.round((Date.now() - start) / 1000);
+          process.stderr.write(`  Categories: ${done}/${total} (${pct}%) \u2502 ${elapsed}s elapsed\n`);
+        },
+      });
+      if (catResult.classified > 0) {
+        process.stderr.write(`  \u2713 ${catResult.classified} categorized\n`);
+      }
 
-    const start = Date.now();
-    process.stderr.write('  Classifying new bookmarks (categories)...\n');
-    const catResult = await classifyWithLlm({
-      engine,
-      onBatch: (done: number, total: number) => {
-        const pct = total > 0 ? Math.round((done / total) * 100) : 0;
-        const elapsed = Math.round((Date.now() - start) / 1000);
-        process.stderr.write(`  Categories: ${done}/${total} (${pct}%) \u2502 ${elapsed}s elapsed\n`);
-      },
+      const domStart = Date.now();
+      process.stderr.write('  Classifying new bookmarks (domains)...\n');
+      const domResult = await classifyDomainsWithLlm({
+        engine,
+        all: false,
+        onBatch: (done: number, total: number) => {
+          const pct = total > 0 ? Math.round((done / total) * 100) : 0;
+          const elapsed = Math.round((Date.now() - domStart) / 1000);
+          process.stderr.write(`  Domains: ${done}/${total} (${pct}%) \u2502 ${elapsed}s elapsed\n`);
+        },
+      });
+      if (domResult.classified > 0) {
+        process.stderr.write(`  \u2713 ${domResult.classified} domains assigned\n`);
+      }
     });
-    if (catResult.classified > 0) {
-      process.stderr.write(`  \u2713 ${catResult.classified} categorized\n`);
-    }
-
-    const domStart = Date.now();
-    process.stderr.write('  Classifying new bookmarks (domains)...\n');
-    const domResult = await classifyDomainsWithLlm({
-      engine,
-      all: false,
-      onBatch: (done: number, total: number) => {
-        const pct = total > 0 ? Math.round((done / total) * 100) : 0;
-        const elapsed = Math.round((Date.now() - domStart) / 1000);
-        process.stderr.write(`  Domains: ${done}/${total} (${pct}%) \u2502 ${elapsed}s elapsed\n`);
-      },
-    });
-    if (domResult.classified > 0) {
-      process.stderr.write(`  \u2713 ${domResult.classified} domains assigned\n`);
-    }
   }
 
   program
@@ -976,32 +977,33 @@ export function buildCli() {
         console.log(formatClassificationSummary(result.summary));
       } else {
         const engine = await resolveEngine({ override: options.engine ? String(options.engine) : undefined });
+        await withClassificationLock('classify', async () => {
+          let catStart = Date.now();
+          process.stderr.write('Classifying categories with LLM (batches of 50, ~2 min per batch)...\n');
+          const catResult = await classifyWithLlm({
+            engine,
+            onBatch: (done: number, total: number) => {
+              const pct = total > 0 ? Math.round((done / total) * 100) : 0;
+              const elapsed = Math.round((Date.now() - catStart) / 1000);
+              process.stderr.write(`  Categories: ${done}/${total} (${pct}%) \u2502 ${elapsed}s elapsed\n`);
+            },
+          });
+          console.log(`\nEngine: ${catResult.engine}`);
+          console.log(`Categories: ${catResult.classified}/${catResult.totalUnclassified} classified`);
 
-        let catStart = Date.now();
-        process.stderr.write('Classifying categories with LLM (batches of 50, ~2 min per batch)...\n');
-        const catResult = await classifyWithLlm({
-          engine,
-          onBatch: (done: number, total: number) => {
-            const pct = total > 0 ? Math.round((done / total) * 100) : 0;
-            const elapsed = Math.round((Date.now() - catStart) / 1000);
-            process.stderr.write(`  Categories: ${done}/${total} (${pct}%) \u2502 ${elapsed}s elapsed\n`);
-          },
+          let domStart = Date.now();
+          process.stderr.write('\nClassifying domains with LLM (batches of 50, ~2 min per batch)...\n');
+          const domResult = await classifyDomainsWithLlm({
+            engine,
+            all: false,
+            onBatch: (done: number, total: number) => {
+              const pct = total > 0 ? Math.round((done / total) * 100) : 0;
+              const elapsed = Math.round((Date.now() - domStart) / 1000);
+              process.stderr.write(`  Domains: ${done}/${total} (${pct}%) \u2502 ${elapsed}s elapsed\n`);
+            },
+          });
+          console.log(`\nDomains: ${domResult.classified}/${domResult.totalUnclassified} classified`);
         });
-        console.log(`\nEngine: ${catResult.engine}`);
-        console.log(`Categories: ${catResult.classified}/${catResult.totalUnclassified} classified`);
-
-        let domStart = Date.now();
-        process.stderr.write('\nClassifying domains with LLM (batches of 50, ~2 min per batch)...\n');
-        const domResult = await classifyDomainsWithLlm({
-          engine,
-          all: false,
-          onBatch: (done: number, total: number) => {
-            const pct = total > 0 ? Math.round((done / total) * 100) : 0;
-            const elapsed = Math.round((Date.now() - domStart) / 1000);
-            process.stderr.write(`  Domains: ${done}/${total} (${pct}%) \u2502 ${elapsed}s elapsed\n`);
-          },
-        });
-        console.log(`\nDomains: ${domResult.classified}/${domResult.totalUnclassified} classified`);
       }
     }));
 
@@ -1015,18 +1017,20 @@ export function buildCli() {
     .action(safe(async (options) => {
       if (!requireData()) return;
       const engine = await resolveEngine({ override: options.engine ? String(options.engine) : undefined });
-      const start = Date.now();
-      process.stderr.write('Classifying bookmark domains with LLM (batches of 50, ~2 min per batch)...\n');
-      const result = await classifyDomainsWithLlm({
-        engine,
-        all: options.all ?? false,
-        onBatch: (done: number, total: number) => {
-          const pct = total > 0 ? Math.round((done / total) * 100) : 0;
-          const elapsed = Math.round((Date.now() - start) / 1000);
-          process.stderr.write(`  Domains: ${done}/${total} (${pct}%) \u2502 ${elapsed}s elapsed\n`);
-        },
+      await withClassificationLock('classify-domains', async () => {
+        const start = Date.now();
+        process.stderr.write('Classifying bookmark domains with LLM (batches of 50, ~2 min per batch)...\n');
+        const result = await classifyDomainsWithLlm({
+          engine,
+          all: options.all ?? false,
+          onBatch: (done: number, total: number) => {
+            const pct = total > 0 ? Math.round((done / total) * 100) : 0;
+            const elapsed = Math.round((Date.now() - start) / 1000);
+            process.stderr.write(`  Domains: ${done}/${total} (${pct}%) \u2502 ${elapsed}s elapsed\n`);
+          },
+        });
+        console.log(`\nDomains: ${result.classified}/${result.totalUnclassified} classified`);
       });
-      console.log(`\nDomains: ${result.classified}/${result.totalUnclassified} classified`);
     }));
 
   // ── model ───────────────────────────────────────────────────────────────

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -48,6 +48,10 @@ export function twitterBookmarksIndexPath(): string {
   return path.join(dataDir(), 'bookmarks.db');
 }
 
+export function classificationLockPath(): string {
+  return path.join(dataDir(), 'classification-lock.json');
+}
+
 export function preferencesPath(): string {
   return path.join(dataDir(), '.preferences');
 }

--- a/tests/bookmark-classify-llm.test.ts
+++ b/tests/bookmark-classify-llm.test.ts
@@ -77,6 +77,30 @@ test('readClassificationLock leaves a freshly malformed lock file in place', () 
   }
 });
 
+test('readClassificationLock tolerates lock removal while checking malformed content', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ft-lock-'));
+  process.env.FT_DATA_DIR = tmpDir;
+
+  const originalStatSync = fs.statSync;
+  try {
+    const lockPath = classificationLockPath();
+    fs.writeFileSync(lockPath, '{\n', 'utf8');
+    fs.statSync = ((targetPath: fs.PathLike, options?: fs.StatOptions) => {
+      if (String(targetPath) === lockPath) {
+        const error = Object.assign(new Error('missing'), { code: 'ENOENT' });
+        throw error;
+      }
+      return originalStatSync(targetPath, options as any);
+    }) as typeof fs.statSync;
+
+    assert.equal(readClassificationLock(), null);
+  } finally {
+    fs.statSync = originalStatSync;
+    delete process.env.FT_DATA_DIR;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
 test('withClassificationLock does not delete a freshly malformed lock file created by another process', async () => {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ft-lock-'));
   process.env.FT_DATA_DIR = tmpDir;
@@ -92,6 +116,45 @@ test('withClassificationLock does not delete a freshly malformed lock file creat
 
     assert.equal(fs.existsSync(lockPath), true);
   } finally {
+    delete process.env.FT_DATA_DIR;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test('withClassificationLock does not delete a replacement lock after stale cleanup', async () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ft-lock-'));
+  process.env.FT_DATA_DIR = tmpDir;
+
+  const originalRmSync = fs.rmSync;
+  let injectedReplacement = false;
+  try {
+    const lockPath = classificationLockPath();
+    fs.writeFileSync(lockPath, '{\n', 'utf8');
+    const staleTime = new Date(Date.now() - 10_000);
+    fs.utimesSync(lockPath, staleTime, staleTime);
+
+    fs.rmSync = ((targetPath: fs.PathLike, options?: fs.RmOptions) => {
+      originalRmSync(targetPath, options);
+      if (!injectedReplacement && String(targetPath) === lockPath) {
+        injectedReplacement = true;
+        fs.writeFileSync(lockPath, JSON.stringify({
+          pid: process.pid,
+          kind: 'classify-domains',
+          startedAt: '2026-04-16T22:27:00.000Z',
+          processStartedAt: new Date(Math.floor((Date.now() - (process.uptime() * 1000)) / 1000) * 1000).toISOString(),
+        }), 'utf8');
+      }
+    }) as typeof fs.rmSync;
+
+    await assert.rejects(
+      () => withClassificationLock('classify', async () => 'nope'),
+      /Classification already running \(classify-domains, pid \d+\)/,
+    );
+
+    const lock = readClassificationLock();
+    assert.equal(lock?.kind, 'classify-domains');
+  } finally {
+    fs.rmSync = originalRmSync;
     delete process.env.FT_DATA_DIR;
     fs.rmSync(tmpDir, { recursive: true, force: true });
   }
@@ -130,6 +193,29 @@ test('readClassificationLock removes stale locks when pid was recycled', () => {
 
     assert.equal(readClassificationLock(), null);
     assert.equal(fs.existsSync(lockPath), false);
+  } finally {
+    delete process.env.FT_DATA_DIR;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test('readClassificationLock normalizes equivalent process start timestamps', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ft-lock-'));
+  process.env.FT_DATA_DIR = tmpDir;
+
+  try {
+    const lockPath = classificationLockPath();
+    const startedAt = new Date(Math.floor((Date.now() - (process.uptime() * 1000)) / 1000) * 1000).toISOString();
+    fs.writeFileSync(lockPath, JSON.stringify({
+      pid: process.pid,
+      kind: 'classify',
+      startedAt: '2026-04-16T00:00:00.000Z',
+      processStartedAt: startedAt.replace('.000Z', 'Z'),
+    }), 'utf8');
+
+    const lock = readClassificationLock();
+    assert.equal(lock?.pid, process.pid);
+    assert.equal(lock?.kind, 'classify');
   } finally {
     delete process.env.FT_DATA_DIR;
     fs.rmSync(tmpDir, { recursive: true, force: true });

--- a/tests/bookmark-classify-llm.test.ts
+++ b/tests/bookmark-classify-llm.test.ts
@@ -4,6 +4,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { readClassificationLock, withClassificationLock } from '../src/bookmark-classify-llm.js';
+import { classificationLockPath } from '../src/paths.js';
 
 test('withClassificationLock writes and clears a live lock file', async () => {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ft-lock-'));
@@ -37,6 +38,60 @@ test('withClassificationLock rejects a second concurrent classify run', async ()
       () => withClassificationLock('classify', async () => withClassificationLock('classify-domains', async () => 'nope')),
       /Classification already running \(classify, pid \d+\)/,
     );
+  } finally {
+    delete process.env.FT_DATA_DIR;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test('readClassificationLock leaves a freshly malformed lock file in place', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ft-lock-'));
+  process.env.FT_DATA_DIR = tmpDir;
+
+  try {
+    const lockPath = classificationLockPath();
+    fs.writeFileSync(lockPath, '{\n', 'utf8');
+
+    assert.equal(readClassificationLock(), null);
+    assert.equal(fs.existsSync(lockPath), true);
+  } finally {
+    delete process.env.FT_DATA_DIR;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test('withClassificationLock does not delete a freshly malformed lock file created by another process', async () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ft-lock-'));
+  process.env.FT_DATA_DIR = tmpDir;
+
+  try {
+    const lockPath = classificationLockPath();
+    fs.writeFileSync(lockPath, '{\n', 'utf8');
+
+    await assert.rejects(
+      () => withClassificationLock('classify', async () => 'nope'),
+      /Classification already running \(lock file initializing\)/,
+    );
+
+    assert.equal(fs.existsSync(lockPath), true);
+  } finally {
+    delete process.env.FT_DATA_DIR;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test('readClassificationLock removes malformed lock files only after the grace window', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ft-lock-'));
+  process.env.FT_DATA_DIR = tmpDir;
+
+  try {
+    const lockPath = classificationLockPath();
+    fs.writeFileSync(lockPath, '{\n', 'utf8');
+    const staleTime = new Date(Date.now() - 10_000);
+    fs.utimesSync(lockPath, staleTime, staleTime);
+
+    assert.equal(readClassificationLock(), null);
+    assert.equal(fs.existsSync(lockPath), false);
   } finally {
     delete process.env.FT_DATA_DIR;
     fs.rmSync(tmpDir, { recursive: true, force: true });

--- a/tests/bookmark-classify-llm.test.ts
+++ b/tests/bookmark-classify-llm.test.ts
@@ -1,0 +1,44 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { readClassificationLock, withClassificationLock } from '../src/bookmark-classify-llm.js';
+
+test('withClassificationLock writes and clears a live lock file', async () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ft-lock-'));
+  process.env.FT_DATA_DIR = tmpDir;
+
+  try {
+    assert.equal(readClassificationLock(), null);
+
+    const result = await withClassificationLock('classify-domains', async () => {
+      const lock = readClassificationLock();
+      assert.equal(lock?.kind, 'classify-domains');
+      assert.equal(lock?.pid, process.pid);
+      assert.match(lock?.startedAt ?? '', /^\d{4}-\d{2}-\d{2}T/);
+      return 'ok';
+    });
+
+    assert.equal(result, 'ok');
+    assert.equal(readClassificationLock(), null);
+  } finally {
+    delete process.env.FT_DATA_DIR;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test('withClassificationLock rejects a second concurrent classify run', async () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ft-lock-'));
+  process.env.FT_DATA_DIR = tmpDir;
+
+  try {
+    await assert.rejects(
+      () => withClassificationLock('classify', async () => withClassificationLock('classify-domains', async () => 'nope')),
+      /Classification already running \(classify, pid \d+\)/,
+    );
+  } finally {
+    delete process.env.FT_DATA_DIR;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});

--- a/tests/bookmark-classify-llm.test.ts
+++ b/tests/bookmark-classify-llm.test.ts
@@ -44,6 +44,23 @@ test('withClassificationLock rejects a second concurrent classify run', async ()
   }
 });
 
+test('withClassificationLock preserves callback errors even when they carry EEXIST', async () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ft-lock-'));
+  process.env.FT_DATA_DIR = tmpDir;
+
+  try {
+    const error = Object.assign(new Error('boom'), { code: 'EEXIST' });
+    await assert.rejects(
+      () => withClassificationLock('classify', async () => { throw error; }),
+      (caught: unknown) => caught === error,
+    );
+    assert.equal(readClassificationLock(), null);
+  } finally {
+    delete process.env.FT_DATA_DIR;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
 test('readClassificationLock leaves a freshly malformed lock file in place', () => {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ft-lock-'));
   process.env.FT_DATA_DIR = tmpDir;
@@ -89,6 +106,27 @@ test('readClassificationLock removes malformed lock files only after the grace w
     fs.writeFileSync(lockPath, '{\n', 'utf8');
     const staleTime = new Date(Date.now() - 10_000);
     fs.utimesSync(lockPath, staleTime, staleTime);
+
+    assert.equal(readClassificationLock(), null);
+    assert.equal(fs.existsSync(lockPath), false);
+  } finally {
+    delete process.env.FT_DATA_DIR;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test('readClassificationLock removes stale locks when pid was recycled', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ft-lock-'));
+  process.env.FT_DATA_DIR = tmpDir;
+
+  try {
+    const lockPath = classificationLockPath();
+    fs.writeFileSync(lockPath, JSON.stringify({
+      pid: process.pid,
+      kind: 'classify',
+      startedAt: '2026-04-16T00:00:00.000Z',
+      processStartedAt: '2000-01-01T00:00:00.000Z',
+    }), 'utf8');
 
     assert.equal(readClassificationLock(), null);
     assert.equal(fs.existsSync(lockPath), false);

--- a/tests/bookmarks-db.test.ts
+++ b/tests/bookmarks-db.test.ts
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 import { mkdtemp, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
-import { buildIndex, searchBookmarks, getStats, formatSearchResults, getBookmarkById, sanitizeFtsQuery, getCategoryCounts, sampleByCategory } from '../src/bookmarks-db.js';
+import { buildIndex, searchBookmarks, getStats, formatSearchResults, getBookmarkById, sanitizeFtsQuery, getCategoryCounts, sampleByCategory, getClassificationProgress } from '../src/bookmarks-db.js';
 import { openDb, saveDb } from '../src/db.js';
 import { twitterBookmarksIndexPath } from '../src/paths.js';
 
@@ -127,6 +127,39 @@ test('getStats returns correct aggregate data', async () => {
     assert.equal(stats.topAuthors[0].count, 2);
     assert.equal(stats.languageBreakdown[0].language, 'en');
     assert.equal(stats.languageBreakdown[0].count, 3);
+  });
+});
+
+test('getClassificationProgress counts completed categories and domains', async () => {
+  await withIsolatedDataDir(async () => {
+    await buildIndex();
+
+    const dbPath = twitterBookmarksIndexPath();
+    const db = await openDb(dbPath);
+    try {
+      db.run(
+        `UPDATE bookmarks
+         SET categories = ?, primary_category = ?, domains = ?, primary_domain = ?
+         WHERE id = ?`,
+        ['tool', 'tool', 'ai', 'ai', '1'],
+      );
+      db.run(
+        `UPDATE bookmarks
+         SET categories = ?, primary_category = ?
+         WHERE id = ?`,
+        ['research', 'research', '2'],
+      );
+      saveDb(db, dbPath);
+    } finally {
+      db.close();
+    }
+
+    const progress = await getClassificationProgress();
+    assert.deepEqual(progress, {
+      total: 3,
+      categoriesDone: 2,
+      domainsDone: 1,
+    });
   });
 });
 

--- a/tests/bookmarks-db.test.ts
+++ b/tests/bookmarks-db.test.ts
@@ -1,5 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import fs from 'node:fs';
 import { mkdtemp, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
@@ -159,6 +160,20 @@ test('getClassificationProgress counts completed categories and domains', async 
       total: 3,
       categoriesDone: 2,
       domainsDone: 1,
+    });
+  });
+});
+
+test('getClassificationProgress returns zeros when the index cannot be opened', async () => {
+  await withIsolatedDataDir(async () => {
+    const dbPath = twitterBookmarksIndexPath();
+    fs.writeFileSync(dbPath, 'not a sqlite database', 'utf8');
+
+    const progress = await getClassificationProgress();
+    assert.deepEqual(progress, {
+      total: 0,
+      categoriesDone: 0,
+      domainsDone: 0,
     });
   });
 });

--- a/tests/bookmarks-service.test.ts
+++ b/tests/bookmarks-service.test.ts
@@ -13,6 +13,7 @@ test('formatBookmarkStatus produces human-readable summary', () => {
   const text = formatBookmarkStatus({
     connected: true,
     bookmarkCount: 99,
+    classificationTotal: 80,
     categoriesDone: 12,
     domainsDone: 34,
     classificationJob: { pid: 17169, kind: 'classify-domains', startedAt: '2026-03-28T17:20:00Z', processStartedAt: '2026-03-28T17:19:30Z' },
@@ -23,8 +24,8 @@ test('formatBookmarkStatus produces human-readable summary', () => {
 
   assert.match(text, /^Bookmarks/);
   assert.match(text, /bookmarks: 99/);
-  assert.match(text, /categories: 12\/99/);
-  assert.match(text, /domains: 34\/99/);
+  assert.match(text, /categories: 12\/80/);
+  assert.match(text, /domains: 34\/80/);
   assert.match(text, /classification: running \(classify-domains, pid 17169\)/);
   assert.match(text, /last updated: 2026-03-28T17:23:00Z/);
   assert.match(text, /sync mode: Incremental by default \(GraphQL \+ API available\)/);
@@ -36,6 +37,7 @@ test('formatBookmarkStatus shows never when no lastUpdated', () => {
   const text = formatBookmarkStatus({
     connected: false,
     bookmarkCount: 0,
+    classificationTotal: 0,
     categoriesDone: 0,
     domainsDone: 0,
     classificationJob: null,
@@ -51,6 +53,7 @@ test('formatBookmarkSummary produces concise operator-friendly output', () => {
   const text = formatBookmarkSummary({
     connected: true,
     bookmarkCount: 99,
+    classificationTotal: 80,
     categoriesDone: 12,
     domainsDone: 34,
     classificationJob: { pid: 17169, kind: 'classify-domains', startedAt: '2026-03-28T17:20:00Z', processStartedAt: '2026-03-28T17:19:30Z' },
@@ -60,8 +63,8 @@ test('formatBookmarkSummary produces concise operator-friendly output', () => {
   });
 
   assert.match(text, /bookmarks=99/);
-  assert.match(text, /categories=12\/99/);
-  assert.match(text, /domains=34\/99/);
+  assert.match(text, /categories=12\/80/);
+  assert.match(text, /domains=34\/80/);
   assert.match(text, /classification=classify-domains:17169/);
   assert.match(text, /updated=2026-03-28T17:23:00Z/);
   assert.match(text, /mode="API sync"/);
@@ -83,6 +86,7 @@ test('getBookmarkStatusView uses the most recent sync timestamp', async () => {
     const view = await getBookmarkStatusView();
 
     assert.equal(view.bookmarkCount, 3);
+    assert.equal(view.classificationTotal, 0);
     assert.equal(view.lastUpdated, '2026-04-05T12:34:56Z');
     assert.equal(view.connected, false);
   } finally {
@@ -158,6 +162,7 @@ test('getBookmarkStatusView includes classification progress and live lock info'
     const view = await getBookmarkStatusView();
 
     assert.equal(view.bookmarkCount, 2);
+    assert.equal(view.classificationTotal, 2);
     assert.equal(view.categoriesDone, 1);
     assert.equal(view.domainsDone, 1);
     assert.equal(view.classificationJob?.pid, process.pid);

--- a/tests/bookmarks-service.test.ts
+++ b/tests/bookmarks-service.test.ts
@@ -2,14 +2,20 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import os from 'node:os';
 import path from 'node:path';
-import { mkdtemp, rm } from 'node:fs/promises';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { writeJson } from '../src/fs.js';
+import { buildIndex } from '../src/bookmarks-db.js';
+import { openDb, saveDb } from '../src/db.js';
 import { formatBookmarkStatus, formatBookmarkSummary, getBookmarkStatusView } from '../src/bookmarks-service.js';
+import { classificationLockPath, twitterBookmarksIndexPath } from '../src/paths.js';
 
 test('formatBookmarkStatus produces human-readable summary', () => {
   const text = formatBookmarkStatus({
     connected: true,
     bookmarkCount: 99,
+    categoriesDone: 12,
+    domainsDone: 34,
+    classificationJob: { pid: 17169, kind: 'classify-domains', startedAt: '2026-03-28T17:20:00Z' },
     lastUpdated: '2026-03-28T17:23:00Z',
     mode: 'Incremental by default (GraphQL + API available)',
     cachePath: '/tmp/x-bookmarks.jsonl',
@@ -17,6 +23,9 @@ test('formatBookmarkStatus produces human-readable summary', () => {
 
   assert.match(text, /^Bookmarks/);
   assert.match(text, /bookmarks: 99/);
+  assert.match(text, /categories: 12\/99/);
+  assert.match(text, /domains: 34\/99/);
+  assert.match(text, /classification: running \(classify-domains, pid 17169\)/);
   assert.match(text, /last updated: 2026-03-28T17:23:00Z/);
   assert.match(text, /sync mode: Incremental by default \(GraphQL \+ API available\)/);
   assert.match(text, /cache: \/tmp\/x-bookmarks\.jsonl/);
@@ -27,6 +36,9 @@ test('formatBookmarkStatus shows never when no lastUpdated', () => {
   const text = formatBookmarkStatus({
     connected: false,
     bookmarkCount: 0,
+    categoriesDone: 0,
+    domainsDone: 0,
+    classificationJob: null,
     lastUpdated: null,
     mode: 'Incremental by default (GraphQL)',
     cachePath: '/tmp/x-bookmarks.jsonl',
@@ -39,12 +51,18 @@ test('formatBookmarkSummary produces concise operator-friendly output', () => {
   const text = formatBookmarkSummary({
     connected: true,
     bookmarkCount: 99,
+    categoriesDone: 12,
+    domainsDone: 34,
+    classificationJob: { pid: 17169, kind: 'classify-domains', startedAt: '2026-03-28T17:20:00Z' },
     lastUpdated: '2026-03-28T17:23:00Z',
     mode: 'API sync',
     cachePath: '/tmp/x-bookmarks.jsonl',
   });
 
   assert.match(text, /bookmarks=99/);
+  assert.match(text, /categories=12\/99/);
+  assert.match(text, /domains=34\/99/);
+  assert.match(text, /classification=classify-domains:17169/);
   assert.match(text, /updated=2026-03-28T17:23:00Z/);
   assert.match(text, /mode="API sync"/);
 });
@@ -67,6 +85,82 @@ test('getBookmarkStatusView uses the most recent sync timestamp', async () => {
     assert.equal(view.bookmarkCount, 3);
     assert.equal(view.lastUpdated, '2026-04-05T12:34:56Z');
     assert.equal(view.connected, false);
+  } finally {
+    delete process.env.FT_DATA_DIR;
+    await rm(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test('getBookmarkStatusView includes classification progress and live lock info', async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), 'ft-status-view-'));
+  process.env.FT_DATA_DIR = tmpDir;
+
+  try {
+    await writeFile(
+      path.join(tmpDir, 'bookmarks.jsonl'),
+      [
+        JSON.stringify({
+          id: '1',
+          tweetId: '1',
+          url: 'https://x.com/alice/status/1',
+          text: 'Machine learning is transforming healthcare',
+          authorHandle: 'alice',
+          authorName: 'Alice Smith',
+          syncedAt: '2026-04-05T10:00:00Z',
+          postedAt: '2026-04-01T12:00:00Z',
+          links: [],
+          mediaObjects: [],
+          tags: [],
+          ingestedVia: 'graphql',
+        }),
+        JSON.stringify({
+          id: '2',
+          tweetId: '2',
+          url: 'https://x.com/bob/status/2',
+          text: 'Rust is a great systems programming language',
+          authorHandle: 'bob',
+          authorName: 'Bob Jones',
+          syncedAt: '2026-04-05T10:00:00Z',
+          postedAt: '2026-04-02T12:00:00Z',
+          links: [],
+          mediaObjects: [],
+          tags: [],
+          ingestedVia: 'graphql',
+        }),
+        '',
+      ].join('\n'),
+      'utf8',
+    );
+
+    await buildIndex();
+
+    const dbPath = twitterBookmarksIndexPath();
+    const db = await openDb(dbPath);
+    try {
+      db.run(
+        `UPDATE bookmarks
+         SET categories = ?, primary_category = ?, domains = ?, primary_domain = ?
+         WHERE id = ?`,
+        ['tool', 'tool', 'ai', 'ai', '1'],
+      );
+      saveDb(db, dbPath);
+    } finally {
+      db.close();
+    }
+
+    await writeJson(classificationLockPath(), {
+      pid: process.pid,
+      kind: 'classify',
+      startedAt: '2026-04-05T12:35:00Z',
+    });
+
+    const view = await getBookmarkStatusView();
+
+    assert.equal(view.bookmarkCount, 2);
+    assert.equal(view.categoriesDone, 1);
+    assert.equal(view.domainsDone, 1);
+    assert.equal(view.classificationJob?.pid, process.pid);
+    assert.equal(view.classificationJob?.kind, 'classify');
   } finally {
     delete process.env.FT_DATA_DIR;
     await rm(tmpDir, { recursive: true, force: true });

--- a/tests/bookmarks-service.test.ts
+++ b/tests/bookmarks-service.test.ts
@@ -15,7 +15,7 @@ test('formatBookmarkStatus produces human-readable summary', () => {
     bookmarkCount: 99,
     categoriesDone: 12,
     domainsDone: 34,
-    classificationJob: { pid: 17169, kind: 'classify-domains', startedAt: '2026-03-28T17:20:00Z' },
+    classificationJob: { pid: 17169, kind: 'classify-domains', startedAt: '2026-03-28T17:20:00Z', processStartedAt: '2026-03-28T17:19:30Z' },
     lastUpdated: '2026-03-28T17:23:00Z',
     mode: 'Incremental by default (GraphQL + API available)',
     cachePath: '/tmp/x-bookmarks.jsonl',
@@ -53,7 +53,7 @@ test('formatBookmarkSummary produces concise operator-friendly output', () => {
     bookmarkCount: 99,
     categoriesDone: 12,
     domainsDone: 34,
-    classificationJob: { pid: 17169, kind: 'classify-domains', startedAt: '2026-03-28T17:20:00Z' },
+    classificationJob: { pid: 17169, kind: 'classify-domains', startedAt: '2026-03-28T17:20:00Z', processStartedAt: '2026-03-28T17:19:30Z' },
     lastUpdated: '2026-03-28T17:23:00Z',
     mode: 'API sync',
     cachePath: '/tmp/x-bookmarks.jsonl',
@@ -152,6 +152,7 @@ test('getBookmarkStatusView includes classification progress and live lock info'
       pid: process.pid,
       kind: 'classify',
       startedAt: '2026-04-05T12:35:00Z',
+      processStartedAt: new Date(Math.floor((Date.now() - (process.uptime() * 1000)) / 1000) * 1000).toISOString(),
     });
 
     const view = await getBookmarkStatusView();


### PR DESCRIPTION
## Summary
- surface category/domain completion counts in `ft status`
- show when a classification job is currently running
- guard classify/classify-domains with a lock file so concurrent runs fail fast instead of stepping on each other
- add regression coverage for progress counting, lock lifecycle, and status rendering


## Validation
- `npm test`
- `npm run build`


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds cross-platform process/lock-file handling (including `ps`/PowerShell probes) and changes CLI execution flow, which could cause false-positive lockouts or platform-specific failures if process detection misbehaves.
> 
> **Overview**
> `ft status` now surfaces classification completion counts (categories/domains) and reports an active classification job when one is running.
> 
> LLM classification commands (`ft classify`, `ft classify-domains`, and `ft sync --classify`) are wrapped in a new lock-file mechanism (`classification-lock.json`) to fail fast on concurrent runs and to clean up stale/malformed locks safely.
> 
> Adds `getClassificationProgress()` DB query support plus regression tests covering progress counting, lock lifecycle/staleness handling, and updated status output; README docs are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c607388b34807125631ade0ae0ce9ed36c46656. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->