### PR TITLE
Fix bookmark export, sync rebuild, and classification regressions

### DIFF
--- a/src/bookmark-classify-llm.ts
+++ b/src/bookmark-classify-llm.ts
@@ -72,12 +72,72 @@ ${items}`;
 
 // ── Parse and validate response ─────────────────────────────────────────
 
+function extractBalancedArraySpan(raw: string, start: number): string | null {
+  let depth = 0;
+  let inString = false;
+  let escape = false;
+
+  for (let i = start; i < raw.length; i += 1) {
+    const ch = raw[i];
+
+    if (escape) {
+      escape = false;
+      continue;
+    }
+
+    if (inString) {
+      if (ch === '\\') {
+        escape = true;
+      } else if (ch === '"') {
+        inString = false;
+      }
+      continue;
+    }
+
+    if (ch === '"') {
+      inString = true;
+      continue;
+    }
+
+    if (ch === '[') {
+      depth += 1;
+      continue;
+    }
+
+    if (ch === ']') {
+      depth -= 1;
+      if (depth === 0) return raw.slice(start, i + 1);
+    }
+  }
+
+  return null;
+}
+
+export function extractJsonArray(raw: string): string | null {
+  for (let start = raw.indexOf('['); start !== -1; start = raw.indexOf('[', start + 1)) {
+    const candidate = extractBalancedArraySpan(raw, start);
+    if (!candidate) return null;
+
+    try {
+      const parsed = JSON.parse(candidate);
+      const looksLikeObjectArray =
+        Array.isArray(parsed) &&
+        (parsed.length === 0 || parsed.some((item) => item != null && typeof item === 'object' && !Array.isArray(item)));
+      if (looksLikeObjectArray) return candidate;
+    } catch {
+      // Keep scanning for a later bracket span that is valid JSON.
+    }
+  }
+
+  return null;
+}
+
 function parseResponse(raw: string, batchIds: Set<string>): LlmClassification[] {
   // Extract JSON array from response (model might add markdown fences or commentary)
-  const jsonMatch = raw.match(/\[[\s\S]*\]/);
-  if (!jsonMatch) throw new Error('No JSON array found in response');
+  const jsonArray = extractJsonArray(raw);
+  if (!jsonArray) throw new Error('No JSON array found in response');
 
-  const parsed = JSON.parse(jsonMatch[0]);
+  const parsed = JSON.parse(jsonArray);
   if (!Array.isArray(parsed)) throw new Error('Response is not an array');
 
   const results: LlmClassification[] = [];

--- a/src/graphql-bookmarks.ts
+++ b/src/graphql-bookmarks.ts
@@ -323,7 +323,12 @@ export function convertTweetToRecord(tweetResult: any, now: string): BookmarkRec
 
   // X Articles / long-form note tweets store full text separately
   const noteTweetText = tweet?.note_tweet?.note_tweet_results?.result?.text;
-  const text = noteTweetText ?? legacy.full_text ?? legacy.text ?? '';
+  let text = noteTweetText ?? legacy.full_text ?? legacy.text ?? '';
+  for (const entity of urlEntities) {
+    if (typeof entity?.url === 'string' && typeof entity?.display_url === 'string') {
+      text = text.split(entity.url).join(entity.display_url);
+    }
+  }
 
   return {
     id: tweetId,
@@ -571,7 +576,7 @@ export async function syncBookmarksGraphQL(
     result.records.forEach((r) => allSeenIds.push(r.id));
     const reachedLatestStored = Boolean(newestKnownId) && result.records.some((record) => record.id === newestKnownId);
 
-    stalePages = added === 0 ? stalePages + 1 : 0;
+    stalePages = (incremental ? added === 0 : result.records.length === 0) ? stalePages + 1 : 0;
 
     options.onProgress?.({
       page,

--- a/src/md-export.ts
+++ b/src/md-export.ts
@@ -15,6 +15,7 @@ import path from 'node:path';
 import { ensureDir, writeMd } from './fs.js';
 import { mdDir } from './paths.js';
 import { listBookmarks, countBookmarks, type BookmarkTimelineItem } from './bookmarks-db.js';
+import { toIsoDate } from './date-utils.js';
 import { slug } from './md.js';
 
 export interface ExportOptions {
@@ -33,8 +34,12 @@ function bookmarksDir(): string {
   return path.join(mdDir(), 'bookmarks');
 }
 
+function exportDate(value?: string | null): string | null {
+  return toIsoDate(value);
+}
+
 function bookmarkFilename(b: BookmarkTimelineItem): string {
-  const date = (b.postedAt ?? b.bookmarkedAt ?? '').slice(0, 10) || 'undated';
+  const date = exportDate(b.postedAt ?? b.bookmarkedAt) ?? 'undated';
   const author = b.authorHandle ? slug(b.authorHandle) : 'unknown';
   const textSlug = slug(b.text.slice(0, 50)) || b.id;
   return `${date}-${author}-${textSlug}.md`;
@@ -47,8 +52,10 @@ function buildBookmarkMd(b: BookmarkTimelineItem): string {
   lines.push('---');
   if (b.authorHandle) lines.push(`author: "@${b.authorHandle}"`);
   if (b.authorName) lines.push(`author_name: "${b.authorName.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\n/g, ' ')}"`);
-  if (b.postedAt) lines.push(`posted_at: ${b.postedAt.slice(0, 10)}`);
-  if (b.bookmarkedAt) lines.push(`bookmarked_at: ${b.bookmarkedAt.slice(0, 10)}`);
+  const postedAt = exportDate(b.postedAt);
+  const bookmarkedAt = exportDate(b.bookmarkedAt);
+  if (postedAt) lines.push(`posted_at: ${postedAt}`);
+  if (bookmarkedAt) lines.push(`bookmarked_at: ${bookmarkedAt}`);
   if (b.primaryCategory) lines.push(`category: ${b.primaryCategory}`);
   if (b.primaryDomain) lines.push(`domain: ${b.primaryDomain}`);
   if (b.categories.length > 0) lines.push(`categories: [${b.categories.join(', ')}]`);

--- a/tests/bookmark-classify-llm.test.ts
+++ b/tests/bookmark-classify-llm.test.ts
@@ -1,0 +1,34 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { extractJsonArray } from '../src/bookmark-classify-llm.js';
+
+test('extractJsonArray: stops at the end of the first balanced JSON array', () => {
+  const raw = `Here you go:
+[{"id":"1","domains":["ai","finance"],"primary":"ai"}]
+
+Some of [these bookmarks] look ambiguous.`;
+
+  assert.equal(
+    extractJsonArray(raw),
+    '[{"id":"1","domains":["ai","finance"],"primary":"ai"}]',
+  );
+});
+
+test('extractJsonArray: skips bracketed prose before the real JSON array', () => {
+  const raw = `Status [draft only]
+[{"id":"1","domains":["ai"],"primary":"ai"}]`;
+
+  assert.equal(
+    extractJsonArray(raw),
+    '[{"id":"1","domains":["ai"],"primary":"ai"}]',
+  );
+});
+
+test('extractJsonArray: ignores brackets inside JSON strings', () => {
+  const raw = '[{"id":"1","domains":["ai"],"primary":"ai","note":"keep [this] literal"}] trailing ]';
+
+  assert.equal(
+    extractJsonArray(raw),
+    '[{"id":"1","domains":["ai"],"primary":"ai","note":"keep [this] literal"}]',
+  );
+});

--- a/tests/graphql-bookmarks.test.ts
+++ b/tests/graphql-bookmarks.test.ts
@@ -17,6 +17,7 @@ import {
   applyFolderMirror,
   clearFolderEverywhere,
   formatSyncResult,
+  syncBookmarksGraphQL,
   syncGaps,
 } from '../src/graphql-bookmarks.js';
 import { buildIndex, getBookmarkById } from '../src/bookmarks-db.js';
@@ -189,6 +190,22 @@ test('convertTweetToRecord: extracts links, filtering out t.co', () => {
 
   assert.equal(result.links!.length, 1);
   assert.equal(result.links![0], 'https://example.com/article');
+});
+
+test('convertTweetToRecord: expands t.co links in visible text using display_url', () => {
+  const result = convertTweetToRecord(makeTweetResult({
+    legacy: {
+      full_text: 'Check this: https://t.co/abc and this: https://t.co/def',
+      entities: {
+        urls: [
+          { expanded_url: 'https://example.com/article', url: 'https://t.co/abc', display_url: 'example.com/foo' },
+          { expanded_url: 'https://tools.exec.security', url: 'https://t.co/def', display_url: 'tools.exec.security' },
+        ],
+      },
+    },
+  }), NOW)!;
+
+  assert.equal(result.text, 'Check this: example.com/foo and this: tools.exec.security');
 });
 
 test('convertTweetToRecord: handles location as object', () => {
@@ -579,6 +596,74 @@ test('syncGaps: transient failure does NOT stamp textExpandedAt so next run retr
       'transient failures must not mark the record so the next run can retry',
     );
   }, [truncated]);
+});
+
+test('syncBookmarksGraphQL: rebuild mode does not treat merged-only pages as stale', async () => {
+  const page1 = makeGraphQLResponse([
+    makeTweetResult({
+      rest_id: '1',
+      legacy: {
+        id_str: '1',
+        full_text: 'First existing bookmark',
+        created_at: 'Tue Mar 11 12:00:00 +0000 2026',
+      },
+    }),
+  ], 'cursor-2');
+  const page2 = makeGraphQLResponse([
+    makeTweetResult({
+      rest_id: '2',
+      legacy: {
+        id_str: '2',
+        full_text: 'Second existing bookmark',
+        created_at: 'Tue Mar 10 12:00:00 +0000 2026',
+      },
+    }),
+  ]);
+
+  const existing = [
+    makeRecord({
+      id: '1',
+      tweetId: '1',
+      text: 'First existing bookmark',
+      postedAt: 'Tue Mar 11 12:00:00 +0000 2026',
+    }),
+    makeRecord({
+      id: '2',
+      tweetId: '2',
+      text: 'Second existing bookmark',
+      postedAt: 'Tue Mar 10 12:00:00 +0000 2026',
+    }),
+  ];
+
+  await withIsolatedGapFillDataDir(async () => {
+    const originalFetch = globalThis.fetch;
+    let fetchCalls = 0;
+    globalThis.fetch = (async () => {
+      const body = fetchCalls === 0 ? page1 : page2;
+      fetchCalls += 1;
+      return new Response(JSON.stringify(body), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }) as typeof fetch;
+
+    try {
+      const result = await syncBookmarksGraphQL({
+        incremental: false,
+        csrfToken: 'ct0',
+        cookieHeader: 'ct0=ct0; auth_token=auth',
+        delayMs: 0,
+        stalePageLimit: 1,
+      });
+
+      assert.equal(fetchCalls, 2);
+      assert.equal(result.pages, 2);
+      assert.equal(result.added, 0);
+      assert.equal(result.stopReason, 'end of bookmarks');
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  }, existing);
 });
 
 test('syncGaps: permanent quoted-tweet failure stamps quotedTweetFailedAt so reruns skip it', async () => {

--- a/tests/md-export.test.ts
+++ b/tests/md-export.test.ts
@@ -1,0 +1,59 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, readFile, readdir, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { buildIndex } from '../src/bookmarks-db.js';
+import { exportBookmarks } from '../src/md-export.js';
+
+async function withIsolatedDataDir(fn: (dir: string) => Promise<void>, fixtures: any[]): Promise<void> {
+  const dir = await mkdtemp(path.join(tmpdir(), 'ft-md-export-'));
+  const jsonl = fixtures.map((r) => JSON.stringify(r)).join('\n') + '\n';
+  await writeFile(path.join(dir, 'bookmarks.jsonl'), jsonl);
+
+  const saved = process.env.FT_DATA_DIR;
+  process.env.FT_DATA_DIR = dir;
+  try {
+    await fn(dir);
+  } finally {
+    if (saved !== undefined) process.env.FT_DATA_DIR = saved;
+    else delete process.env.FT_DATA_DIR;
+  }
+}
+
+test('exportBookmarks: writes ISO dates for legacy postedAt in filenames and frontmatter', async () => {
+  const fixtures = [
+    {
+      id: '1908170645818536087',
+      tweetId: '1908170645818536087',
+      url: 'https://x.com/Thom_Wolf/status/1908170645818536087',
+      text: 'Test md export dates',
+      authorHandle: 'Thom_Wolf',
+      authorName: 'Thomas Wolf',
+      syncedAt: '2026-04-18T00:00:00.000Z',
+      postedAt: 'Fri Apr 04 19:53:15 +0000 2026',
+      bookmarkedAt: '2026-04-17T08:07:48.007Z',
+      language: 'en',
+      engagement: { likeCount: 61, repostCount: 12 },
+      mediaObjects: [],
+      links: [],
+      tags: [],
+      ingestedVia: 'graphql',
+    },
+  ];
+
+  await withIsolatedDataDir(async (dir) => {
+    await buildIndex();
+
+    const result = await exportBookmarks({ force: true });
+    assert.equal(result.exported, 1);
+
+    const bookmarksDir = path.join(dir, 'md', 'bookmarks');
+    const files = await readdir(bookmarksDir);
+    assert.deepEqual(files, ['2026-04-04-thom-wolf-test-md-export-dates.md']);
+
+    const content = await readFile(path.join(bookmarksDir, files[0]), 'utf8');
+    assert.match(content, /^posted_at: 2026-04-04$/m);
+    assert.match(content, /^bookmarked_at: 2026-04-17$/m);
+  }, fixtures);
+});


### PR DESCRIPTION
## Summary
- fix `ft md` bookmark export dates so filenames and frontmatter both use ISO dates for legacy Twitter timestamps
- fix GraphQL rebuild sync so merged-only pages are not treated as stale, and expand visible `t.co` text with `display_url`
- harden LLM classification response parsing so bracketed prose does not break JSON extraction

## Verification
- `./node_modules/.bin/tsx --test tests/bookmark-classify-llm.test.ts tests/graphql-bookmarks.test.ts tests/md-export.test.ts`
- `npm run build`

Addresses #53, #77, #97, #98.