### PR TITLE
Add media backfill improvements and bump to 1.3.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ On first run, `ft sync` extracts your X session from Chrome and downloads your b
 | `ft sync --folders` | Also sync X bookmark folder tags (read-only mirror of X state) |
 | `ft sync --folder <name>` | Sync a single folder by name (exact or unambiguous prefix) |
 | `ft sync --classify` | Sync then classify new bookmarks with LLM |
+| `ft sync --media` | Sync bookmarks, then download X media assets locally (photos, video posters, capped videos) |
 | `ft sync --api` | Sync via OAuth API (cross-platform) |
 | `ft auth` | Set up OAuth for API-based sync (optional) |
 
@@ -94,7 +95,7 @@ On first run, `ft sync` extracts your X session from Chrome and downloads your b
 | Command | Description |
 |---------|-------------|
 | `ft index` | Rebuild search index from JSONL cache (preserves classifications) |
-| `ft fetch-media` | Download media assets (static images only) |
+| `ft fetch-media` | Backfill/download X media assets for existing bookmarks (default: all pending bookmarks) |
 | `ft status` | Show sync status and data location |
 | `ft path` | Print data directory path |
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fieldtheory",
-  "version": "1.3.12",
+  "version": "1.3.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fieldtheory",
-      "version": "1.3.12",
+      "version": "1.3.13",
       "license": "MIT",
       "dependencies": {
         "commander": "^14.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fieldtheory",
-  "version": "1.3.12",
+  "version": "1.3.13",
   "description": "Field Theory CLI. Self-custody for your X/Twitter bookmarks. Local sync, full-text search, classification, and terminal dashboards.",
   "type": "module",
   "bin": {

--- a/src/bookmark-media.ts
+++ b/src/bookmark-media.ts
@@ -63,6 +63,23 @@ interface MediaTargetSource {
   mediaObjects?: BookmarkRecord['mediaObjects'];
 }
 
+interface CachedMediaResult {
+  localPath?: string;
+  contentType?: string;
+  bytes?: number;
+  status: MediaFetchEntry['status'];
+  reason?: string;
+  fetchedAt: string;
+}
+
+function mediaEntryKey(tweetId: string, sourceUrl: string, isProfileImage: boolean): string {
+  return isProfileImage ? `profile::${sourceUrl}` : `${tweetId}::${sourceUrl}`;
+}
+
+function mediaEntryKeyFromEntry(entry: MediaFetchEntry): string {
+  return mediaEntryKey(entry.tweetId, entry.sourceUrl, entry.sourceUrl.includes('/profile_images/'));
+}
+
 function sanitizeExtFromContentType(contentType?: string, sourceUrl?: string): string {
   if (contentType?.includes('jpeg')) return '.jpg';
   if (contentType?.includes('png')) return '.png';
@@ -99,7 +116,7 @@ function pushTarget(
   isProfileImage: boolean,
 ): void {
   if (!sourceUrl) return;
-  const key = isProfileImage ? `profile::${sourceUrl}` : `${base.tweetId}::${sourceUrl}`;
+  const key = mediaEntryKey(base.tweetId, sourceUrl, isProfileImage);
   if (seenKeys.has(key)) return;
   seenKeys.add(key);
   targets.push({
@@ -237,7 +254,8 @@ export async function fetchBookmarkMediaBatch(
     .filter(hasMediaCandidate)
     .filter((bookmark) => hasPendingMediaTarget(bookmark, coveredAssetKeys, coveredProfileImageUrls))
     .slice(0, limit);
-  const entries: MediaFetchEntry[] = previous?.entries ? [...previous.entries] : [];
+  const entriesByKey = new Map((previous?.entries ?? []).map((entry) => [mediaEntryKeyFromEntry(entry), entry]));
+  const cachedResultsBySourceUrl = new Map<string, CachedMediaResult>();
 
   let downloaded = 0;
   let skippedTooLarge = 0;
@@ -255,6 +273,44 @@ export async function fetchBookmarkMediaBatch(
     });
   };
 
+  const upsertEntry = (entry: MediaFetchEntry): void => {
+    entriesByKey.set(mediaEntryKeyFromEntry(entry), entry);
+  };
+
+  const applyCachedResult = (
+    target: MediaFetchTarget,
+    key: string,
+    cached: CachedMediaResult,
+  ): void => {
+    const { bookmarkId, tweetId, tweetUrl, authorHandle, authorName, sourceUrl, isProfileImage } = target;
+    if (isProfileImage) return;
+    upsertEntry({
+      bookmarkId,
+      tweetId,
+      tweetUrl,
+      authorHandle,
+      authorName,
+      sourceUrl,
+      localPath: cached.localPath,
+      contentType: cached.contentType,
+      bytes: cached.bytes,
+      status: cached.status,
+      reason: cached.reason,
+      fetchedAt: cached.fetchedAt,
+    });
+    if (cached.status === 'downloaded') {
+      coveredAssetKeys.add(key);
+      downloaded += 1;
+    } else if (cached.status === 'skipped_too_large') {
+      coveredAssetKeys.add(key);
+      skippedTooLarge += 1;
+    } else {
+      failed += 1;
+    }
+    processed += 1;
+    emitProgress(sourceUrl);
+  };
+
   emitProgress();
 
   for (const bookmark of candidates) {
@@ -262,8 +318,13 @@ export async function fetchBookmarkMediaBatch(
 
     for (const target of mediaTargets) {
       const { bookmarkId, tweetId, tweetUrl, authorHandle, authorName, sourceUrl, isProfileImage } = target;
-      const key = `${tweetId}::${sourceUrl}`;
+      const key = mediaEntryKey(tweetId, sourceUrl, isProfileImage);
       if (!isProfileImage && coveredAssetKeys.has(key)) continue;
+      const cachedResult = cachedResultsBySourceUrl.get(sourceUrl);
+      if (cachedResult) {
+        applyCachedResult(target, key, cachedResult);
+        continue;
+      }
 
       const fetchedAt = new Date().toISOString();
 
@@ -274,7 +335,7 @@ export async function fetchBookmarkMediaBatch(
         const declaredBytes = contentLengthHeader ? Number(contentLengthHeader) : undefined;
 
         if (typeof declaredBytes === 'number' && !Number.isNaN(declaredBytes) && declaredBytes > maxBytes) {
-          entries.push({
+          const entry = {
             bookmarkId,
             tweetId,
             tweetUrl,
@@ -285,6 +346,14 @@ export async function fetchBookmarkMediaBatch(
             bytes: declaredBytes,
             status: 'skipped_too_large',
             reason: `content-length ${declaredBytes} exceeds max ${maxBytes}`,
+            fetchedAt,
+          } satisfies MediaFetchEntry;
+          upsertEntry(entry);
+          cachedResultsBySourceUrl.set(sourceUrl, {
+            contentType,
+            bytes: declaredBytes,
+            status: entry.status,
+            reason: entry.reason,
             fetchedAt,
           });
           skippedTooLarge += 1;
@@ -297,7 +366,7 @@ export async function fetchBookmarkMediaBatch(
 
         const response = await fetch(sourceUrl);
         if (!response.ok) {
-          entries.push({
+          const entry = {
             bookmarkId,
             tweetId,
             tweetUrl,
@@ -306,6 +375,12 @@ export async function fetchBookmarkMediaBatch(
             sourceUrl,
             status: 'failed',
             reason: `HTTP ${response.status}`,
+            fetchedAt,
+          } satisfies MediaFetchEntry;
+          upsertEntry(entry);
+          cachedResultsBySourceUrl.set(sourceUrl, {
+            status: entry.status,
+            reason: entry.reason,
             fetchedAt,
           });
           failed += 1;
@@ -316,7 +391,7 @@ export async function fetchBookmarkMediaBatch(
 
         const buffer = Buffer.from(await response.arrayBuffer());
         if (buffer.byteLength > maxBytes) {
-          entries.push({
+          const entry = {
             bookmarkId,
             tweetId,
             tweetUrl,
@@ -328,8 +403,18 @@ export async function fetchBookmarkMediaBatch(
             status: 'skipped_too_large',
             reason: `downloaded size ${buffer.byteLength} exceeds max ${maxBytes}`,
             fetchedAt,
+          } satisfies MediaFetchEntry;
+          upsertEntry(entry);
+          cachedResultsBySourceUrl.set(sourceUrl, {
+            contentType: entry.contentType,
+            bytes: buffer.byteLength,
+            status: entry.status,
+            reason: entry.reason,
+            fetchedAt,
           });
           skippedTooLarge += 1;
+          if (isProfileImage) coveredProfileImageUrls.add(sourceUrl);
+          else coveredAssetKeys.add(key);
           processed += 1;
           emitProgress(sourceUrl);
           continue;
@@ -345,7 +430,7 @@ export async function fetchBookmarkMediaBatch(
         if (isProfileImage) coveredProfileImageUrls.add(sourceUrl);
         else coveredAssetKeys.add(key);
 
-        entries.push({
+        const entry = {
           bookmarkId,
           tweetId,
           tweetUrl,
@@ -357,12 +442,20 @@ export async function fetchBookmarkMediaBatch(
           bytes: buffer.byteLength,
           status: 'downloaded',
           fetchedAt,
+        } satisfies MediaFetchEntry;
+        upsertEntry(entry);
+        cachedResultsBySourceUrl.set(sourceUrl, {
+          localPath,
+          contentType: entry.contentType,
+          bytes: buffer.byteLength,
+          status: entry.status,
+          fetchedAt,
         });
         downloaded += 1;
         processed += 1;
         emitProgress(sourceUrl);
       } catch (error) {
-        entries.push({
+        const entry = {
           bookmarkId,
           tweetId,
           tweetUrl,
@@ -371,6 +464,12 @@ export async function fetchBookmarkMediaBatch(
           sourceUrl,
           status: 'failed',
           reason: error instanceof Error ? error.message : String(error),
+          fetchedAt,
+        } satisfies MediaFetchEntry;
+        upsertEntry(entry);
+        cachedResultsBySourceUrl.set(sourceUrl, {
+          status: entry.status,
+          reason: entry.reason,
           fetchedAt,
         });
         failed += 1;
@@ -390,7 +489,7 @@ export async function fetchBookmarkMediaBatch(
     downloaded,
     skippedTooLarge,
     failed,
-    entries,
+    entries: Array.from(entriesByKey.values()),
   };
 
   await writeJson(manifestPath, manifest);

--- a/src/bookmark-media.ts
+++ b/src/bookmark-media.ts
@@ -5,6 +5,8 @@ import { ensureDir, pathExists, readJson, readJsonLines, writeJson } from './fs.
 import { bookmarkMediaDir, bookmarkMediaManifestPath, twitterBookmarksCachePath } from './paths.js';
 import type { BookmarkRecord } from './types.js';
 
+export const DEFAULT_MEDIA_MAX_BYTES = 200 * 1024 * 1024;
+
 export interface MediaFetchEntry {
   bookmarkId: string;
   tweetId: string;
@@ -32,6 +34,35 @@ export interface MediaFetchManifest {
   entries: MediaFetchEntry[];
 }
 
+export interface MediaFetchProgress {
+  candidateBookmarks: number;
+  processed: number;
+  downloaded: number;
+  skippedTooLarge: number;
+  failed: number;
+  currentSourceUrl?: string;
+}
+
+interface MediaFetchTarget {
+  bookmarkId: string;
+  tweetId: string;
+  tweetUrl: string;
+  authorHandle?: string;
+  authorName?: string;
+  sourceUrl: string;
+  isProfileImage: boolean;
+}
+
+interface MediaTargetSource {
+  tweetId: string;
+  tweetUrl: string;
+  authorHandle?: string;
+  authorName?: string;
+  authorProfileImageUrl?: string;
+  media?: string[];
+  mediaObjects?: BookmarkRecord['mediaObjects'];
+}
+
 function sanitizeExtFromContentType(contentType?: string, sourceUrl?: string): string {
   if (contentType?.includes('jpeg')) return '.jpg';
   if (contentType?.includes('png')) return '.png';
@@ -51,26 +82,161 @@ async function loadManifest(): Promise<MediaFetchManifest | null> {
   return readJson<MediaFetchManifest>(manifestPath);
 }
 
+function hasTargets(source: { media?: unknown[]; mediaObjects?: unknown[]; authorProfileImageUrl?: string } | undefined): boolean {
+  if (!source) return false;
+  return (source.media?.length ?? 0) > 0 || (source.mediaObjects?.length ?? 0) > 0 || Boolean(source.authorProfileImageUrl);
+}
+
+function hasMediaCandidate(bookmark: BookmarkRecord): boolean {
+  return hasTargets(bookmark) || hasTargets(bookmark.quotedTweet);
+}
+
+function pushTarget(
+  targets: MediaFetchTarget[],
+  seenKeys: Set<string>,
+  base: Omit<MediaFetchTarget, 'sourceUrl' | 'isProfileImage'>,
+  sourceUrl: string | undefined,
+  isProfileImage: boolean,
+): void {
+  if (!sourceUrl) return;
+  const key = isProfileImage ? `profile::${sourceUrl}` : `${base.tweetId}::${sourceUrl}`;
+  if (seenKeys.has(key)) return;
+  seenKeys.add(key);
+  targets.push({
+    ...base,
+    sourceUrl,
+    isProfileImage,
+  });
+}
+
+function appendMediaTargets(
+  targets: MediaFetchTarget[],
+  seenKeys: Set<string>,
+  bookmarkId: string,
+  source: MediaTargetSource,
+  downloadedProfileImageUrls: Set<string>,
+): void {
+  const base = {
+    bookmarkId,
+    tweetId: source.tweetId,
+    tweetUrl: source.tweetUrl,
+    authorHandle: source.authorHandle,
+    authorName: source.authorName,
+  };
+
+  if (source.mediaObjects?.length) {
+    for (const mo of source.mediaObjects) {
+      const previewUrl = mo.previewUrl ?? mo.url ?? mo.mediaUrl;
+      if (mo.type === 'video' || mo.type === 'animated_gif') {
+        pushTarget(targets, seenKeys, base, previewUrl, false);
+        const mp4s = (mo.videoVariants ?? mo.variants ?? [])
+          .filter((v) => v.url && (!v.contentType || v.contentType === 'video/mp4'))
+          .sort((a, b) => (b.bitrate ?? 0) - (a.bitrate ?? 0));
+        pushTarget(targets, seenKeys, base, mp4s[0]?.url, false);
+        continue;
+      }
+      pushTarget(targets, seenKeys, base, previewUrl, false);
+    }
+  } else {
+    for (const mediaUrl of source.media ?? []) {
+      pushTarget(targets, seenKeys, base, mediaUrl, false);
+    }
+  }
+
+  if (source.authorProfileImageUrl) {
+    const fullUrl = source.authorProfileImageUrl.replace('_normal.', '_400x400.');
+    if (!downloadedProfileImageUrls.has(fullUrl)) {
+      pushTarget(targets, seenKeys, base, fullUrl, true);
+    }
+  }
+}
+
+function resolveMediaTargets(
+  bookmark: BookmarkRecord,
+  downloadedProfileImageUrls: Set<string>,
+): MediaFetchTarget[] {
+  const targets: MediaFetchTarget[] = [];
+  const seenKeys = new Set<string>();
+
+  appendMediaTargets(targets, seenKeys, bookmark.id, {
+    tweetId: bookmark.tweetId,
+    tweetUrl: bookmark.url,
+    authorHandle: bookmark.authorHandle,
+    authorName: bookmark.authorName,
+    authorProfileImageUrl: bookmark.authorProfileImageUrl,
+    media: bookmark.media,
+    mediaObjects: bookmark.mediaObjects,
+  }, downloadedProfileImageUrls);
+
+  if (bookmark.quotedTweet) {
+    appendMediaTargets(targets, seenKeys, bookmark.id, {
+      tweetId: bookmark.quotedTweet.id,
+      tweetUrl: bookmark.quotedTweet.url,
+      authorHandle: bookmark.quotedTweet.authorHandle,
+      authorName: bookmark.quotedTweet.authorName,
+      authorProfileImageUrl: bookmark.quotedTweet.authorProfileImageUrl,
+      media: bookmark.quotedTweet.media,
+      mediaObjects: bookmark.quotedTweet.mediaObjects,
+    }, downloadedProfileImageUrls);
+  }
+
+  return targets;
+}
+
+function isCoveredEntry(entry: MediaFetchEntry, maxBytes: number): boolean {
+  if (entry.status === 'downloaded') return true;
+  if (entry.status !== 'skipped_too_large') return false;
+  return typeof entry.bytes === 'number' && !Number.isNaN(entry.bytes) && entry.bytes > maxBytes;
+}
+
+function buildCoveredAssetKeys(previous: MediaFetchManifest | null, maxBytes: number): Set<string> {
+  return new Set(
+    (previous?.entries ?? [])
+      .filter((entry) => !entry.sourceUrl.includes('/profile_images/'))
+      .filter((entry) => isCoveredEntry(entry, maxBytes))
+      .map((entry) => `${entry.tweetId}::${entry.sourceUrl}`),
+  );
+}
+
+function buildCoveredProfileImageUrls(previous: MediaFetchManifest | null, maxBytes: number): Set<string> {
+  return new Set(
+    (previous?.entries ?? [])
+      .filter((entry) => entry.sourceUrl.includes('/profile_images/'))
+      .filter((entry) => isCoveredEntry(entry, maxBytes))
+      .map((entry) => entry.sourceUrl),
+  );
+}
+
+function hasPendingMediaTarget(
+  bookmark: BookmarkRecord,
+  coveredAssetKeys: Set<string>,
+  coveredProfileImageUrls: Set<string>,
+): boolean {
+  return resolveMediaTargets(bookmark, coveredProfileImageUrls).some(({ tweetId, sourceUrl, isProfileImage }) => {
+    if (isProfileImage) return true;
+    return !coveredAssetKeys.has(`${tweetId}::${sourceUrl}`);
+  });
+}
+
 export async function fetchBookmarkMediaBatch(
-  options: { limit?: number; maxBytes?: number } = {}
+  options: { limit?: number; maxBytes?: number; onProgress?: (progress: MediaFetchProgress) => void } = {}
 ): Promise<MediaFetchManifest> {
-  const limit = options.limit ?? 100;
-  const maxBytes = options.maxBytes ?? 50 * 1024 * 1024;
+  const limit = typeof options.limit === 'number' && !Number.isNaN(options.limit)
+    ? Math.max(0, options.limit)
+    : Infinity;
+  const maxBytes = options.maxBytes ?? DEFAULT_MEDIA_MAX_BYTES;
   const mediaDir = bookmarkMediaDir();
   const manifestPath = bookmarkMediaManifestPath();
   await ensureDir(mediaDir);
 
+  const previous = await loadManifest();
+  const coveredAssetKeys = buildCoveredAssetKeys(previous, maxBytes);
+  const coveredProfileImageUrls = buildCoveredProfileImageUrls(previous, maxBytes);
   const bookmarks = await readJsonLines<BookmarkRecord>(twitterBookmarksCachePath());
   const candidates = bookmarks
-    .filter((b) => (b.media?.length ?? 0) > 0 || (b.mediaObjects?.length ?? 0) > 0 || b.authorProfileImageUrl)
+    .filter(hasMediaCandidate)
+    .filter((bookmark) => hasPendingMediaTarget(bookmark, coveredAssetKeys, coveredProfileImageUrls))
     .slice(0, limit);
-  const previous = await loadManifest();
-  const priorKeys = new Set((previous?.entries ?? []).map((e) => `${e.bookmarkId}::${e.sourceUrl}`));
-  const downloadedProfileImageUrls = new Set(
-    (previous?.entries ?? [])
-      .filter((entry) => entry.status === 'downloaded' && entry.sourceUrl.includes('/profile_images/'))
-      .map((entry) => entry.sourceUrl),
-  );
   const entries: MediaFetchEntry[] = previous?.entries ? [...previous.entries] : [];
 
   let downloaded = 0;
@@ -78,36 +244,26 @@ export async function fetchBookmarkMediaBatch(
   let failed = 0;
   let processed = 0;
 
+  const emitProgress = (currentSourceUrl?: string) => {
+    options.onProgress?.({
+      candidateBookmarks: candidates.length,
+      processed,
+      downloaded,
+      skippedTooLarge,
+      failed,
+      currentSourceUrl,
+    });
+  };
+
+  emitProgress();
+
   for (const bookmark of candidates) {
-    // Resolve media URLs: prefer mediaObjects (richer, includes video variants), fall back to media[]
-    const mediaUrls: { sourceUrl: string; isProfileImage: boolean }[] = [];
-    if (bookmark.mediaObjects?.length) {
-      for (const mo of bookmark.mediaObjects) {
-        if (mo.type === 'video' || mo.type === 'animated_gif') {
-          const mp4s = (mo.videoVariants ?? mo.variants ?? [])
-            .filter((v) => v.url && (!v.contentType || v.contentType === 'video/mp4'))
-            .sort((a, b) => (b.bitrate ?? 0) - (a.bitrate ?? 0));
-          if (mp4s.length > 0 && mp4s[0].url) { mediaUrls.push({ sourceUrl: mp4s[0].url, isProfileImage: false }); continue; }
-        }
-        const mediaUrl = mo.url ?? mo.mediaUrl;
-        if (mediaUrl) mediaUrls.push({ sourceUrl: mediaUrl, isProfileImage: false });
-      }
-    } else {
-      mediaUrls.push(...(bookmark.media ?? []).map((sourceUrl) => ({ sourceUrl, isProfileImage: false })));
-    }
+    const mediaTargets = resolveMediaTargets(bookmark, coveredProfileImageUrls);
 
-    // Also include author profile image (upgraded to 400x400)
-    if (bookmark.authorProfileImageUrl) {
-      const fullUrl = bookmark.authorProfileImageUrl.replace('_normal.', '_400x400.');
-      if (!downloadedProfileImageUrls.has(fullUrl)) {
-        mediaUrls.push({ sourceUrl: fullUrl, isProfileImage: true });
-      }
-    }
-
-    for (const { sourceUrl, isProfileImage } of mediaUrls) {
-      const key = `${bookmark.id}::${sourceUrl}`;
-      if (!isProfileImage && priorKeys.has(key)) continue;
-      processed += 1;
+    for (const target of mediaTargets) {
+      const { bookmarkId, tweetId, tweetUrl, authorHandle, authorName, sourceUrl, isProfileImage } = target;
+      const key = `${tweetId}::${sourceUrl}`;
+      if (!isProfileImage && coveredAssetKeys.has(key)) continue;
 
       const fetchedAt = new Date().toISOString();
 
@@ -119,11 +275,11 @@ export async function fetchBookmarkMediaBatch(
 
         if (typeof declaredBytes === 'number' && !Number.isNaN(declaredBytes) && declaredBytes > maxBytes) {
           entries.push({
-            bookmarkId: bookmark.id,
-            tweetId: bookmark.tweetId,
-            tweetUrl: bookmark.url,
-            authorHandle: bookmark.authorHandle,
-            authorName: bookmark.authorName,
+            bookmarkId,
+            tweetId,
+            tweetUrl,
+            authorHandle,
+            authorName,
             sourceUrl,
             contentType,
             bytes: declaredBytes,
@@ -132,34 +288,40 @@ export async function fetchBookmarkMediaBatch(
             fetchedAt,
           });
           skippedTooLarge += 1;
+          if (isProfileImage) coveredProfileImageUrls.add(sourceUrl);
+          else coveredAssetKeys.add(key);
+          processed += 1;
+          emitProgress(sourceUrl);
           continue;
         }
 
         const response = await fetch(sourceUrl);
         if (!response.ok) {
           entries.push({
-            bookmarkId: bookmark.id,
-            tweetId: bookmark.tweetId,
-            tweetUrl: bookmark.url,
-            authorHandle: bookmark.authorHandle,
-            authorName: bookmark.authorName,
+            bookmarkId,
+            tweetId,
+            tweetUrl,
+            authorHandle,
+            authorName,
             sourceUrl,
             status: 'failed',
             reason: `HTTP ${response.status}`,
             fetchedAt,
           });
           failed += 1;
+          processed += 1;
+          emitProgress(sourceUrl);
           continue;
         }
 
         const buffer = Buffer.from(await response.arrayBuffer());
         if (buffer.byteLength > maxBytes) {
           entries.push({
-            bookmarkId: bookmark.id,
-            tweetId: bookmark.tweetId,
-            tweetUrl: bookmark.url,
-            authorHandle: bookmark.authorHandle,
-            authorName: bookmark.authorName,
+            bookmarkId,
+            tweetId,
+            tweetUrl,
+            authorHandle,
+            authorName,
             sourceUrl,
             contentType: response.headers.get('content-type') ?? contentType ?? undefined,
             bytes: buffer.byteLength,
@@ -168,6 +330,8 @@ export async function fetchBookmarkMediaBatch(
             fetchedAt,
           });
           skippedTooLarge += 1;
+          processed += 1;
+          emitProgress(sourceUrl);
           continue;
         }
 
@@ -175,17 +339,18 @@ export async function fetchBookmarkMediaBatch(
         const ext = sanitizeExtFromContentType(response.headers.get('content-type') ?? contentType ?? undefined, sourceUrl);
         const filename = isProfileImage
           ? `${digest}${ext}`
-          : `${bookmark.tweetId}-${digest}${ext}`;
+          : `${tweetId}-${digest}${ext}`;
         const localPath = path.join(mediaDir, filename);
         await writeFile(localPath, buffer);
-        if (isProfileImage) downloadedProfileImageUrls.add(sourceUrl);
+        if (isProfileImage) coveredProfileImageUrls.add(sourceUrl);
+        else coveredAssetKeys.add(key);
 
         entries.push({
-          bookmarkId: bookmark.id,
-          tweetId: bookmark.tweetId,
-          tweetUrl: bookmark.url,
-          authorHandle: bookmark.authorHandle,
-          authorName: bookmark.authorName,
+          bookmarkId,
+          tweetId,
+          tweetUrl,
+          authorHandle,
+          authorName,
           sourceUrl,
           localPath,
           contentType: response.headers.get('content-type') ?? contentType ?? undefined,
@@ -194,27 +359,32 @@ export async function fetchBookmarkMediaBatch(
           fetchedAt,
         });
         downloaded += 1;
+        processed += 1;
+        emitProgress(sourceUrl);
       } catch (error) {
         entries.push({
-          bookmarkId: bookmark.id,
-          tweetId: bookmark.tweetId,
-          tweetUrl: bookmark.url,
-          authorHandle: bookmark.authorHandle,
-          authorName: bookmark.authorName,
+          bookmarkId,
+          tweetId,
+          tweetUrl,
+          authorHandle,
+          authorName,
           sourceUrl,
           status: 'failed',
           reason: error instanceof Error ? error.message : String(error),
           fetchedAt,
         });
         failed += 1;
+        processed += 1;
+        emitProgress(sourceUrl);
       }
     }
   }
 
+  const manifestLimit = Number.isFinite(limit) ? limit : candidates.length;
   const manifest: MediaFetchManifest = {
     schemaVersion: 1,
     generatedAt: new Date().toISOString(),
-    limit,
+    limit: manifestLimit,
     maxBytes,
     processed,
     downloaded,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,7 +6,8 @@ import { runTwitterOAuthFlow } from './xauth.js';
 import { syncBookmarksGraphQL, syncGaps, syncBookmarkFolders } from './graphql-bookmarks.js';
 import type { SyncProgress, GapFillProgress, FolderSyncProgress } from './graphql-bookmarks.js';
 import type { BookmarkFolder } from './types.js';
-import { fetchBookmarkMediaBatch } from './bookmark-media.js';
+import { DEFAULT_MEDIA_MAX_BYTES, fetchBookmarkMediaBatch } from './bookmark-media.js';
+import type { MediaFetchManifest, MediaFetchProgress } from './bookmark-media.js';
 import {
   buildIndex,
   searchBookmarks,
@@ -31,7 +32,7 @@ import { lintMd, fixLintIssues } from './md-lint.js';
 import { exportBookmarks } from './md-export.js';
 import { renderViz } from './bookmarks-viz.js';
 import { listBrowserIds } from './browsers.js';
-import { dataDir, ensureDataDir, isFirstRun, twitterBookmarksIndexPath, twitterBackfillStatePath, mdDir } from './paths.js';
+import { dataDir, ensureDataDir, isFirstRun, twitterBookmarksIndexPath, twitterBackfillStatePath, mdDir, bookmarkMediaDir, bookmarkMediaManifestPath } from './paths.js';
 import { PromptCancelledError, promptText } from './prompt.js';
 import { skillWithFrontmatter, installSkill, uninstallSkill } from './skill.js';
 import fs from 'node:fs';
@@ -107,6 +108,47 @@ function formatRetryAfter(seconds?: number): string | undefined {
   const minutes = Math.floor(seconds / 60);
   const remainingSeconds = seconds % 60;
   return remainingSeconds > 0 ? `${minutes}m ${remainingSeconds}s` : `${minutes}m`;
+}
+
+function printMediaFetchSummary(result: MediaFetchManifest): void {
+  if (result.processed === 0) {
+    console.log('  ✓ No pending media assets found');
+  }
+  console.log(`  ✓ ${result.downloaded} media assets downloaded`);
+  if (result.skippedTooLarge > 0) {
+    console.log(`  ${result.skippedTooLarge} media assets skipped for size`);
+  }
+  if (result.failed > 0) {
+    console.log(`  ${result.failed} media assets failed`);
+  }
+  console.log(`  ✓ Media: ${bookmarkMediaDir()}`);
+  console.log(`  ✓ Manifest: ${bookmarkMediaManifestPath()}`);
+}
+
+async function runMediaFetchWithProgress(options: { limit?: number; maxBytes?: number } = {}): Promise<MediaFetchManifest> {
+  const startTime = Date.now();
+  let lastMedia: MediaFetchProgress = {
+    candidateBookmarks: 0,
+    processed: 0,
+    downloaded: 0,
+    skippedTooLarge: 0,
+    failed: 0,
+  };
+  const spinner = createSpinner(() => {
+    const elapsed = Math.round((Date.now() - startTime) / 1000);
+    return `Fetching media...  ${lastMedia.processed} processed  │  ${lastMedia.downloaded} downloaded  │  ${elapsed}s`;
+  });
+  const result = await runWithSpinner(spinner, () => fetchBookmarkMediaBatch({
+    limit: options.limit,
+    maxBytes: options.maxBytes,
+    onProgress: (progress: MediaFetchProgress) => {
+      lastMedia = progress;
+      spinner.update();
+    },
+  }));
+  console.log('');
+  printMediaFetchSummary(result);
+  return result;
 }
 
 function warnIfEmpty(totalBookmarks: number): void {
@@ -186,6 +228,11 @@ function showCachedUpdateNotice(): void {
 // ── What's new ────────────────────────────────────────────────────────────
 
 const WHATS_NEW: Record<string, string[]> = {
+  '1.3.13': [
+    'ft sync --media now downloads X photos, video posters, capped videos, and quoted-tweet media',
+    'ft fetch-media now backfills missing media across your archive instead of stopping at the first 100 bookmarks',
+    'Media downloads now show live progress and use a 200 MB per-asset cap by default',
+  ],
   '1.3.12': [
     'ft md now exports correct ISO dates in bookmark filenames and frontmatter',
     'ft sync --rebuild now refreshes existing caches without stopping early',
@@ -510,6 +557,8 @@ export function buildCli() {
     .option('--gaps', 'Backfill missing data (quoted tweets, truncated articles, linked article content)', false)
     .option('--yes', 'Skip confirmation prompts', false)
     .option('--classify', 'Classify new bookmarks with LLM after syncing', false)
+    .option('--media', 'Also download media assets for bookmarks after syncing', false)
+    .option('--media-max-bytes <n>', 'Per-asset byte limit for --media (default: 200 MB)', (v: string) => Number(v), DEFAULT_MEDIA_MAX_BYTES)
     .option('--max-pages <n>', 'Max pages to fetch (default: unlimited)', (v: string) => Number(v))
     .option('--target-adds <n>', 'Stop after N new bookmarks', (v: string) => Number(v))
     .option('--delay-ms <n>', 'Delay between requests in ms', (v: string) => Number(v), 600)
@@ -559,6 +608,14 @@ export function buildCli() {
           process.exitCode = 1;
           return;
         }
+        if (options.media && options.gaps) {
+          console.error('  Error: --media cannot be combined with --gaps. Run them separately.');
+          process.exitCode = 1;
+          return;
+        }
+        const mediaMaxBytes = typeof options.mediaMaxBytes === 'number' && !Number.isNaN(options.mediaMaxBytes)
+          ? options.mediaMaxBytes
+          : DEFAULT_MEDIA_MAX_BYTES;
 
         // ── gaps mode: backfill missing data for existing bookmarks ──
         if (options.gaps) {
@@ -667,6 +724,10 @@ export function buildCli() {
           console.log(`\n  \u2713 ${result.added} new bookmarks synced (${result.totalBookmarks} total)`);
           console.log(`  \u2713 Data: ${dataDir()}\n`);
           warnIfEmpty(result.totalBookmarks);
+          if (options.media) {
+            await runMediaFetchWithProgress({ maxBytes: mediaMaxBytes });
+            console.log('');
+          }
           const newCount = await rebuildIndex();
           if (options.classify && newCount > 0) {
             await classifyNew(engineOverride);
@@ -803,6 +864,11 @@ export function buildCli() {
               console.error(`\n  Folder sync error: ${(err as Error).message}\n`);
               // Continue — main sync already succeeded, folders are bonus
             }
+          }
+
+          if (options.media) {
+            await runMediaFetchWithProgress({ maxBytes: mediaMaxBytes });
+            console.log('');
           }
 
           const newCount = await rebuildIndex();
@@ -1255,16 +1321,17 @@ export function buildCli() {
 
   program
     .command('fetch-media')
-    .description('Download media assets for bookmarks (static images only)')
-    .option('--limit <n>', 'Max bookmarks to process', (v: string) => Number(v), 100)
-    .option('--max-bytes <n>', 'Per-asset byte limit', (v: string) => Number(v), 50 * 1024 * 1024)
+    .description('Download media assets for bookmarks')
+    .option('--limit <n>', 'Max pending bookmarks to process (default: all)', (v: string) => Number(v))
+    .option('--max-bytes <n>', 'Per-asset byte limit (default: 200 MB)', (v: string) => Number(v), DEFAULT_MEDIA_MAX_BYTES)
     .action(safe(async (options) => {
       if (!requireData()) return;
-      const result = await fetchBookmarkMediaBatch({
-        limit: Number(options.limit) || 100,
-        maxBytes: Number(options.maxBytes) || 50 * 1024 * 1024,
+      await runMediaFetchWithProgress({
+        limit: typeof options.limit === 'number' && !Number.isNaN(options.limit) ? options.limit : undefined,
+        maxBytes: typeof options.maxBytes === 'number' && !Number.isNaN(options.maxBytes)
+          ? options.maxBytes
+          : DEFAULT_MEDIA_MAX_BYTES,
       });
-      console.log(JSON.stringify(result, null, 2));
     }));
 
   // ── ft md ── Export bookmarks as markdown files ────────────────────────

--- a/src/graphql-bookmarks.ts
+++ b/src/graphql-bookmarks.ts
@@ -316,6 +316,12 @@ export function convertTweetToRecord(tweetResult: any, now: string): BookmarkRec
           expandedUrl: m.expanded_url,
           width: m.original_info?.width,
           height: m.original_info?.height,
+          altText: m.ext_alt_text,
+          videoVariants: Array.isArray(m.video_info?.variants)
+            ? m.video_info.variants
+                .filter((v: any) => v.content_type === 'video/mp4')
+                .map((v: any) => ({ bitrate: v.bitrate, url: v.url }))
+            : undefined,
         })),
         url: `https://x.com/${qtHandle ?? '_'}/status/${qtId}`,
       };

--- a/tests/bookmark-media.test.ts
+++ b/tests/bookmark-media.test.ts
@@ -23,6 +23,7 @@ async function withMediaDataDir(records: any[], fn: () => Promise<void>): Promis
 
 test('fetchBookmarkMediaBatch downloads post media from GraphQL mediaObjects shape', async () => {
   const photoUrl = 'https://pbs.twimg.com/media/example.jpg';
+  const videoPosterUrl = 'https://pbs.twimg.com/amplify_video_thumb/example.jpg';
   const videoUrl = 'https://video.twimg.com/ext_tw_video/example.mp4';
   const profileUrl = 'https://pbs.twimg.com/profile_images/123/avatar_normal.jpg';
   const records = [{
@@ -36,7 +37,7 @@ test('fetchBookmarkMediaBatch downloads post media from GraphQL mediaObjects sha
     syncedAt: '2026-04-09T00:00:00.000Z',
     mediaObjects: [
       { type: 'photo', url: photoUrl },
-      { type: 'video', videoVariants: [{ url: videoUrl, bitrate: 832000 }] },
+      { type: 'video', url: videoPosterUrl, videoVariants: [{ url: videoUrl, bitrate: 832000 }] },
     ],
     links: [],
     tags: [],
@@ -71,8 +72,78 @@ test('fetchBookmarkMediaBatch downloads post media from GraphQL mediaObjects sha
       assert.deepEqual(downloaded, [
         photoUrl,
         profileUrl.replace('_normal.', '_400x400.'),
+        videoPosterUrl,
         videoUrl,
       ].sort());
+    });
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('fetchBookmarkMediaBatch downloads quoted tweet media targets', async () => {
+  const quotedPhotoUrl = 'https://pbs.twimg.com/media/quoted-photo.jpg';
+  const quotedPosterUrl = 'https://pbs.twimg.com/amplify_video_thumb/quoted.jpg';
+  const quotedVideoUrl = 'https://video.twimg.com/ext_tw_video/quoted.mp4';
+  const quotedProfileUrl = 'https://pbs.twimg.com/profile_images/456/quoted_normal.jpg';
+  const records = [{
+    id: '1',
+    tweetId: '1',
+    url: 'https://x.com/alice/status/1',
+    text: 'quoted media test',
+    authorHandle: 'alice',
+    authorName: 'Alice',
+    syncedAt: '2026-04-09T00:00:00.000Z',
+    mediaObjects: [],
+    quotedTweet: {
+      id: '99',
+      url: 'https://x.com/bob/status/99',
+      text: 'quoted',
+      authorHandle: 'bob',
+      authorName: 'Bob',
+      authorProfileImageUrl: quotedProfileUrl,
+      media: [quotedPhotoUrl],
+      mediaObjects: [
+        { type: 'photo', url: quotedPhotoUrl },
+        { type: 'video', url: quotedPosterUrl, videoVariants: [{ url: quotedVideoUrl, bitrate: 832000 }] },
+      ],
+    },
+    links: [],
+    tags: [],
+    ingestedVia: 'graphql',
+  }];
+
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+    const url = String(input instanceof Request ? input.url : input);
+    const method = init?.method ?? 'GET';
+    const contentType = url.endsWith('.mp4') ? 'video/mp4' : 'image/jpeg';
+    if (method === 'HEAD') {
+      return new Response(null, {
+        status: 200,
+        headers: { 'content-length': '4', 'content-type': contentType },
+      });
+    }
+    return new Response(Uint8Array.from([1, 2, 3, 4]), {
+      status: 200,
+      headers: { 'content-type': contentType },
+    });
+  };
+
+  try {
+    await withMediaDataDir(records, async () => {
+      const manifest = await fetchBookmarkMediaBatch({ limit: 10, maxBytes: 1024 });
+      const downloaded = manifest.entries
+        .filter((entry) => entry.status === 'downloaded')
+        .map((entry) => ({ tweetId: entry.tweetId, sourceUrl: entry.sourceUrl }))
+        .sort((a, b) => a.sourceUrl.localeCompare(b.sourceUrl));
+
+      assert.deepEqual(downloaded, [
+        { tweetId: '99', sourceUrl: quotedPosterUrl },
+        { tweetId: '99', sourceUrl: quotedPhotoUrl },
+        { tweetId: '99', sourceUrl: quotedProfileUrl.replace('_normal.', '_400x400.') },
+        { tweetId: '99', sourceUrl: quotedVideoUrl },
+      ]);
     });
   } finally {
     globalThis.fetch = originalFetch;
@@ -288,6 +359,177 @@ test('fetchBookmarkMediaBatch retries failed profile image from previous manifes
 
       assert.equal(profileGetRequests, 2);
       assert.equal(downloadedProfileEntries.length, 1);
+    });
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('fetchBookmarkMediaBatch reports progress as assets complete', async () => {
+  const photoUrl = 'https://pbs.twimg.com/media/progress.jpg';
+  const records = [{
+    id: '1',
+    tweetId: '1',
+    url: 'https://x.com/alice/status/1',
+    text: 'progress test',
+    authorHandle: 'alice',
+    authorName: 'Alice',
+    syncedAt: '2026-04-09T00:00:00.000Z',
+    mediaObjects: [{ type: 'photo', url: photoUrl }],
+    links: [],
+    tags: [],
+    ingestedVia: 'graphql',
+  }];
+
+  const progressSnapshots: Array<{ processed: number; downloaded: number; candidateBookmarks: number }> = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (_input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+    const method = init?.method ?? 'GET';
+    if (method === 'HEAD') {
+      return new Response(null, {
+        status: 200,
+        headers: { 'content-length': '4', 'content-type': 'image/jpeg' },
+      });
+    }
+    return new Response(Uint8Array.from([1, 2, 3, 4]), {
+      status: 200,
+      headers: { 'content-type': 'image/jpeg' },
+    });
+  };
+
+  try {
+    await withMediaDataDir(records, async () => {
+      await fetchBookmarkMediaBatch({
+        limit: 10,
+        maxBytes: 1024,
+        onProgress: (progress) => {
+          progressSnapshots.push({
+            processed: progress.processed,
+            downloaded: progress.downloaded,
+            candidateBookmarks: progress.candidateBookmarks,
+          });
+        },
+      });
+    });
+
+    assert.equal(progressSnapshots[0]?.processed, 0);
+    assert.equal(progressSnapshots[0]?.candidateBookmarks, 1);
+    assert.equal(progressSnapshots.at(-1)?.processed, 1);
+    assert.equal(progressSnapshots.at(-1)?.downloaded, 1);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('fetchBookmarkMediaBatch applies limit after filtering out already-downloaded bookmarks', async () => {
+  const firstUrl = 'https://pbs.twimg.com/media/first.jpg';
+  const secondUrl = 'https://pbs.twimg.com/media/second.jpg';
+  const records = [
+    {
+      id: '1',
+      tweetId: '1',
+      url: 'https://x.com/alice/status/1',
+      text: 'first',
+      authorHandle: 'alice',
+      authorName: 'Alice',
+      syncedAt: '2026-04-09T00:00:00.000Z',
+      mediaObjects: [{ type: 'photo', url: firstUrl }],
+      links: [],
+      tags: [],
+      ingestedVia: 'graphql',
+    },
+    {
+      id: '2',
+      tweetId: '2',
+      url: 'https://x.com/alice/status/2',
+      text: 'second',
+      authorHandle: 'alice',
+      authorName: 'Alice',
+      syncedAt: '2026-04-09T00:00:00.000Z',
+      mediaObjects: [{ type: 'photo', url: secondUrl }],
+      links: [],
+      tags: [],
+      ingestedVia: 'graphql',
+    },
+  ];
+
+  const fetchedUrls: string[] = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+    const url = String(input instanceof Request ? input.url : input);
+    const method = init?.method ?? 'GET';
+    if (method === 'HEAD') {
+      return new Response(null, {
+        status: 200,
+        headers: { 'content-length': '4', 'content-type': 'image/jpeg' },
+      });
+    }
+    fetchedUrls.push(url);
+    return new Response(Uint8Array.from([1, 2, 3, 4]), {
+      status: 200,
+      headers: { 'content-type': 'image/jpeg' },
+    });
+  };
+
+  try {
+    await withMediaDataDir(records, async () => {
+      const firstRun = await fetchBookmarkMediaBatch({ limit: 1, maxBytes: 1024 });
+      assert.equal(firstRun.downloaded, 1);
+      assert.equal(fetchedUrls.at(-1), firstUrl);
+
+      const secondRun = await fetchBookmarkMediaBatch({ limit: 1, maxBytes: 1024 });
+      assert.equal(secondRun.downloaded, 1);
+      assert.equal(fetchedUrls.at(-1), secondUrl);
+    });
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('fetchBookmarkMediaBatch retries failed non-profile media on later runs', async () => {
+  const photoUrl = 'https://pbs.twimg.com/media/retry-photo.jpg';
+  const records = [{
+    id: '1',
+    tweetId: '1',
+    url: 'https://x.com/alice/status/1',
+    text: 'retry test',
+    authorHandle: 'alice',
+    authorName: 'Alice',
+    syncedAt: '2026-04-09T00:00:00.000Z',
+    mediaObjects: [{ type: 'photo', url: photoUrl }],
+    links: [],
+    tags: [],
+    ingestedVia: 'graphql',
+  }];
+
+  let getCalls = 0;
+  const originalFetch = globalThis.fetch;
+
+  try {
+    await withMediaDataDir(records, async () => {
+      globalThis.fetch = async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+        const method = init?.method ?? 'GET';
+        if (method === 'HEAD') {
+          return new Response(null, {
+            status: 200,
+            headers: { 'content-length': '4', 'content-type': 'image/jpeg' },
+          });
+        }
+        getCalls += 1;
+        return getCalls === 1
+          ? new Response(null, { status: 500 })
+          : new Response(Uint8Array.from([1, 2, 3, 4]), {
+              status: 200,
+              headers: { 'content-type': 'image/jpeg' },
+            });
+      };
+
+      const firstRun = await fetchBookmarkMediaBatch({ maxBytes: 1024 });
+      assert.equal(firstRun.failed, 1);
+
+      const secondRun = await fetchBookmarkMediaBatch({ maxBytes: 1024 });
+      assert.equal(secondRun.downloaded, 1);
+      assert.equal(getCalls, 2);
     });
   } finally {
     globalThis.fetch = originalFetch;

--- a/tests/bookmark-media.test.ts
+++ b/tests/bookmark-media.test.ts
@@ -218,7 +218,7 @@ test('fetchBookmarkMediaBatch downloads shared profile images only once across b
   }
 });
 
-test('fetchBookmarkMediaBatch retries shared profile image after same-run failure', async () => {
+test('fetchBookmarkMediaBatch deduplicates shared profile image failure within one run', async () => {
   const profileUrl = 'https://pbs.twimg.com/profile_images/123/avatar_normal.jpg';
   const fullProfileUrl = profileUrl.replace('_normal.', '_400x400.');
   const records = [
@@ -285,8 +285,8 @@ test('fetchBookmarkMediaBatch retries shared profile image after same-run failur
         (entry) => entry.status === 'failed' && entry.sourceUrl === fullProfileUrl,
       );
 
-      assert.equal(profileGetRequests, 2);
-      assert.equal(downloadedProfileEntries.length, 1);
+      assert.equal(profileGetRequests, 1);
+      assert.equal(downloadedProfileEntries.length, 0);
       assert.equal(failedProfileEntries.length, 1);
     });
   } finally {
@@ -526,10 +526,74 @@ test('fetchBookmarkMediaBatch retries failed non-profile media on later runs', a
 
       const firstRun = await fetchBookmarkMediaBatch({ maxBytes: 1024 });
       assert.equal(firstRun.failed, 1);
+      assert.equal(firstRun.entries.filter((entry) => entry.sourceUrl === photoUrl).length, 1);
 
       const secondRun = await fetchBookmarkMediaBatch({ maxBytes: 1024 });
       assert.equal(secondRun.downloaded, 1);
       assert.equal(getCalls, 2);
+      assert.equal(secondRun.entries.filter((entry) => entry.sourceUrl === photoUrl).length, 1);
+      assert.equal(
+        secondRun.entries.find((entry) => entry.sourceUrl === photoUrl)?.status,
+        'downloaded',
+      );
+    });
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('fetchBookmarkMediaBatch does not retry the same failing asset twice in one run', async () => {
+  const sharedPhotoUrl = 'https://pbs.twimg.com/media/shared-failure.jpg';
+  const records = [
+    {
+      id: '1',
+      tweetId: '1',
+      url: 'https://x.com/alice/status/1',
+      text: 'first',
+      authorHandle: 'alice',
+      authorName: 'Alice',
+      syncedAt: '2026-04-09T00:00:00.000Z',
+      mediaObjects: [{ type: 'photo', url: sharedPhotoUrl }],
+      links: [],
+      tags: [],
+      ingestedVia: 'graphql',
+    },
+    {
+      id: '2',
+      tweetId: '2',
+      url: 'https://x.com/bob/status/2',
+      text: 'second',
+      authorHandle: 'bob',
+      authorName: 'Bob',
+      syncedAt: '2026-04-09T00:00:00.000Z',
+      mediaObjects: [{ type: 'photo', url: sharedPhotoUrl }],
+      links: [],
+      tags: [],
+      ingestedVia: 'graphql',
+    },
+  ];
+
+  let getCalls = 0;
+  const originalFetch = globalThis.fetch;
+
+  try {
+    await withMediaDataDir(records, async () => {
+      globalThis.fetch = async (_input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+        const method = init?.method ?? 'GET';
+        if (method === 'HEAD') {
+          return new Response(null, {
+            status: 200,
+            headers: { 'content-length': '4', 'content-type': 'image/jpeg' },
+          });
+        }
+        getCalls += 1;
+        return new Response(null, { status: 500 });
+      };
+
+      const manifest = await fetchBookmarkMediaBatch({ maxBytes: 1024 });
+      assert.equal(manifest.failed, 2);
+      assert.equal(getCalls, 1);
+      assert.equal(manifest.entries.filter((entry) => entry.sourceUrl === sharedPhotoUrl).length, 2);
     });
   } finally {
     globalThis.fetch = originalFetch;

--- a/tests/graphql-bookmarks.test.ts
+++ b/tests/graphql-bookmarks.test.ts
@@ -322,6 +322,54 @@ test('convertTweetToRecord: extracts quoted tweet snapshot', () => {
   assert.equal(result.quotedTweet!.media?.length, 1);
 });
 
+test('convertTweetToRecord: preserves quoted tweet video variants', () => {
+  const tr = makeTweetResult({
+    legacy: { quoted_status_id_str: '9999999' },
+    tweet: {
+      quoted_status_result: {
+        result: {
+          rest_id: '9999999',
+          legacy: {
+            id_str: '9999999',
+            full_text: 'Quoted video tweet',
+            created_at: 'Mon Mar 09 10:00:00 +0000 2026',
+            entities: { urls: [] },
+            extended_entities: {
+              media: [{
+                type: 'video',
+                media_url_https: 'https://pbs.twimg.com/amplify_video_thumb/quoted.jpg',
+                expanded_url: 'https://x.com/quoteduser/status/9999999/video/1',
+                original_info: { width: 1280, height: 720 },
+                ext_alt_text: 'Quoted video poster',
+                video_info: {
+                  variants: [
+                    { content_type: 'video/mp4', bitrate: 832000, url: 'https://video.twimg.com/quoted.mp4' },
+                  ],
+                },
+              }],
+            },
+          },
+          core: {
+            user_results: {
+              result: {
+                rest_id: '6666',
+                core: { screen_name: 'quoteduser', name: 'Quoted User' },
+                avatar: { image_url: 'https://pbs.twimg.com/profile_images/6666/qt.jpg' },
+                legacy: {},
+              },
+            },
+          },
+        },
+      },
+    },
+  });
+  const result = convertTweetToRecord(tr, NOW);
+  assert.ok(result?.quotedTweet);
+  assert.equal(result.quotedTweet!.mediaObjects?.[0].type, 'video');
+  assert.equal(result.quotedTweet!.mediaObjects?.[0].altText, 'Quoted video poster');
+  assert.equal(result.quotedTweet!.mediaObjects?.[0].videoVariants?.[0].url, 'https://video.twimg.com/quoted.mp4');
+});
+
 test('convertTweetToRecord: handles missing quoted tweet gracefully', () => {
   const tr = makeTweetResult({
     legacy: { quoted_status_id_str: '7777777' },


### PR DESCRIPTION
## Summary
- add media-aware archive backfill so `ft fetch-media` fills missing assets across the archive instead of defaulting to the first 100 bookmarks
- make `ft sync --media` download X photos, video posters, capped videos, and quoted-tweet media with live progress reporting
- bump the CLI to `1.3.13` and add release notes for the new media behavior

## Verification
- `./node_modules/.bin/tsx --test tests/bookmark-media.test.ts tests/graphql-bookmarks.test.ts`
- `npm run build`