### PR TITLE
bump v1.3.12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fieldtheory",
-  "version": "1.3.11",
+  "version": "1.3.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fieldtheory",
-      "version": "1.3.11",
+      "version": "1.3.12",
       "license": "MIT",
       "dependencies": {
         "commander": "^14.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fieldtheory",
-  "version": "1.3.11",
+  "version": "1.3.12",
   "description": "Field Theory CLI. Self-custody for your X/Twitter bookmarks. Local sync, full-text search, classification, and terminal dashboards.",
   "type": "module",
   "bin": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -186,6 +186,14 @@ function showCachedUpdateNotice(): void {
 // ── What's new ────────────────────────────────────────────────────────────
 
 const WHATS_NEW: Record<string, string[]> = {
+  '1.3.12': [
+    'ft md now exports correct ISO dates in bookmark filenames and frontmatter',
+    'ft sync --rebuild now refreshes existing caches without stopping early',
+    'ft classify-domains is more robust when the model adds bracketed commentary',
+    'Bookmark text now expands visible t.co links using display_url',
+    'ft sync now pauses cleanly on X rate limits and saves progress for ft sync --continue',
+    'Paused rebuilds no longer mark a full bookmark crawl as completed',
+  ],
   '1.3.11': [
     'ft md now exports correct ISO dates in bookmark filenames and frontmatter',
     'ft sync --rebuild now refreshes existing caches without stopping early',


### PR DESCRIPTION
## Summary
- bump the package version from 1.3.11 to 1.3.12
- add a 1.3.12 What's new entry that bundles the 1.3.11 regression fixes with the paused-sync recovery changes

## Verification
- `npm run build`