### PR TITLE
Show classification counts in ft status

### DIFF
--- a/src/bookmarks-db.ts
+++ b/src/bookmarks-db.ts
@@ -69,6 +69,12 @@ export interface BookmarkTimelineFilters {
   offset?: number;
 }
 
+export interface BookmarkClassificationProgress {
+  total: number;
+  categoriesDone: number;
+  domainsDone: number;
+}
+
 function parseJsonArray(value: unknown): string[] {
   if (typeof value !== 'string' || !value.trim()) return [];
   try {
@@ -927,6 +933,37 @@ export async function getCategoryCounts(existingDb?: Database): Promise<Record<s
     return counts;
   } finally {
     if (!existingDb) db.close();
+  }
+}
+
+export async function getClassificationProgress(): Promise<BookmarkClassificationProgress> {
+  const dbPath = twitterBookmarksIndexPath();
+  let db: Database;
+  try {
+    db = await openDb(dbPath);
+  } catch {
+    return { total: 0, categoriesDone: 0, domainsDone: 0 };
+  }
+
+  try {
+    ensureMigrations(db);
+    const row = db.exec(
+      `SELECT
+         COUNT(*) AS total,
+         SUM(CASE WHEN primary_category IS NOT NULL AND primary_category <> '' AND primary_category <> 'unclassified' THEN 1 ELSE 0 END) AS categories_done,
+         SUM(CASE WHEN primary_domain IS NOT NULL AND primary_domain <> '' THEN 1 ELSE 0 END) AS domains_done
+       FROM bookmarks`
+    )[0]?.values?.[0];
+
+    return {
+      total: Number(row?.[0] ?? 0),
+      categoriesDone: Number(row?.[1] ?? 0),
+      domainsDone: Number(row?.[2] ?? 0),
+    };
+  } catch {
+    return { total: 0, categoriesDone: 0, domainsDone: 0 };
+  } finally {
+    db.close();
   }
 }
 

--- a/src/bookmarks-service.ts
+++ b/src/bookmarks-service.ts
@@ -1,5 +1,5 @@
 import { getTwitterBookmarksStatus, latestBookmarkSyncAt } from './bookmarks.js';
-import { buildIndex } from './bookmarks-db.js';
+import { buildIndex, getClassificationProgress } from './bookmarks-db.js';
 import { loadTwitterOAuthToken } from './xauth.js';
 import { syncBookmarksGraphQL, type SyncProgress } from './graphql-bookmarks.js';
 
