### PR TITLE
bump v1.3.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fieldtheory",
-  "version": "1.3.9",
+  "version": "1.3.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fieldtheory",
-      "version": "1.3.9",
+      "version": "1.3.11",
       "license": "MIT",
       "dependencies": {
         "commander": "^14.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fieldtheory",
-  "version": "1.3.9",
+  "version": "1.3.11",
   "description": "Field Theory CLI. Self-custody for your X/Twitter bookmarks. Local sync, full-text search, classification, and terminal dashboards.",
   "type": "module",
   "bin": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -177,6 +177,12 @@ function showCachedUpdateNotice(): void {
 // ── What's new ────────────────────────────────────────────────────────────
 
 const WHATS_NEW: Record<string, string[]> = {
+  '1.3.11': [
+    'ft md now exports correct ISO dates in bookmark filenames and frontmatter',
+    'ft sync --rebuild now refreshes existing caches without stopping early',
+    'ft classify-domains is more robust when the model adds bracketed commentary',
+    'Bookmark text now expands visible t.co links using display_url',
+  ],
   '1.3.9': [
     'ft sync now captures full long-form note_tweets (Karpathy-style threads) instead of 275-char previews',
     'ft sync --gaps backfills existing truncated note_tweets via an authenticated GraphQL path',


### PR DESCRIPTION
## Summary
- bump the CLI version from `1.3.9` to `1.3.11`
- add `What’s new` notes for the regression fixes that landed in #104

## Verification
- `npm run build`