### PR TITLE
Fix X Article export and CLI stdout hygiene

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ On first run, `ft sync` extracts your X session from Chrome and downloads your b
 | `ft sync` | Download and sync bookmarks (no API required) |
 | `ft sync --rebuild` | Full re-crawl of all bookmarks |
 | `ft sync --continue` | Resume a paused or interrupted sync from the saved cursor |
-| `ft sync --gaps` | Backfill quoted tweets, expand truncated articles, enrich linked article content |
+| `ft sync --gaps` | Backfill quoted tweets, expand truncated/X Article text, enrich linked article content |
 | `ft sync --folders` | Also sync X bookmark folder tags (read-only mirror of X state) |
 | `ft sync --folder <name>` | Sync a single folder by name (exact or unambiguous prefix) |
 | `ft sync --classify` | Sync then classify new bookmarks with LLM |
@@ -75,7 +75,7 @@ On first run, `ft sync` extracts your X session from Chrome and downloads your b
 
 | Command | Description |
 |---------|-------------|
-| `ft md` | Export bookmarks as individual markdown files |
+| `ft md` | Export bookmarks as individual markdown files, including enriched article text |
 | `ft wiki` | Compile a Karpathy-style interlinked knowledge base |
 | `ft ask <question>` | Ask questions against the knowledge base |
 | `ft ask <question> --save` | Ask and save the answer as a concept page |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fieldtheory",
