### PR TITLE
[codex] Fetch X Article content state

### DIFF
--- a/src/graphql-bookmarks.ts
+++ b/src/graphql-bookmarks.ts
@@ -1370,6 +1370,17 @@ const TWEET_RESULT_FEATURES = {
   responsive_web_enhance_cards_enabled: false,
 };
 
+const TWEET_RESULT_FIELD_TOGGLES = {
+  withArticleRichContentState: true,
+  withArticlePlainText: true,
+  withArticleSummaryText: true,
+  withArticleVoiceOver: false,
+  withGrokAnalyze: false,
+  withDisallowedReplyControls: false,
+  withPayments: false,
+  withAuxiliaryUserLabels: false,
+};
+
 export type TweetFetchSource = 'graphql' | 'syndication';
 
 export interface TweetFetchResult {
@@ -1468,7 +1479,7 @@ function articleFromCandidate(candidate: any): ArticleContent | null {
       : '';
 
   let text = '';
-  for (const key of ['articleBody', 'body', 'text', 'description']) {
+  for (const key of ['articleBody', 'plain_text', 'plainText', 'body', 'text', 'description', 'preview_text', 'summary_text']) {
     if (typeof candidate[key] === 'string' && candidate[key].length > text.length) {
       text = candidate[key];
     }
@@ -1479,6 +1490,10 @@ function articleFromCandidate(candidate: any): ArticleContent | null {
       const fromBlocks = candidate[key].map(blockText).filter(Boolean).join('\n\n');
       if (fromBlocks.length > text.length) text = fromBlocks;
     }
+  }
+  if (Array.isArray(candidate.content_state?.blocks)) {
+    const fromRichTextBlocks = candidate.content_state.blocks.map(blockText).filter(Boolean).join('\n\n');
+    if (fromRichTextBlocks.length > text.length) text = fromRichTextBlocks;
   }
 
   text = text.replace(/\s+\n/g, '\n').replace(/\n{3,}/g, '\n\n').trim();
@@ -1516,6 +1531,7 @@ function buildTweetResultByRestIdUrl(tweetId: string): string {
   const params = new URLSearchParams({
     variables: JSON.stringify(variables),
     features: JSON.stringify(TWEET_RESULT_FEATURES),
+    fieldToggles: JSON.stringify(TWEET_RESULT_FIELD_TOGGLES),
   });
   return `https://x.com/i/api/graphql/${TWEET_RESULT_BY_REST_ID_QUERY_ID}/${TWEET_RESULT_BY_REST_ID_OPERATION}?${params}`;
 }

--- a/tests/graphql-bookmarks.test.ts
+++ b/tests/graphql-bookmarks.test.ts
@@ -477,6 +477,42 @@ test('parseTweetArticleByRestId: extracts X Article rich-text content', () => {
   assert.match(article.text, /useful body lives in the X Article payload/);
 });
 
+test('parseTweetArticleByRestId: extracts current X Article content_state shape', () => {
+  const fixture = {
+    data: {
+      tweetResult: {
+        result: {
+          rest_id: '2045577435484221722',
+          legacy: {
+            id_str: '2045577435484221722',
+            full_text: 'x.com/i/article/2045...',
+          },
+          article: {
+            article_results: {
+              result: {
+                title: 'Thoughts and Feelings around Claude Design',
+                plain_text: 'I tried Claude Design yesterday and I have a theory for how this whole thing shakes out.',
+                content_state: {
+                  blocks: [
+                    { text: 'I tried Claude Design yesterday and I have a theory for how this whole thing shakes out.' },
+                    { text: 'Figma invented its own primitives to make design systems work: components, styles, variables, and props.' },
+                  ],
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  };
+
+  const article = parseTweetArticleByRestId(fixture);
+  assert.ok(article);
+  assert.equal(article.title, 'Thoughts and Feelings around Claude Design');
+  assert.match(article.text, /I tried Claude Design yesterday/);
+  assert.match(article.text, /components, styles, variables, and props/);
+});
+
 test('parseTweetResultByRestId: returns null on tombstone / unavailable tweets', () => {
   assert.equal(
     parseTweetResultByRestId({ data: { tweetResult: { result: { __typename: 'TweetTombstone' } } } }, '123'),


### PR DESCRIPTION
## Summary
- Send X's current `TweetResultByRestId` article field toggles so X Article payloads include rich/plain article content.
- Parse the current X Article `article.article_results.result.content_state.blocks` and `plain_text` shapes.
- Add a regression test for the current `content_state` response shape.

## Root Cause
#118 correctly reported missing article bodies, but the request still did not ask X for the article field toggles that expose the body. The existing endpoint returns the content once those toggles are present.

## Validation
- Live check: `2045477517201477686` returned article `Number Go Down`, body length `73,019`.
- Live check: `2045577435484221722` returned article `Thoughts and Feelings around Claude Design`, body length `6,027`.
- Isolated end-to-end `syncGaps`: `articlesEnriched: 2`, `failed: 0`, markdown exports included `## Article`.
- `./node_modules/.bin/tsx --test tests/graphql-bookmarks.test.ts tests/md-export.test.ts`
- `npm run build`
- `npm test` (`294` passing)

## Commits
- `c5cbefb` fetch X Article content state
