### PR TITLE
Add Dia browser support for session sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ Use `ft classify` for LLM-powered classification that catches what regex misses.
 
 | Feature | macOS | Linux | Windows |
 |---------|-------|-------|---------|
-| Session sync (`ft sync`) | Chrome, Chromium, Brave, Helium, Comet, Firefox | Chrome, Chromium, Brave, Firefox | Chrome, Chromium, Brave, Firefox |
+| Session sync (`ft sync`) | Chrome, Chromium, Brave, Helium, Comet, Dia, Firefox | Chrome, Chromium, Brave, Firefox | Chrome, Chromium, Brave, Firefox |
 | OAuth API sync (`ft sync --api`) | Yes | Yes | Yes |
 | Search, list, classify, viz, wiki | Yes | Yes | Yes |
 

--- a/src/browsers.ts
+++ b/src/browsers.ts
@@ -82,6 +82,15 @@ const BROWSERS: BrowserDef[] = [
     macPath: 'Library/Application Support/Comet',
   },
   {
+    id: 'dia',
+    displayName: 'Dia',
+    cookieBackend: 'chromium',
+    keychainEntries: [
+      { service: 'Dia Safe Storage', account: 'Dia' },
+    ],
+    macPath: 'Library/Application Support/Dia/User Data',
+  },
+  {
     id: 'firefox',
     displayName: 'Firefox',
     cookieBackend: 'firefox',

--- a/tests/browsers.test.ts
+++ b/tests/browsers.test.ts
@@ -29,7 +29,16 @@ test('listBrowserIds: returns all registered ids', () => {
   assert.ok(ids.includes('firefox'));
   assert.ok(ids.includes('helium'));
   assert.ok(ids.includes('comet'));
+  assert.ok(ids.includes('dia'));
   assert.ok(ids.includes('chromium'));
+});
+
+test('getBrowser: dia has correct keychain entries and User Data macPath', () => {
+  const browser = getBrowser('dia');
+  assert.equal(browser.cookieBackend, 'chromium');
+  const services = browser.keychainEntries.map(e => e.service);
+  assert.ok(services.includes('Dia Safe Storage'));
+  assert.match(browser.macPath!, /Dia\/User Data$/);
 });
 
 test('getBrowser: firefox has firefox cookieBackend', () => {


### PR DESCRIPTION
## Summary
- add Dia as a supported Chromium-based browser for session sync on macOS
- add a focused browser test for Dia keychain and user-data path handling
- update the README platform support table to list Dia

## Verification
- `/Users/afar/dev/fieldtheory-cli/node_modules/.bin/tsx --test tests/browsers.test.ts`
- `npm run build`