@@ -14,6 +14,9 @@ export interface BookmarkEnableResult {
 export interface BookmarkStatusView {
   connected: boolean;
   bookmarkCount: number;
+  classificationTotal: number;
+  categoriesDone: number;
+  domainsDone: number;
   lastUpdated: string | null;
   mode: string;
   cachePath: string;
@@ -49,19 +52,30 @@ export async function enableBookmarks(): Promise<BookmarkEnableResult> {
 export async function getBookmarkStatusView(): Promise<BookmarkStatusView> {
   const token = await loadTwitterOAuthToken();
   const status = await getTwitterBookmarksStatus();
+  const progress = await getClassificationProgress();
   return {
     connected: Boolean(token?.access_token),
     bookmarkCount: status.totalBookmarks,
+    classificationTotal: progress.total,
+    categoriesDone: progress.categoriesDone,
+    domainsDone: progress.domainsDone,
     lastUpdated: latestBookmarkSyncAt(status),
     mode: token?.access_token ? 'Incremental by default (GraphQL + API available)' : 'Incremental by default (GraphQL)',
     cachePath: status.cachePath,
   };
 }
 
+function classificationDenominator(view: BookmarkStatusView): number {
+  return Math.max(view.bookmarkCount, view.classificationTotal);
+}
+
 export function formatBookmarkStatus(view: BookmarkStatusView): string {
+  const total = classificationDenominator(view);
   return [
     'Bookmarks',
     `  bookmarks: ${view.bookmarkCount}`,
+    `  categories: ${view.categoriesDone}/${total}`,
+    `  domains: ${view.domainsDone}/${total}`,
     `  last updated: ${view.lastUpdated ?? 'never'}`,
     `  sync mode: ${view.mode}`,
     `  cache: ${view.cachePath}`,
@@ -69,5 +83,6 @@ export function formatBookmarkStatus(view: BookmarkStatusView): string {
 }
 
 export function formatBookmarkSummary(view: BookmarkStatusView): string {
-  return `bookmarks=${view.bookmarkCount} updated=${view.lastUpdated ?? 'never'} mode="${view.mode}"`;
+  const total = classificationDenominator(view);
+  return `bookmarks=${view.bookmarkCount} categories=${view.categoriesDone}/${total} domains=${view.domainsDone}/${total} updated=${view.lastUpdated ?? 'never'} mode="${view.mode}"`;
 }

--- a/tests/bookmarks-db.test.ts
+++ b/tests/bookmarks-db.test.ts
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 import { mkdtemp, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
-import { buildIndex, searchBookmarks, getStats, formatSearchResults, getBookmarkById, sanitizeFtsQuery, getCategoryCounts, sampleByCategory } from '../src/bookmarks-db.js';
+import { buildIndex, searchBookmarks, getStats, formatSearchResults, getBookmarkById, sanitizeFtsQuery, getCategoryCounts, sampleByCategory, getClassificationProgress } from '../src/bookmarks-db.js';
 import { openDb, saveDb } from '../src/db.js';
 import { twitterBookmarksIndexPath } from '../src/paths.js';
 
@@ -173,6 +173,37 @@ test('getCategoryCounts still returns real categories alongside the exclusion', 
     const counts = await getCategoryCounts();
     assert.equal(counts['tool'], 2, 'real category should be present');
     assert.ok(!('unclassified' in counts), 'unclassified placeholder should still be excluded');
+  });
+});
+
+test('getClassificationProgress returns category and domain completion counts', async () => {
+  await withIsolatedDataDir(async () => {
+    await buildIndex();
+
+    const dbPath = twitterBookmarksIndexPath();
+    const db = await openDb(dbPath);
+    try {
+      db.run(
+        `UPDATE bookmarks
+         SET categories = ?, primary_category = ?, domains = ?, primary_domain = ?
+         WHERE id = '1'`,
+        ['tool', 'tool', 'ai', 'ai'],
+      );
+      db.run(
+        `UPDATE bookmarks
+         SET categories = ?, primary_category = ?
+         WHERE id = '2'`,
+        ['research', 'research'],
+      );
+      saveDb(db, dbPath);
+    } finally {
+      db.close();
+    }
+
+    const progress = await getClassificationProgress();
+    assert.equal(progress.total, 3);
+    assert.equal(progress.categoriesDone, 2);
+    assert.equal(progress.domainsDone, 1);
   });
 });
 

--- a/tests/bookmarks-service.test.ts
+++ b/tests/bookmarks-service.test.ts
@@ -3,13 +3,19 @@ import assert from 'node:assert/strict';
 import os from 'node:os';
 import path from 'node:path';
 import { mkdtemp, rm } from 'node:fs/promises';
-import { writeJson } from '../src/fs.js';
+import { writeJson, writeJsonLines } from '../src/fs.js';
+import { buildIndex } from '../src/bookmarks-db.js';
+import { openDb, saveDb } from '../src/db.js';
+import { twitterBookmarksIndexPath } from '../src/paths.js';
 import { formatBookmarkStatus, formatBookmarkSummary, getBookmarkStatusView } from '../src/bookmarks-service.js';
 
 test('formatBookmarkStatus produces human-readable summary', () => {
   const text = formatBookmarkStatus({
     connected: true,
     bookmarkCount: 99,
+    classificationTotal: 99,
+    categoriesDone: 80,
+    domainsDone: 65,
     lastUpdated: '2026-03-28T17:23:00Z',
     mode: 'Incremental by default (GraphQL + API available)',
     cachePath: '/tmp/x-bookmarks.jsonl',
@@ -17,6 +23,8 @@ test('formatBookmarkStatus produces human-readable summary', () => {
 
   assert.match(text, /^Bookmarks/);
   assert.match(text, /bookmarks: 99/);
+  assert.match(text, /categories: 80\/99/);
+  assert.match(text, /domains: 65\/99/);
   assert.match(text, /last updated: 2026-03-28T17:23:00Z/);
   assert.match(text, /sync mode: Incremental by default \(GraphQL \+ API available\)/);
   assert.match(text, /cache: \/tmp\/x-bookmarks\.jsonl/);
@@ -27,6 +35,9 @@ test('formatBookmarkStatus shows never when no lastUpdated', () => {
   const text = formatBookmarkStatus({
     connected: false,
     bookmarkCount: 0,
+    classificationTotal: 0,
+    categoriesDone: 0,
+    domainsDone: 0,
     lastUpdated: null,
     mode: 'Incremental by default (GraphQL)',
     cachePath: '/tmp/x-bookmarks.jsonl',
@@ -39,12 +50,17 @@ test('formatBookmarkSummary produces concise operator-friendly output', () => {
   const text = formatBookmarkSummary({
     connected: true,
     bookmarkCount: 99,
+    classificationTotal: 99,
+    categoriesDone: 80,
+    domainsDone: 65,
     lastUpdated: '2026-03-28T17:23:00Z',
     mode: 'API sync',
     cachePath: '/tmp/x-bookmarks.jsonl',
   });
 
   assert.match(text, /bookmarks=99/);
+  assert.match(text, /categories=80\/99/);
+  assert.match(text, /domains=65\/99/);
   assert.match(text, /updated=2026-03-28T17:23:00Z/);
   assert.match(text, /mode="API sync"/);
 });
@@ -65,8 +81,71 @@ test('getBookmarkStatusView uses the most recent sync timestamp', async () => {
     const view = await getBookmarkStatusView();
 
     assert.equal(view.bookmarkCount, 3);
+    assert.equal(view.classificationTotal, 0);
+    assert.equal(view.categoriesDone, 0);
+    assert.equal(view.domainsDone, 0);
     assert.equal(view.lastUpdated, '2026-04-05T12:34:56Z');
     assert.equal(view.connected, false);
+  } finally {
+    delete process.env.FT_DATA_DIR;
+    await rm(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test('getBookmarkStatusView includes classification progress counts', async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), 'ft-status-view-'));
+  process.env.FT_DATA_DIR = tmpDir;
+
+  try {
+    await writeJson(path.join(tmpDir, 'bookmarks-meta.json'), {
+      provider: 'twitter',
+      schemaVersion: 1,
+      lastIncrementalSyncAt: '2026-04-05T12:34:56Z',
+      totalBookmarks: 3,
+    });
+
+    await writeJson(path.join(tmpDir, 'bookmarks-backfill-state.json'), {
+      provider: 'twitter',
+      lastRunAt: '2026-04-05T12:34:56Z',
+      totalRuns: 1,
+      totalAdded: 3,
+      lastAdded: 3,
+      lastSeenIds: ['1', '2', '3'],
+      stopReason: 'caught up to newest stored bookmark',
+    });
+
+    await writeJsonLines(path.join(tmpDir, 'bookmarks.jsonl'), [
+      { id: '1', tweetId: '1', url: 'https://x.com/alice/status/1', text: 'one', syncedAt: '2026-04-05T12:00:00Z', tags: [] },
+      { id: '2', tweetId: '2', url: 'https://x.com/bob/status/2', text: 'two', syncedAt: '2026-04-05T12:00:00Z', tags: [] },
+      { id: '3', tweetId: '3', url: 'https://x.com/carol/status/3', text: 'three', syncedAt: '2026-04-05T12:00:00Z', tags: [] },
+    ]);
+
+    await buildIndex();
+    const db = await openDb(twitterBookmarksIndexPath());
+    try {
+      db.run(
+        `UPDATE bookmarks
+         SET categories = ?, primary_category = ?, domains = ?, primary_domain = ?
+         WHERE id = '1'`,
+        ['tool', 'tool', 'ai', 'ai'],
+      );
+      db.run(
+        `UPDATE bookmarks
+         SET categories = ?, primary_category = ?
+         WHERE id = '2'`,
+        ['research', 'research'],
+      );
+      saveDb(db, twitterBookmarksIndexPath());
+    } finally {
+      db.close();
+    }
+
+    const view = await getBookmarkStatusView();
+
+    assert.equal(view.bookmarkCount, 3);
+    assert.equal(view.classificationTotal, 3);
+    assert.equal(view.categoriesDone, 2);
+    assert.equal(view.domainsDone, 1);
   } finally {
     delete process.env.FT_DATA_DIR;
     await rm(tmpDir, { recursive: true, force: true });


### PR DESCRIPTION
## Summary
- surface category and domain completion counts in `ft status`
- add a small DB query for classification progress
- cover the new counts in status formatting and DB/service tests

## Out of scope
- no lock file or process-detection logic
- no "classification job is running" status inference

## Verification
- `./node_modules/.bin/tsx --test tests/bookmarks-service.test.ts tests/bookmarks-db.test.ts tests/bookmarks-status.test.ts`
- `npm run build`