### PR TITLE
Add proxy environment support for CLI requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,8 @@ Works with Claude Code, Codex, or any agent with shell access.
 0 7 * * * ft sync --classify
 ```
 
+`ft` respects standard proxy environment variables for network requests: `HTTPS_PROXY`, `HTTP_PROXY`, `ALL_PROXY`, and `NO_PROXY`.
+
 ## Data
 
 All data is stored locally at `~/.ft-bookmarks/`:

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "commander": "^14.0.3",
         "dotenv": "^17.3.1",
         "sql.js": "^1.14.1",
-        "sql.js-fts5": "^1.4.0"
+        "sql.js-fts5": "^1.4.0",
+        "undici": "^6.25.0"
       },
       "bin": {
         "fieldtheory": "bin/ft.mjs",
@@ -643,6 +644,15 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "6.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.25.0.tgz",
+      "integrity": "sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "commander": "^14.0.3",
     "dotenv": "^17.3.1",
     "sql.js": "^1.14.1",
-    "sql.js-fts5": "^1.4.0"
+    "sql.js-fts5": "^1.4.0",
+    "undici": "^6.25.0"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -32,12 +32,15 @@ import { lintMd, fixLintIssues } from './md-lint.js';
 import { exportBookmarks } from './md-export.js';
 import { renderViz } from './bookmarks-viz.js';
 import { listBrowserIds } from './browsers.js';
+import { configureHttpProxyFromEnv } from './http-proxy.js';
 import { dataDir, ensureDataDir, isFirstRun, twitterBookmarksIndexPath, twitterBackfillStatePath, mdDir, bookmarkMediaDir, bookmarkMediaManifestPath } from './paths.js';
 import { PromptCancelledError, promptText } from './prompt.js';
 import { skillWithFrontmatter, installSkill, uninstallSkill } from './skill.js';
 import fs from 'node:fs';
 import path from 'node:path';
 import { createRequire } from 'node:module';
+
+configureHttpProxyFromEnv();
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
 

--- a/src/http-proxy.ts
+++ b/src/http-proxy.ts
@@ -1,0 +1,36 @@
+import { EnvHttpProxyAgent, setGlobalDispatcher } from 'undici';
+
+const PROXY_ENV_KEYS = [
+  'HTTPS_PROXY',
+  'https_proxy',
+  'HTTP_PROXY',
+  'http_proxy',
+  'ALL_PROXY',
+  'all_proxy',
+] as const;
+
+export function hasProxyEnv(env: NodeJS.ProcessEnv = process.env): boolean {
+  return PROXY_ENV_KEYS.some((key) => {
+    const value = env[key];
+    return typeof value === 'string' && value.trim().length > 0;
+  });
+}
+
+interface ConfigureHttpProxyOptions {
+  env?: NodeJS.ProcessEnv;
+  createAgent?: () => unknown;
+  setDispatcher?: (dispatcher: unknown) => void;
+}
+
+export function configureHttpProxyFromEnv(
+  {
+    env = process.env,
+    createAgent = () => new EnvHttpProxyAgent(),
+    setDispatcher = (dispatcher: unknown) => setGlobalDispatcher(dispatcher as Parameters<typeof setGlobalDispatcher>[0]),
+  }: ConfigureHttpProxyOptions = {},
+): boolean {
+  if (!hasProxyEnv(env)) return false;
+
+  setDispatcher(createAgent());
+  return true;
+}

--- a/tests/http-proxy.test.ts
+++ b/tests/http-proxy.test.ts
@@ -1,0 +1,49 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { configureHttpProxyFromEnv, hasProxyEnv } from '../src/http-proxy.js';
+
+test('hasProxyEnv: detects uppercase and lowercase proxy environment variables', () => {
+  assert.equal(hasProxyEnv({ HTTPS_PROXY: 'http://proxy.local:8080' } as NodeJS.ProcessEnv), true);
+  assert.equal(hasProxyEnv({ all_proxy: 'socks5://proxy.local:1080' } as NodeJS.ProcessEnv), true);
+});
+
+test('hasProxyEnv: ignores empty proxy environment variables', () => {
+  assert.equal(hasProxyEnv({ HTTPS_PROXY: '   ' } as NodeJS.ProcessEnv), false);
+  assert.equal(hasProxyEnv({ NO_PROXY: 'x.com' } as NodeJS.ProcessEnv), false);
+});
+
+test('configureHttpProxyFromEnv: does nothing when no proxy env is set', () => {
+  let created = 0;
+  let dispatched = 0;
+
+  const configured = configureHttpProxyFromEnv({
+    env: {},
+    createAgent: () => {
+      created += 1;
+      return {};
+    },
+    setDispatcher: () => {
+      dispatched += 1;
+    },
+  });
+
+  assert.equal(configured, false);
+  assert.equal(created, 0);
+  assert.equal(dispatched, 0);
+});
+
+test('configureHttpProxyFromEnv: installs dispatcher when proxy env is set', () => {
+  const agent = { kind: 'proxy-agent' };
+  let received: unknown;
+
+  const configured = configureHttpProxyFromEnv({
+    env: { HTTP_PROXY: 'http://proxy.local:8080', NO_PROXY: 'localhost,127.0.0.1' } as NodeJS.ProcessEnv,
+    createAgent: () => agent,
+    setDispatcher: (dispatcher) => {
+      received = dispatcher;
+    },
+  });
+
+  assert.equal(configured, true);
+  assert.equal(received, agent);
+});


### PR DESCRIPTION
## Summary
- add a small shared helper that installs proxy support from standard environment variables
- use `EnvHttpProxyAgent` so `NO_PROXY` works correctly
- document proxy environment variables and add focused tests for env detection and dispatcher installation

## Verification
- `./node_modules/.bin/tsx --test tests/http-proxy.test.ts tests/cli.test.ts`
- `npm run build`