-  "version": "1.3.13",
+  "version": "1.3.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fieldtheory",
-      "version": "1.3.13",
+      "version": "1.3.14",
       "license": "MIT",
       "dependencies": {
         "commander": "^14.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fieldtheory",
-  "version": "1.3.13",
+  "version": "1.3.14",
   "description": "Field Theory CLI. Self-custody for your X/Twitter bookmarks. Local sync, full-text search, classification, and terminal dashboards.",
   "type": "module",
   "bin": {

--- a/src/bookmarks-db.ts
+++ b/src/bookmarks-db.ts
@@ -44,6 +44,9 @@ export interface BookmarkTimelineItem {
   primaryDomain?: string | null;
   githubUrls: string[];
   links: string[];
+  articleTitle?: string | null;
+  articleText?: string | null;
+  articleSite?: string | null;
   mediaCount: number;
   linkCount: number;
   likeCount?: number | null;
@@ -145,6 +148,9 @@ function mapTimelineRow(row: unknown[]): BookmarkTimelineItem {
     viewCount: row[22] as number | null,
     folderIds: parseJsonArray(row[23]),
     folderNames: parseJsonArray(row[24]),
+    articleTitle: (row[25] as string) ?? null,
+    articleText: (row[26] as string) ?? null,
+    articleSite: (row[27] as string) ?? null,
   };
 }
 
@@ -631,7 +637,10 @@ export async function listBookmarks(
         b.bookmark_count,
         b.view_count,
         b.folder_ids,
-        b.folder_names
+        b.folder_names,
+        b.article_title,
+        b.article_text,
+        b.article_site
       FROM bookmarks b
       ${where}
       ${bookmarkSortClause(filters.sort)}
@@ -772,7 +781,10 @@ export async function getBookmarkById(id: string): Promise<BookmarkTimelineItem 
         b.bookmark_count,
         b.view_count,
         b.folder_ids,
-        b.folder_names
+        b.folder_names,
+        b.article_title,
+        b.article_text,
+        b.article_site
       FROM bookmarks b
       WHERE b.id = ?
       LIMIT 1`,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -336,6 +336,7 @@ export function showWelcome(): void {
 
 export async function showDashboard(): Promise<void> {
   console.log(logo());
+  showWhatsNew();
   try {
     const view = await getBookmarkStatusView();
     const ago = view.lastUpdated ? timeAgo(view.lastUpdated) : 'never';
@@ -543,11 +544,7 @@ export function buildCli() {
     .name('ft')
     .description('Self-custody for your X/Twitter bookmarks. Sync, search, classify, and explore locally.')
     .version(getLocalVersion())
-    .showHelpAfterError()
-    .hook('preAction', () => {
-      console.log(logo());
-      showWhatsNew();
-    });
+    .showHelpAfterError();
 
   // ── sync ────────────────────────────────────────────────────────────────
 

--- a/src/graphql-bookmarks.ts
+++ b/src/graphql-bookmarks.ts
@@ -8,6 +8,7 @@ import type { BookmarkBackfillState, BookmarkCacheMeta, BookmarkFolder, Bookmark
 import { exportBookmarksForSyncSeed, updateQuotedTweets, updateBookmarkText, updateArticleContent } from './bookmarks-db.js';
 import type { ArticleUpdate } from './bookmarks-db.js';
 import { fetchArticle, resolveTcoLink } from './bookmark-enrich.js';
+import type { ArticleContent } from './bookmark-enrich.js';
 
 const CHROME_UA = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.0.0 Safari/537.36';
 
@@ -1373,6 +1374,7 @@ export type TweetFetchSource = 'graphql' | 'syndication';
 
 export interface TweetFetchResult {
   snapshot: QuotedTweetSnapshot | null;
+  article?: ArticleContent | null;
   status: 'ok' | 'empty' | 'not_found' | 'forbidden' | 'rate_limited' | 'server_error' | 'error';
   httpStatus?: number;
   /**
@@ -1422,6 +1424,88 @@ export function parseTweetResultByRestId(json: any, tweetId: string): QuotedTwee
   };
 }
 
+function unwrapGraphqlResult(value: any): any {
+  return value?.result?.tweet ?? value?.result ?? value?.tweet ?? value;
+}
+
+function collectArticleCandidates(value: any, depth = 0): any[] {
+  if (!value || typeof value !== 'object' || depth > 8) return [];
+  const candidates: any[] = [];
+  for (const [key, child] of Object.entries(value)) {
+    if (!child || typeof child !== 'object') continue;
+    if (key.toLowerCase().includes('article')) {
+      candidates.push(unwrapGraphqlResult(child));
+    }
+    candidates.push(...collectArticleCandidates(child, depth + 1));
+  }
+  return candidates;
+}
+
+function blockText(block: any): string {
+  if (!block) return '';
+  if (typeof block === 'string') return block;
+  if (typeof block !== 'object') return '';
+
+  const direct = block.text ?? block.value ?? block.content ?? block.body;
+  if (typeof direct === 'string') return direct;
+
+  for (const key of ['children', 'items', 'spans', 'contents']) {
+    if (Array.isArray(block[key])) {
+      return block[key].map(blockText).filter(Boolean).join(' ');
+    }
+  }
+
+  return '';
+}
+
+function articleFromCandidate(candidate: any): ArticleContent | null {
+  if (!candidate || typeof candidate !== 'object') return null;
+
+  const title = typeof candidate.title === 'string'
+    ? candidate.title
+    : typeof candidate.headline === 'string'
+      ? candidate.headline
+      : '';
+
+  let text = '';
+  for (const key of ['articleBody', 'body', 'text', 'description']) {
+    if (typeof candidate[key] === 'string' && candidate[key].length > text.length) {
+      text = candidate[key];
+    }
+  }
+
+  for (const key of ['contents', 'content', 'blocks']) {
+    if (Array.isArray(candidate[key])) {
+      const fromBlocks = candidate[key].map(blockText).filter(Boolean).join('\n\n');
+      if (fromBlocks.length > text.length) text = fromBlocks;
+    }
+  }
+
+  text = text.replace(/\s+\n/g, '\n').replace(/\n{3,}/g, '\n\n').trim();
+  if (text.length < 50) return null;
+
+  const siteName = typeof candidate.siteName === 'string'
+    ? candidate.siteName
+    : typeof candidate.site_name === 'string'
+      ? candidate.site_name
+      : undefined;
+
+  return { title, text, siteName };
+}
+
+export function parseTweetArticleByRestId(json: any): ArticleContent | null {
+  const result = json?.data?.tweetResult?.result;
+  if (!result) return null;
+  const tweet = result.tweet ?? result;
+
+  for (const candidate of collectArticleCandidates(tweet)) {
+    const article = articleFromCandidate(candidate);
+    if (article) return article;
+  }
+
+  return null;
+}
+
 function buildTweetResultByRestIdUrl(tweetId: string): string {
   const variables = {
     tweetId,
@@ -1467,8 +1551,9 @@ export async function fetchTweetByIdViaGraphQL(
         return { snapshot: null, status: 'not_found', source: 'graphql' };
       }
       const snapshot = parseTweetResultByRestId(json, tweetId);
-      if (!snapshot) return { snapshot: null, status: 'empty', source: 'graphql' };
-      return { snapshot, status: 'ok', source: 'graphql' };
+      const article = parseTweetArticleByRestId(json);
+      if (!snapshot) return { snapshot: null, article, status: article ? 'ok' : 'empty', source: 'graphql' };
+      return { snapshot, article, status: 'ok', source: 'graphql' };
     }
 
     if (response.status === 429) {
@@ -1543,6 +1628,7 @@ async function fetchTweetViaSyndication(tweetId: string): Promise<TweetFetchResu
 
 // Text >= 275 chars may be truncated by Twitter's legacy.full_text limit
 const TRUNCATION_THRESHOLD = 275;
+const LINK_ONLY_THRESHOLD = 80;
 
 const GAP_FILL_FAILURE_REASONS: Record<string, string> = {
   empty: 'tweet exists but has no text content',
@@ -1623,6 +1709,39 @@ function resolveGapFillCookies(options: SyncGapsOptions): { csrfToken?: string; 
   }
 }
 
+function textWithoutUrls(text: string): string {
+  return text.replace(/https?:\/\/\S+/g, '').trim();
+}
+
+function isLinkOnlyBookmark(record: BookmarkRecord): boolean {
+  if (!record.links?.length) return false;
+  return textWithoutUrls(record.text ?? '').length < LINK_ONLY_THRESHOLD;
+}
+
+function isXArticleUrl(value: string): boolean {
+  try {
+    const url = new URL(value);
+    const host = url.hostname.toLowerCase();
+    return (host === 'x.com' || host === 'twitter.com') && url.pathname.startsWith('/i/article/');
+  } catch {
+    return false;
+  }
+}
+
+async function readEnrichedBookmarkIds(): Promise<Set<string>> {
+  const enrichedIds = new Set<string>();
+  try {
+    const { openDb } = await import('./db.js');
+    const { twitterBookmarksIndexPath } = await import('./paths.js');
+    const db = await openDb(twitterBookmarksIndexPath());
+    try {
+      const rows = db.exec('SELECT id FROM bookmarks WHERE enriched_at IS NOT NULL');
+      for (const row of rows[0]?.values ?? []) enrichedIds.add(row[0] as string);
+    } finally { db.close(); }
+  } catch { /* DB may not exist yet */ }
+  return enrichedIds;
+}
+
 export async function syncGaps(options: SyncGapsOptions = {}): Promise<GapFillResult> {
   const delayMs = options.delayMs ?? 300;
   const cachePath = twitterBookmarksCachePath();
@@ -1643,6 +1762,7 @@ export async function syncGaps(options: SyncGapsOptions = {}): Promise<GapFillRe
       }
       return fetchTweetViaSyndication(tweetId);
     });
+  const enrichedIds = await readEnrichedBookmarkIds();
 
   // Gap 1: missing quoted tweets. Skip records where a previous gap-fill run
   // already tried and failed — otherwise dead tweets get re-fetched forever.
@@ -1654,6 +1774,13 @@ export async function syncGaps(options: SyncGapsOptions = {}): Promise<GapFillRe
   // that's already full-length won't be re-fetched on every run.
   const maybeTruncated = records.filter((r) => (r.text?.length ?? 0) >= TRUNCATION_THRESHOLD && !r.textExpandedAt);
   const truncatedIds = new Set(maybeTruncated.map((r) => r.tweetId));
+
+  // Gap 3a: X Article bookmarks can look short ("x.com/i/article/…") even
+  // when the useful body exists in the authenticated TweetResult payload.
+  const needsXArticle = records.filter((r) =>
+    !enrichedIds.has(r.id) && isLinkOnlyBookmark(r) && (r.links ?? []).some(isXArticleUrl)
+  );
+  const xArticleIds = new Set(needsXArticle.map((r) => r.tweetId));
 
   // Build lookup indexes for applying results
   const recordsByQuotedId = new Map<string, BookmarkRecord[]>();
@@ -1668,31 +1795,41 @@ export async function syncGaps(options: SyncGapsOptions = {}): Promise<GapFillRe
     list.push(r);
     recordsByTweetId.set(r.tweetId, list);
   }
+  const recordsByXArticleTweetId = new Map<string, BookmarkRecord[]>();
+  for (const r of needsXArticle) {
+    const list = recordsByXArticleTweetId.get(r.tweetId) ?? [];
+    list.push(r);
+    recordsByXArticleTweetId.set(r.tweetId, list);
+  }
 
   // Combine all IDs to fetch — deduplicated
-  const allFetchIds = [...new Set([...quotedIds, ...truncatedIds])];
+  const allFetchIds = [...new Set([...quotedIds, ...truncatedIds, ...xArticleIds])];
   const total = allFetchIds.length;
 
   let quotedFetched = 0;
   let textExpanded = 0;
+  let articlesEnriched = 0;
   let failed = 0;
   const failures: GapFillFailure[] = [];
   const dbQuotedUpdates: Array<{ id: string; quotedTweet: QuotedTweetSnapshot }> = [];
   const dbTextUpdates: Array<{ id: string; text: string }> = [];
+  const articleDbUpdates: ArticleUpdate[] = [];
 
   // Fetch and apply incrementally
   for (let i = 0; i < allFetchIds.length; i++) {
     const tweetId = allFetchIds[i];
     const now = new Date().toISOString();
     let snapshot: QuotedTweetSnapshot | null = null;
+    let article: ArticleContent | null | undefined;
     let resultStatus: TweetFetchResult['status'] = 'error';
     let resultSource: TweetFetchSource | undefined;
     try {
       const result = await fetcher(tweetId);
       snapshot = result.snapshot;
+      article = result.article;
       resultStatus = result.status;
       resultSource = result.source;
-      if (!snapshot) {
+      if (!snapshot && !article) {
         failed++;
         failures.push({
           tweetId,
@@ -1746,12 +1883,26 @@ export async function syncGaps(options: SyncGapsOptions = {}): Promise<GapFillRe
       }
     }
 
+    if (article) {
+      for (const record of recordsByXArticleTweetId.get(tweetId) ?? []) {
+        if (enrichedIds.has(record.id)) continue;
+        articleDbUpdates.push({
+          id: record.id,
+          articleTitle: article.title,
+          articleText: article.text,
+          articleSite: article.siteName,
+        });
+        enrichedIds.add(record.id);
+        articlesEnriched++;
+      }
+    }
+
     options?.onProgress?.({
       done: i + 1,
       total,
       quotedFetched,
       textExpanded,
-      articlesEnriched: 0,
+      articlesEnriched,
       failed,
     });
 
@@ -1773,33 +1924,16 @@ export async function syncGaps(options: SyncGapsOptions = {}): Promise<GapFillRe
   if (dbQuotedUpdates.length > 0) await updateQuotedTweets(dbQuotedUpdates);
   if (dbTextUpdates.length > 0) await updateBookmarkText(dbTextUpdates);
 
-  // ── Gap 3: Article enrichment for link-only bookmarks ───────────────────
+  // ── Gap 3b: Article enrichment for ordinary link-only bookmarks ─────────
   // Bookmarks with < 80 chars of text after stripping URLs are "link-only"
   // and invisible to search. Fetch the linked article to make them searchable.
   // Article content goes directly to SQLite (not JSONL) to avoid memory bloat.
 
-  const LINK_ONLY_THRESHOLD = 80;
-  const articleDbUpdates: ArticleUpdate[] = [];
-  let articlesEnriched = 0;
-
-  // Read enriched_at from DB to skip already-enriched bookmarks
-  const enrichedIds = new Set<string>();
-  try {
-    const { openDb } = await import('./db.js');
-    const { twitterBookmarksIndexPath } = await import('./paths.js');
-    const db = await openDb(twitterBookmarksIndexPath());
-    try {
-      const rows = db.exec('SELECT id FROM bookmarks WHERE enriched_at IS NOT NULL');
-      for (const row of rows[0]?.values ?? []) enrichedIds.add(row[0] as string);
-    } finally { db.close(); }
-  } catch { /* DB may not exist yet */ }
-
   // Filter to link-only bookmarks not yet enriched
-  const textWithoutUrls = (text: string) => text.replace(/https?:\/\/\S+/g, '').trim();
   const needsEnrichment = records.filter((r) => {
     if (enrichedIds.has(r.id)) return false;
-    if (!r.links?.length) return false;
-    return textWithoutUrls(r.text ?? '').length < LINK_ONLY_THRESHOLD;
+    if ((r.links ?? []).some(isXArticleUrl)) return false;
+    return isLinkOnlyBookmark(r);
   });
 
   const articleTotal = Math.min(needsEnrichment.length, 50); // cap per run

--- a/src/md-export.ts
+++ b/src/md-export.ts
@@ -45,6 +45,10 @@ function bookmarkFilename(b: BookmarkTimelineItem): string {
   return `${date}-${author}-${textSlug}.md`;
 }
 
+function oneLine(value: string): string {
+  return value.replace(/\s+/g, ' ').trim();
+}
+
 function buildBookmarkMd(b: BookmarkTimelineItem): string {
   const lines: string[] = [];
 
@@ -76,6 +80,21 @@ function buildBookmarkMd(b: BookmarkTimelineItem): string {
   // ── Body ────────────────────────────────────────────────────────────
   lines.push(b.text);
   lines.push('');
+
+  // ── Enriched article content ───────────────────────────────────────
+  if (b.articleText) {
+    lines.push('## Article');
+    if (b.articleTitle) {
+      lines.push(`### ${oneLine(b.articleTitle)}`);
+      lines.push('');
+    }
+    if (b.articleSite) {
+      lines.push(`Source: ${oneLine(b.articleSite)}`);
+      lines.push('');
+    }
+    lines.push(b.articleText.trim());
+    lines.push('');
+  }
 
   // ── Links ───────────────────────────────────────────────────────────
   if (b.links.length > 0) {

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -4,6 +4,27 @@ import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
 import { compareVersions, runWithSpinner, buildCli } from '../src/cli.js';
+import { dataDir } from '../src/paths.js';
+import { skillWithFrontmatter } from '../src/skill.js';
+
+async function captureStdout(fn: () => Promise<void>): Promise<string> {
+  const chunks: string[] = [];
+  const origWrite = process.stdout.write;
+  process.stdout.write = ((chunk: any, encodingOrCb?: any, cb?: any) => {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk.toString('utf-8') : String(chunk));
+    if (typeof encodingOrCb === 'function') encodingOrCb();
+    if (typeof cb === 'function') cb();
+    return true;
+  }) as typeof process.stdout.write;
+
+  try {
+    await fn();
+  } finally {
+    process.stdout.write = origWrite;
+  }
+
+  return chunks.join('');
+}
 
 test('showDashboard: prints update notice when cache is newer than local', async () => {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ft-dashboard-'));
@@ -48,6 +69,30 @@ test('ft wiki: description mentions engine prerequisite', () => {
   assert.ok(wikiCmd);
   const desc = wikiCmd.description().toLowerCase();
   assert.ok(desc.includes('claude') && desc.includes('codex'));
+});
+
+test('ft path: prints only the data directory', async () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ft-path-'));
+  const origEnv = process.env.FT_DATA_DIR;
+  process.env.FT_DATA_DIR = tmpDir;
+
+  try {
+    const output = await captureStdout(async () => {
+      await buildCli().parseAsync(['node', 'ft', 'path']);
+    });
+    assert.equal(output, `${dataDir()}\n`);
+  } finally {
+    process.env.FT_DATA_DIR = origEnv;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test('ft skill show: prints only skill content', async () => {
+  const output = await captureStdout(async () => {
+    await buildCli().parseAsync(['node', 'ft', 'skill', 'show']);
+  });
+
+  assert.equal(output, skillWithFrontmatter());
 });
 
 test('compareVersions: equal versions return 0', () => {

--- a/tests/graphql-bookmarks.test.ts
+++ b/tests/graphql-bookmarks.test.ts
@@ -9,6 +9,7 @@ import {
   convertTweetToRecord,
   parseBookmarksResponse,
   parseFolderTimelineResponse,
+  parseTweetArticleByRestId,
   parseTweetResultByRestId,
   sanitizeBookmarkedAt,
   scoreRecord,
@@ -445,11 +446,96 @@ test('parseTweetResultByRestId: extracts note_tweet body from live TweetResultBy
   assert.ok(snapshot.text.startsWith('LLM Knowledge Bases'));
 });
 
+test('parseTweetArticleByRestId: extracts X Article rich-text content', () => {
+  const fixture = {
+    data: {
+      tweetResult: {
+        result: {
+          rest_id: '2042685676949270724',
+          legacy: {
+            id_str: '2042685676949270724',
+            full_text: 'x.com/i/article/2042...',
+          },
+          article_results: {
+            result: {
+              title: 'How agents should use context',
+              contents: [
+                { type: 'header-two', text: 'Context discipline' },
+                { type: 'unstyled', text: 'The useful body lives in the X Article payload, not in the tweet preview.' },
+              ],
+            },
+          },
+        },
+      },
+    },
+  };
+
+  const article = parseTweetArticleByRestId(fixture);
+  assert.ok(article);
+  assert.equal(article.title, 'How agents should use context');
+  assert.match(article.text, /Context discipline/);
+  assert.match(article.text, /useful body lives in the X Article payload/);
+});
+
 test('parseTweetResultByRestId: returns null on tombstone / unavailable tweets', () => {
   assert.equal(
     parseTweetResultByRestId({ data: { tweetResult: { result: { __typename: 'TweetTombstone' } } } }, '123'),
     null,
   );
+});
+
+test('syncGaps: enriches X Article bookmarks through TweetResult payload', async () => {
+  const xArticle: BookmarkRecord = {
+    id: '2042685676949270724',
+    tweetId: '2042685676949270724',
+    url: 'https://x.com/danveloper/status/2042685676949270724',
+    text: 'x.com/i/article/2042...',
+    authorHandle: 'danveloper',
+    syncedAt: NOW,
+    postedAt: 'Fri Apr 10 19:26:31 +0000 2026',
+    links: ['http://x.com/i/article/2042676487711584257'],
+    tags: [],
+    ingestedVia: 'graphql',
+  };
+
+  await withIsolatedGapFillDataDir(async () => {
+    await buildIndex();
+    let fetchCalls = 0;
+    const result = await syncGaps({
+      tweetFetcher: async (tweetId) => {
+        fetchCalls += 1;
+        assert.equal(tweetId, '2042685676949270724');
+        return {
+          snapshot: {
+            id: tweetId,
+            text: 'x.com/i/article/2042...',
+            url: 'https://x.com/danveloper/status/2042685676949270724',
+          },
+          article: {
+            title: 'How agents should use context',
+            text: 'The article body is the useful content. It should not be lost behind an X Article link.',
+            siteName: 'X Articles',
+          },
+          status: 'ok',
+          source: 'graphql',
+        };
+      },
+    });
+
+    assert.equal(fetchCalls, 1);
+    assert.equal(result.articlesEnriched, 1);
+    assert.equal(result.failed, 0);
+
+    const refreshed = await getBookmarkById('2042685676949270724');
+    assert.ok(refreshed);
+    assert.equal(refreshed.text, 'x.com/i/article/2042...');
+    assert.equal(refreshed.articleTitle, 'How agents should use context');
+    assert.match(refreshed.articleText ?? '', /useful content/);
+
+    const jsonl = await readFile(path.join(process.env.FT_DATA_DIR!, 'bookmarks.jsonl'), 'utf8');
+    const stored = JSON.parse(jsonl.trim().split('\n').pop()!);
+    assert.equal(stored.text, 'x.com/i/article/2042...');
+  }, [xArticle]);
 });
 
 async function withIsolatedGapFillDataDir(

--- a/tests/md-export.test.ts
+++ b/tests/md-export.test.ts
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 import { mkdtemp, readFile, readdir, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
-import { buildIndex } from '../src/bookmarks-db.js';
+import { buildIndex, updateArticleContent } from '../src/bookmarks-db.js';
 import { exportBookmarks } from '../src/md-export.js';
 
 async function withIsolatedDataDir(fn: (dir: string) => Promise<void>, fixtures: any[]): Promise<void> {
@@ -55,5 +55,50 @@ test('exportBookmarks: writes ISO dates for legacy postedAt in filenames and fro
     const content = await readFile(path.join(bookmarksDir, files[0]), 'utf8');
     assert.match(content, /^posted_at: 2026-04-04$/m);
     assert.match(content, /^bookmarked_at: 2026-04-17$/m);
+  }, fixtures);
+});
+
+test('exportBookmarks: includes enriched article content for X Article bookmarks', async () => {
+  const fixtures = [
+    {
+      id: '2042685676949270724',
+      tweetId: '2042685676949270724',
+      url: 'https://x.com/danveloper/status/2042685676949270724',
+      text: 'x.com/i/article/2042...',
+      authorHandle: 'danveloper',
+      authorName: 'Dan Woods',
+      syncedAt: '2026-04-20T00:00:00.000Z',
+      postedAt: 'Fri Apr 10 19:26:31 +0000 2026',
+      mediaObjects: [],
+      links: ['http://x.com/i/article/2042676487711584257'],
+      tags: [],
+      ingestedVia: 'graphql',
+    },
+  ];
+
+  await withIsolatedDataDir(async (dir) => {
+    await buildIndex();
+    await updateArticleContent([
+      {
+        id: '2042685676949270724',
+        articleTitle: 'How agents should use context',
+        articleText: 'The article body is the useful content. It should not be lost behind an X Article link.',
+        articleSite: 'X Articles',
+      },
+    ]);
+
+    const result = await exportBookmarks({ force: true });
+    assert.equal(result.exported, 1);
+
+    const bookmarksDir = path.join(dir, 'md', 'bookmarks');
+    const files = await readdir(bookmarksDir);
+    assert.equal(files.length, 1);
+
+    const content = await readFile(path.join(bookmarksDir, files[0]), 'utf8');
+    assert.match(content, /x\.com\/i\/article\/2042\.\.\./);
+    assert.match(content, /## Article/);
+    assert.match(content, /### How agents should use context/);
+    assert.match(content, /The article body is the useful content/);
+    assert.match(content, /## Links\n- http:\/\/x\.com\/i\/article\/2042676487711584257/);
   }, fixtures);
 });


### PR DESCRIPTION
## Summary
- stop printing the Field Theory banner before normal subcommand output so JSON/path/skill output stays machine-readable
- enrich link-only X Article bookmarks through TweetResult payloads and expose stored article fields in show/list/export paths
- include enriched article text in markdown exports without replacing the original tweet preview
- bump package version to 1.3.14 and update README command descriptions

## Commit summary
- `f2c9671` fix x article exports and cli stdout

## Validation
- `npm run build`
- `npm test`
- focused CLI, GraphQL gap-fill, DB, and markdown export tests