### PR TITLE
fix: pause bookmark sync cleanly on rate limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ On first run, `ft sync` extracts your X session from Chrome and downloads your b
 |---------|-------------|
 | `ft sync` | Download and sync bookmarks (no API required) |
 | `ft sync --rebuild` | Full re-crawl of all bookmarks |
-| `ft sync --continue` | Resume an interrupted sync from the saved cursor |
+| `ft sync --continue` | Resume a paused or interrupted sync from the saved cursor |
 | `ft sync --gaps` | Backfill quoted tweets, expand truncated articles, enrich linked article content |
 | `ft sync --folders` | Also sync X bookmark folder tags (read-only mirror of X state) |
 | `ft sync --folder <name>` | Sync a single folder by name (exact or unambiguous prefix) |

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -92,12 +92,21 @@ const FRIENDLY_STOP_REASONS: Record<string, string> = {
   'end of bookmarks': 'Sync complete \u2014 all bookmarks fetched.',
   'max runtime reached': 'Paused after 30 minutes. Run again to continue.',
   'max pages reached': 'Paused after reaching page limit. Run again to continue.',
+  'rate limited': 'Paused by X rate limiting.',
   'target additions reached': 'Reached target bookmark count.',
 };
 
 function friendlyStopReason(raw?: string): string {
   if (!raw) return 'Sync complete.';
   return FRIENDLY_STOP_REASONS[raw] ?? `Sync complete \u2014 ${raw}`;
+}
+
+function formatRetryAfter(seconds?: number): string | undefined {
+  if (!seconds || seconds <= 0) return undefined;
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  const remainingSeconds = seconds % 60;
+  return remainingSeconds > 0 ? `${minutes}m ${remainingSeconds}s` : `${minutes}m`;
 }
 
 function warnIfEmpty(totalBookmarks: number): void {
@@ -712,6 +721,14 @@ export function buildCli() {
 
           console.log(`\n  \u2713 ${result.added} new bookmarks synced (${result.totalBookmarks} total)`);
           console.log(`  ${friendlyStopReason(result.stopReason)}`);
+          if (result.stopReason === 'rate limited') {
+            const retryAfter = formatRetryAfter(result.retryAfterSec);
+            if (retryAfter) {
+              console.log(`  Retry after about ${retryAfter}, then resume with: ft sync --continue`);
+            } else {
+              console.log('  Resume with: ft sync --continue');
+            }
+          }
           if (result.bookmarkedAtRepaired > 0) {
             console.log(`  \u2713 ${result.bookmarkedAtRepaired} invalid bookmark dates cleared`);
           }

--- a/src/graphql-bookmarks.ts
+++ b/src/graphql-bookmarks.ts
@@ -743,11 +743,12 @@ export async function syncBookmarksGraphQL(
 
   const syncedAt = new Date().toISOString();
   const bookmarkedAtMissing = existing.filter((record) => !record.bookmarkedAt).length;
+  const completedFullSync = !incremental && stopReason === 'end of bookmarks';
   await writeJsonLines(cachePath, existing);
   await writeJson(metaPath, {
     provider: 'twitter',
     schemaVersion: 1,
-    lastFullSyncAt: incremental ? previousMeta?.lastFullSyncAt : syncedAt,
+    lastFullSyncAt: completedFullSync ? syncedAt : previousMeta?.lastFullSyncAt,
     lastIncrementalSyncAt: incremental ? syncedAt : previousMeta?.lastIncrementalSyncAt,
     totalBookmarks: existing.length,
   } satisfies BookmarkCacheMeta);

--- a/src/graphql-bookmarks.ts
+++ b/src/graphql-bookmarks.ts
@@ -113,6 +113,7 @@ export interface SyncResult {
   stopReason: string;
   cachePath: string;
   statePath: string;
+  retryAfterSec?: number;
 }
 
 function parseSnowflake(value?: string | null): bigint | null {
@@ -398,6 +399,35 @@ export function parseBookmarksResponse(json: any, now?: string): PageResult {
   return { records, nextCursor };
 }
 
+class RateLimitError extends Error {
+  constructor(message: string, readonly retryAfterSec?: number) {
+    super(message);
+    this.name = 'RateLimitError';
+  }
+}
+
+function parseRetryAfterSec(response: Response): number | undefined {
+  const retryAfter = response.headers.get('retry-after');
+  if (retryAfter) {
+    const seconds = Number(retryAfter);
+    if (Number.isFinite(seconds) && seconds > 0) return Math.ceil(seconds);
+
+    const resumeAt = Date.parse(retryAfter);
+    if (!Number.isNaN(resumeAt)) {
+      const secondsUntil = Math.ceil((resumeAt - Date.now()) / 1000);
+      if (secondsUntil > 0) return secondsUntil;
+    }
+  }
+
+  const resetAt = Number(response.headers.get('x-rate-limit-reset'));
+  if (Number.isFinite(resetAt) && resetAt > 0) {
+    const secondsUntil = Math.ceil(resetAt - Date.now() / 1000);
+    if (secondsUntil > 0) return secondsUntil;
+  }
+
+  return undefined;
+}
+
 async function fetchPageWithRetry(csrfToken: string, cursor?: string, cookieHeader?: string, pageSize?: number): Promise<PageResult> {
   let lastError: Error | undefined;
 
@@ -405,8 +435,9 @@ async function fetchPageWithRetry(csrfToken: string, cursor?: string, cookieHead
     const response = await fetch(buildUrl(cursor, pageSize), { headers: buildHeaders(csrfToken, cookieHeader) });
 
     if (response.status === 429) {
-      const waitSec = Math.min(15 * Math.pow(2, attempt), 120);
-      lastError = new Error(`Rate limited (429) on attempt ${attempt + 1}`);
+      const retryAfterSec = parseRetryAfterSec(response);
+      const waitSec = retryAfterSec ?? Math.min(15 * Math.pow(2, attempt), 120);
+      lastError = new RateLimitError(`Rate limited (429) on attempt ${attempt + 1}`, retryAfterSec);
       await new Promise((r) => setTimeout(r, waitSec * 1000));
       continue;
     }
@@ -555,6 +586,20 @@ export async function syncBookmarksGraphQL(
   let cursor: string | undefined = options.resumeCursor;
   const allSeenIds: string[] = [];
   let stopReason = 'unknown';
+  let retryAfterSec: number | undefined;
+
+  const fetchNextPage = async (): Promise<PageResult | undefined> => {
+    try {
+      return await fetchPageWithRetry(csrfToken, cursor, cookieHeader, pageSize);
+    } catch (error) {
+      if (error instanceof RateLimitError) {
+        stopReason = 'rate limited';
+        retryAfterSec = error.retryAfterSec;
+        return undefined;
+      }
+      throw error;
+    }
+  };
 
   while (page < maxPages) {
     if (Date.now() - started > maxMinutes * 60_000) {
@@ -562,7 +607,8 @@ export async function syncBookmarksGraphQL(
       break;
     }
 
-    const result = await fetchPageWithRetry(csrfToken, cursor, cookieHeader, pageSize);
+    const result = await fetchNextPage();
+    if (!result) break;
     page += 1;
 
     if (result.records.length === 0 && !result.nextCursor) {
@@ -624,6 +670,7 @@ export async function syncBookmarksGraphQL(
     !options.resumeCursor &&
     existing.length >= OLD_CAP_THRESHOLD &&
     !terminalStops.has(stopReason) &&
+    stopReason !== 'rate limited' &&
     cursor != null;
 
   if (shouldAutoContinue) {
@@ -651,7 +698,8 @@ export async function syncBookmarksGraphQL(
         break;
       }
 
-      const result = await fetchPageWithRetry(csrfToken, cursor, cookieHeader, pageSize);
+      const result = await fetchNextPage();
+      if (!result) break;
       page += 1;
 
       if (result.records.length === 0 && !result.nextCursor) {
@@ -733,6 +781,7 @@ export async function syncBookmarksGraphQL(
     stopReason,
     cachePath,
     statePath,
+    retryAfterSec,
   };
 }
 

--- a/tests/graphql-bookmarks.test.ts
+++ b/tests/graphql-bookmarks.test.ts
@@ -682,6 +682,12 @@ test('syncBookmarksGraphQL: rate limit stops cleanly and saves cursor for contin
     const originalFetch = globalThis.fetch;
     const originalSetTimeout = globalThis.setTimeout;
     let fetchCalls = 0;
+    await writeFile(path.join(process.env.FT_DATA_DIR!, 'bookmarks-meta.json'), JSON.stringify({
+      provider: 'twitter',
+      schemaVersion: 1,
+      lastFullSyncAt: '2026-04-18T12:00:00.000Z',
+      totalBookmarks: existing.length,
+    }));
     globalThis.fetch = (async () => {
       fetchCalls += 1;
       if (fetchCalls === 1) {
@@ -718,6 +724,9 @@ test('syncBookmarksGraphQL: rate limit stops cleanly and saves cursor for contin
       const state = JSON.parse(await readFile(path.join(process.env.FT_DATA_DIR!, 'bookmarks-backfill-state.json'), 'utf8'));
       assert.equal(state.stopReason, 'rate limited');
       assert.equal(state.lastCursor, 'cursor-2');
+
+      const meta = JSON.parse(await readFile(path.join(process.env.FT_DATA_DIR!, 'bookmarks-meta.json'), 'utf8'));
+      assert.equal(meta.lastFullSyncAt, '2026-04-18T12:00:00.000Z');
     } finally {
       globalThis.fetch = originalFetch;
       globalThis.setTimeout = originalSetTimeout;

--- a/tests/graphql-bookmarks.test.ts
+++ b/tests/graphql-bookmarks.test.ts
@@ -666,6 +666,65 @@ test('syncBookmarksGraphQL: rebuild mode does not treat merged-only pages as sta
   }, existing);
 });
 
+test('syncBookmarksGraphQL: rate limit stops cleanly and saves cursor for continue', async () => {
+  const page1 = makeGraphQLResponse([makeTweetResult()], 'cursor-2');
+
+  const existing = [
+    makeRecord({
+      id: '1234567890',
+      tweetId: '1234567890',
+      text: 'Existing bookmark',
+      postedAt: 'Tue Mar 10 12:00:00 +0000 2026',
+    }),
+  ];
+
+  await withIsolatedGapFillDataDir(async () => {
+    const originalFetch = globalThis.fetch;
+    const originalSetTimeout = globalThis.setTimeout;
+    let fetchCalls = 0;
+    globalThis.fetch = (async () => {
+      fetchCalls += 1;
+      if (fetchCalls === 1) {
+        return new Response(JSON.stringify(page1), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      return new Response('', {
+        status: 429,
+        headers: { 'retry-after': '1' },
+      });
+    }) as typeof fetch;
+    globalThis.setTimeout = (((handler: TimerHandler, _timeout?: number, ...args: any[]) => {
+      if (typeof handler === 'function') handler(...args);
+      return 0 as any;
+    }) as typeof setTimeout);
+
+    try {
+      const result = await syncBookmarksGraphQL({
+        incremental: false,
+        csrfToken: 'ct0',
+        cookieHeader: 'ct0=ct0; auth_token=auth',
+        delayMs: 0,
+        stalePageLimit: 1,
+      });
+
+      assert.equal(fetchCalls, 5);
+      assert.equal(result.pages, 1);
+      assert.equal(result.added, 0);
+      assert.equal(result.stopReason, 'rate limited');
+      assert.equal(result.retryAfterSec, 1);
+
+      const state = JSON.parse(await readFile(path.join(process.env.FT_DATA_DIR!, 'bookmarks-backfill-state.json'), 'utf8'));
+      assert.equal(state.stopReason, 'rate limited');
+      assert.equal(state.lastCursor, 'cursor-2');
+    } finally {
+      globalThis.fetch = originalFetch;
+      globalThis.setTimeout = originalSetTimeout;
+    }
+  }, existing);
+});
+
 test('syncGaps: permanent quoted-tweet failure stamps quotedTweetFailedAt so reruns skip it', async () => {
   const deadQuoted: BookmarkRecord = {
     id: '222',


### PR DESCRIPTION
## Summary
- treat terminal bookmark-sync 429s as a clean pause instead of throwing
- save the cursor so `ft sync --continue` can resume rebuilds and other deep crawls
- add a friendly CLI resume hint and update the README wording for paused syncs
- add a regression test for mid-crawl rate limiting

## Verification
- `./node_modules/.bin/tsx --test tests/graphql-bookmarks.test.ts`
- `npm run build`