### PR TITLE
feat(browsers): add Dia support for session sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ Use `ft classify` for LLM-powered classification that catches what regex misses.
 
 | Feature | macOS | Linux | Windows |
 |---------|-------|-------|---------|
-| Session sync (`ft sync`) | Chrome, Chromium, Brave, Helium, Comet, Firefox | Chrome, Chromium, Brave, Firefox | Chrome, Chromium, Brave, Firefox |
+| Session sync (`ft sync`) | Chrome, Chromium, Brave, Helium, Comet, Dia, Firefox | Chrome, Chromium, Brave, Firefox | Chrome, Chromium, Brave, Firefox |
 | OAuth API sync (`ft sync --api`) | Yes | Yes | Yes |
 | Search, list, classify, viz, wiki | Yes | Yes | Yes |
 

--- a/src/browsers.ts
+++ b/src/browsers.ts
@@ -82,6 +82,15 @@ const BROWSERS: BrowserDef[] = [
     macPath: 'Library/Application Support/Comet',
   },
   {
+    id: 'dia',
+    displayName: 'Dia',
+    cookieBackend: 'chromium',
+    keychainEntries: [
+      { service: 'Dia Safe Storage', account: 'Dia' },
+    ],
+    macPath: 'Library/Application Support/Dia/User Data',
+  },
+  {
     id: 'firefox',
     displayName: 'Firefox',
     cookieBackend: 'firefox',

--- a/tests/browsers.test.ts
+++ b/tests/browsers.test.ts
@@ -29,7 +29,16 @@ test('listBrowserIds: returns all registered ids', () => {
   assert.ok(ids.includes('firefox'));
   assert.ok(ids.includes('helium'));
   assert.ok(ids.includes('comet'));
+  assert.ok(ids.includes('dia'));
   assert.ok(ids.includes('chromium'));
+});
+
+test('getBrowser: dia has correct keychain entries and User Data macPath', () => {
+  const browser = getBrowser('dia');
+  assert.equal(browser.cookieBackend, 'chromium');
+  const services = browser.keychainEntries.map(e => e.service);
+  assert.ok(services.includes('Dia Safe Storage'));
+  assert.match(browser.macPath!, /Dia\/User Data$/);
 });
 
 test('getBrowser: firefox has firefox cookieBackend', () => {


### PR DESCRIPTION
## Summary

Adds [Dia](https://diabrowser.com/) (by The Browser Company of New York) to the supported browsers for `ft sync`. Dia is Chromium-based and uses the standard `<Name> Safe Storage` macOS Keychain pattern, so it plugs into the existing chromium cookie-extraction path with no new logic.

## Changes

- `src/browsers.ts` — new `dia` entry:
  - `macPath: Library/Application Support/Dia/User Data` (Dia nests profiles under `User Data/`, unlike Chrome on macOS)
  - Keychain: `{ service: 'Dia Safe Storage', account: 'Dia' }` (verified via `security find-generic-password -s "Dia Safe Storage"`)
  - `cookieBackend: 'chromium'`
- `tests/browsers.test.ts` — assertions that `dia` appears in `listBrowserIds()` and has the expected Keychain service + `User Data` macPath
- `README.md` — added Dia to the macOS row of the Platform support table

Linux/Windows paths are omitted because Dia is currently macOS-only.

## Test plan

- [x] `npm run build` passes
- [x] `npx tsx --test tests/browsers.test.ts` — 10/10 pass (including new Dia test)
- [x] Locally linked `ft` recognizes `--browser dia` (verified on my machine; ready to run `ft sync --browser dia` against my own X login)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new browser definition and corresponding documentation/tests without changing cookie-extraction logic or sync flow.
> 
> **Overview**
> Adds macOS session-sync support for the Chromium-based Dia browser by registering a new `dia` browser definition (Keychain `Dia Safe Storage` + `Library/Application Support/Dia/User Data` path).
> 
> Updates tests to ensure `dia` is listed and correctly configured, and updates the README platform-support table to include Dia on macOS.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e655671548f3a41501d78bee67c153d11eb9f54. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->