### PR TITLE
Add Edge browser support metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,11 +162,22 @@ To remove all data: `rm -rf ~/.ft-bookmarks`
 
 Use `ft classify` for LLM-powered classification that catches what regex misses.
 
+## Windows Notes
+
+In PowerShell, use `fieldtheory` instead of `ft` because `ft` is already a built-in PowerShell alias.
+
+If you want to sync from Microsoft Edge explicitly:
+
+```powershell
+fieldtheory sync --browser edge
+fieldtheory sync --browser edge --chrome-profile-directory "Default"
+```
+
 ## Platform support
 
 | Feature | macOS | Linux | Windows |
 |---------|-------|-------|---------|
-| Session sync (`ft sync`) | Chrome, Chromium, Brave, Helium, Comet, Dia, Firefox | Chrome, Chromium, Brave, Firefox | Chrome, Chromium, Brave, Firefox |
+| Session sync (`ft sync`) | Chrome, Chromium, Brave, Edge, Helium, Comet, Dia, Firefox | Chrome, Chromium, Brave, Edge, Firefox | Chrome, Chromium, Brave, Edge, Firefox |
 | OAuth API sync (`ft sync --api`) | Yes | Yes | Yes |
 | Search, list, classify, viz, wiki | Yes | Yes | Yes |
 

--- a/src/browsers.ts
+++ b/src/browsers.ts
@@ -64,6 +64,18 @@ const BROWSERS: BrowserDef[] = [
     winPath: 'AppData/Local/BraveSoftware/Brave-Browser/User Data',
   },
   {
+    id: 'edge',
+    displayName: 'Microsoft Edge',
+    cookieBackend: 'chromium',
+    keychainEntries: [
+      { service: 'Microsoft Edge Safe Storage', account: 'Microsoft Edge' },
+      { service: 'Edge Safe Storage', account: 'Microsoft Edge' },
+    ],
+    macPath: 'Library/Application Support/Microsoft Edge',
+    linuxPath: '.config/microsoft-edge',
+    winPath: 'AppData/Local/Microsoft/Edge/User Data',
+  },
+  {
     id: 'helium',
     displayName: 'Helium',
     cookieBackend: 'chromium',

--- a/tests/browsers.test.ts
+++ b/tests/browsers.test.ts
@@ -26,6 +26,7 @@ test('listBrowserIds: returns all registered ids', () => {
   const ids = listBrowserIds();
   assert.ok(ids.includes('chrome'));
   assert.ok(ids.includes('brave'));
+  assert.ok(ids.includes('edge'));
   assert.ok(ids.includes('firefox'));
   assert.ok(ids.includes('helium'));
   assert.ok(ids.includes('comet'));
@@ -59,6 +60,13 @@ test('getBrowser: brave has correct keychain entries', () => {
   const browser = getBrowser('brave');
   const services = browser.keychainEntries.map(e => e.service);
   assert.ok(services.some(s => s.includes('Brave')));
+});
+
+test('getBrowser: edge has chromium backend and Microsoft path metadata', () => {
+  const browser = getBrowser('edge');
+  assert.equal(browser.cookieBackend, 'chromium');
+  assert.ok(browser.keychainEntries.some(e => e.service.includes('Edge')));
+  assert.match(browser.winPath!, /AppData[\\/]Local[\\/]Microsoft[\\/]Edge[\\/]User Data/);
 });
 
 test('browserUserDataDir: returns a path for known browsers on this OS', () => {


### PR DESCRIPTION
## Summary
- add Microsoft Edge to the supported browser registry for session sync
- add a focused browser test for the Edge keychain entries and Windows user-data path
- document the PowerShell `fieldtheory` alias and `--browser edge` example in the README

## Verification
- `./node_modules/.bin/tsx --test tests/browsers.test.ts`
- `npm run build`