### PR TITLE
[codex] Report missing X Article bodies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fieldtheory",
-  "version": "1.3.14",
+  "version": "1.3.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fieldtheory",
-      "version": "1.3.14",
+      "version": "1.3.15",
       "license": "MIT",
       "dependencies": {
         "commander": "^14.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fieldtheory",
-  "version": "1.3.14",
+  "version": "1.3.15",
   "description": "Field Theory CLI. Self-custody for your X/Twitter bookmarks. Local sync, full-text search, classification, and terminal dashboards.",
   "type": "module",
   "bin": {

--- a/src/graphql-bookmarks.ts
+++ b/src/graphql-bookmarks.ts
@@ -1639,6 +1639,12 @@ const GAP_FILL_FAILURE_REASONS: Record<string, string> = {
   error: 'X GraphQL rejected the request (likely rotated queryId or feature flags)',
 };
 
+const X_ARTICLE_MISSING_REASONS: Record<string, string> = {
+  graphql: 'X GraphQL response did not include article content',
+  syndication: 'X Article body requires authenticated X GraphQL; syndication only returned the tweet preview',
+  unknown: 'X Article body was not returned',
+};
+
 export interface GapFillProgress {
   done: number;
   total: number;
@@ -1895,6 +1901,13 @@ export async function syncGaps(options: SyncGapsOptions = {}): Promise<GapFillRe
         enrichedIds.add(record.id);
         articlesEnriched++;
       }
+    } else if (recordsByXArticleTweetId.has(tweetId) && snapshot) {
+      failed++;
+      failures.push({
+        tweetId,
+        reason: X_ARTICLE_MISSING_REASONS[resultSource ?? 'unknown'],
+        url: `https://x.com/_/status/${tweetId}`,
+      });
     }
 
     options?.onProgress?.({

--- a/tests/graphql-bookmarks.test.ts
+++ b/tests/graphql-bookmarks.test.ts
@@ -538,6 +538,45 @@ test('syncGaps: enriches X Article bookmarks through TweetResult payload', async
   }, [xArticle]);
 });
 
+test('syncGaps: reports X Article when fallback only returns tweet preview', async () => {
+  const xArticle: BookmarkRecord = {
+    id: '2042685676949270724',
+    tweetId: '2042685676949270724',
+    url: 'https://x.com/danveloper/status/2042685676949270724',
+    text: 'x.com/i/article/2042...',
+    authorHandle: 'danveloper',
+    syncedAt: NOW,
+    postedAt: 'Fri Apr 10 19:26:31 +0000 2026',
+    links: ['http://x.com/i/article/2042676487711584257'],
+    tags: [],
+    ingestedVia: 'graphql',
+  };
+
+  await withIsolatedGapFillDataDir(async () => {
+    await buildIndex();
+    const result = await syncGaps({
+      tweetFetcher: async (tweetId) => ({
+        snapshot: {
+          id: tweetId,
+          text: 'x.com/i/article/2042...',
+          url: 'https://x.com/danveloper/status/2042685676949270724',
+        },
+        status: 'ok',
+        source: 'syndication',
+      }),
+    });
+
+    assert.equal(result.articlesEnriched, 0);
+    assert.equal(result.failed, 1);
+    assert.equal(result.failures[0].tweetId, '2042685676949270724');
+    assert.match(result.failures[0].reason, /authenticated X GraphQL/);
+
+    const refreshed = await getBookmarkById('2042685676949270724');
+    assert.ok(refreshed);
+    assert.equal(refreshed.articleText, null);
+  }, [xArticle]);
+});
+
 async function withIsolatedGapFillDataDir(
   fn: () => Promise<void>,
   fixtures: BookmarkRecord[],


### PR DESCRIPTION
## Summary
- Report X Article bookmarks as gap-fill failures when only the tweet preview is returned and no article body is available.
- Add a regression test for the syndication fallback case so `ft sync --gaps` no longer silently leaves markdown exports link-only.
- Bump the package version to `1.3.15`.

## Root Cause
#116 handled storing and exporting article bodies once they were returned, but the fallback path could return a tweet preview without the X Article body and still look successful.

## Validation
- `./node_modules/.bin/tsx --test tests/graphql-bookmarks.test.ts tests/md-export.test.ts`
- `npm run build`

## Commits
- `68a90cd` report missing X Article bodies
- `649e0b9` merge latest `main`
- `cfe4332` bump version to 1.3.15
