### PR TITLE
Add changed markdown export mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ On first run, `ft sync` extracts your X session from your browser and downloads 
 | Command | Description |
 |---------|-------------|
 | `ft md` | Export bookmarks as individual markdown files, including enriched article text |
+| `ft md --changed` | Re-export only markdown files whose source bookmark data changed |
 | `ft wiki` | Compile a Karpathy-style interlinked knowledge base |
 | `ft ask <question>` | Ask questions against the knowledge base |
 | `ft ask <question> --save` | Ask and save the answer as a concept page |

--- a/src/bookmarks-db.ts
+++ b/src/bookmarks-db.ts
@@ -38,6 +38,7 @@ export interface BookmarkTimelineItem {
   authorProfileImageUrl?: string;
   postedAt?: string | null;
   bookmarkedAt?: string | null;
+  syncedAt?: string | null;
   categories: string[];
   primaryCategory?: string | null;
   domains: string[];
@@ -47,6 +48,7 @@ export interface BookmarkTimelineItem {
   articleTitle?: string | null;
   articleText?: string | null;
   articleSite?: string | null;
+  enrichedAt?: string | null;
   mediaCount: number;
   linkCount: number;
   likeCount?: number | null;
@@ -151,6 +153,8 @@ function mapTimelineRow(row: unknown[]): BookmarkTimelineItem {
     articleTitle: (row[25] as string) ?? null,
     articleText: (row[26] as string) ?? null,
     articleSite: (row[27] as string) ?? null,
+    syncedAt: (row[28] as string) ?? null,
+    enrichedAt: (row[29] as string) ?? null,
   };
 }
 
@@ -640,7 +644,9 @@ export async function listBookmarks(
         b.folder_names,
         b.article_title,
         b.article_text,
-        b.article_site
+        b.article_site,
+        b.synced_at,
+        b.enriched_at
       FROM bookmarks b
       ${where}
       ${bookmarkSortClause(filters.sort)}
@@ -784,7 +790,9 @@ export async function getBookmarkById(id: string): Promise<BookmarkTimelineItem 
         b.folder_names,
         b.article_title,
         b.article_text,
-        b.article_site
+        b.article_site,
+        b.synced_at,
+        b.enriched_at
       FROM bookmarks b
       WHERE b.id = ?
       LIMIT 1`,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1340,19 +1340,27 @@ export function buildCli() {
     .command('md')
     .description('Export bookmarks as individual markdown files')
     .option('--force', 'Re-export all bookmarks (overwrite existing files)')
+    .option('--changed', 'Re-export bookmarks whose source data changed since markdown was written')
     .action(safe(async (options) => {
       if (!requireIndex()) return;
+      if (options.force && options.changed) {
+        console.error('  Error: --force and --changed cannot be used together.');
+        process.exitCode = 1;
+        return;
+      }
       let lastLine = '';
       const spinner = createSpinner(() => lastLine);
       const result = await exportBookmarks({
         force: options.force,
+        changed: options.changed,
         onProgress: (s) => {
           lastLine = s;
           spinner.update();
         },
       });
       spinner.stop();
-      const skippedNote = result.skipped > 0 ? ` (${result.skipped} already existed)` : '';
+      const skippedReason = options.changed ? 'up to date' : 'already existed';
+      const skippedNote = result.skipped > 0 ? ` (${result.skipped} ${skippedReason})` : '';
       console.log(`Exported ${result.exported}/${result.total} bookmarks${skippedNote}`);
       console.log(`  ${result.elapsed}s elapsed`);
       console.log(`\n  Open in your markdown viewer:\n  ${mdDir()}`);

--- a/src/md-export.ts
+++ b/src/md-export.ts
@@ -1,7 +1,7 @@
 /**
  * Bookmark-to-markdown export.
  *
- * ft md [--force]
+ * ft md [--force|--changed]
  *
  * Exports each bookmark as an individual .md file with YAML frontmatter,
  * full tweet text, and [[wikilinks]] to wiki category/domain/entity pages.
@@ -15,11 +15,12 @@ import path from 'node:path';
 import { ensureDir, writeMd } from './fs.js';
 import { mdDir } from './paths.js';
 import { listBookmarks, countBookmarks, type BookmarkTimelineItem } from './bookmarks-db.js';
-import { toIsoDate } from './date-utils.js';
+import { parseTimestampMs, toIsoDate } from './date-utils.js';
 import { slug } from './md.js';
 
 export interface ExportOptions {
   force?: boolean;
+  changed?: boolean;
   onProgress?: (status: string) => void;
 }
 
@@ -47,6 +48,25 @@ function bookmarkFilename(b: BookmarkTimelineItem): string {
 
 function oneLine(value: string): string {
   return value.replace(/\s+/g, ' ').trim();
+}
+
+function latestSourceUpdateMs(b: BookmarkTimelineItem): number | null {
+  const values = [b.syncedAt, b.enrichedAt]
+    .map((value) => value ? parseTimestampMs(value) : null)
+    .filter((value): value is number => value != null);
+  return values.length > 0 ? Math.max(...values) : null;
+}
+
+function shouldExportBookmark(b: BookmarkTimelineItem, filePath: string, options: ExportOptions): boolean {
+  if (options.force) return true;
+  if (!fs.existsSync(filePath)) return true;
+  if (!options.changed) return false;
+
+  const changedAt = latestSourceUpdateMs(b);
+  if (changedAt == null) return false;
+
+  const fileMtime = fs.statSync(filePath).mtimeMs;
+  return changedAt > fileMtime;
 }
 
 function buildBookmarkMd(b: BookmarkTimelineItem): string {
@@ -135,18 +155,7 @@ export async function exportBookmarks(options: ExportOptions = {}): Promise<Expo
   await ensureDir(bookmarksDir());
 
   const total = await countBookmarks();
-  progress(`Exporting ${total} bookmarks to markdown...`);
-
-  // Track existing files to skip unless --force
-  const existingFiles = new Set<string>();
-  if (!options.force) {
-    try {
-      const files = fs.readdirSync(bookmarksDir());
-      for (const f of files) {
-        if (f.endsWith('.md')) existingFiles.add(f);
-      }
-    } catch { /* dir may not exist yet */ }
-  }
+  progress(options.changed ? `Exporting changed bookmarks to markdown...` : `Exporting ${total} bookmarks to markdown...`);
 
   let exported = 0;
   let skipped = 0;
@@ -159,14 +168,14 @@ export async function exportBookmarks(options: ExportOptions = {}): Promise<Expo
 
     for (const b of bookmarks) {
       const filename = bookmarkFilename(b);
+      const filePath = path.join(bookmarksDir(), filename);
 
-      if (!options.force && existingFiles.has(filename)) {
+      if (!shouldExportBookmark(b, filePath, options)) {
         skipped++;
         continue;
       }
 
       const content = buildBookmarkMd(b);
-      const filePath = path.join(bookmarksDir(), filename);
       await writeMd(filePath, content);
       exported++;
 

--- a/tests/md-export.test.ts
+++ b/tests/md-export.test.ts
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtemp, readFile, readdir, writeFile } from 'node:fs/promises';
+import { mkdtemp, readFile, readdir, utimes, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { buildIndex, updateArticleContent } from '../src/bookmarks-db.js';
@@ -100,5 +100,69 @@ test('exportBookmarks: includes enriched article content for X Article bookmarks
     assert.match(content, /### How agents should use context/);
     assert.match(content, /The article body is the useful content/);
     assert.match(content, /## Links\n- http:\/\/x\.com\/i\/article\/2042676487711584257/);
+  }, fixtures);
+});
+
+test('exportBookmarks: changed mode rewrites only stale enriched markdown', async () => {
+  const fixtures = [
+    {
+      id: '2042685676949270724',
+      tweetId: '2042685676949270724',
+      url: 'https://x.com/danveloper/status/2042685676949270724',
+      text: 'x.com/i/article/2042...',
+      authorHandle: 'danveloper',
+      authorName: 'Dan Woods',
+      syncedAt: '2026-04-20T00:00:00.000Z',
+      postedAt: 'Fri Apr 10 19:26:31 +0000 2026',
+      mediaObjects: [],
+      links: ['http://x.com/i/article/2042676487711584257'],
+      tags: [],
+      ingestedVia: 'graphql',
+    },
+    {
+      id: '1908170645818536087',
+      tweetId: '1908170645818536087',
+      url: 'https://x.com/Thom_Wolf/status/1908170645818536087',
+      text: 'Already exported note',
+      authorHandle: 'Thom_Wolf',
+      authorName: 'Thomas Wolf',
+      syncedAt: '2026-04-18T00:00:00.000Z',
+      postedAt: 'Fri Apr 04 19:53:15 +0000 2026',
+      mediaObjects: [],
+      links: [],
+      tags: [],
+      ingestedVia: 'graphql',
+    },
+  ];
+
+  await withIsolatedDataDir(async (dir) => {
+    await buildIndex();
+    const initial = await exportBookmarks({ force: true });
+    assert.equal(initial.exported, 2);
+
+    await updateArticleContent([
+      {
+        id: '2042685676949270724',
+        articleTitle: 'How agents should use context',
+        articleText: 'The article body was added after the first markdown export.',
+        articleSite: 'X Articles',
+      },
+    ]);
+
+    const bookmarksDir = path.join(dir, 'md', 'bookmarks');
+    const files = await readdir(bookmarksDir);
+    const articleFile = files.find((file) => file.includes('danveloper'));
+    assert.ok(articleFile);
+    const articlePath = path.join(bookmarksDir, articleFile);
+    await utimes(articlePath, new Date('2020-01-01T00:00:00Z'), new Date('2020-01-01T00:00:00Z'));
+
+    const result = await exportBookmarks({ changed: true });
+    assert.equal(result.exported, 1);
+    assert.equal(result.skipped, 1);
+    assert.equal(result.total, 2);
+
+    const content = await readFile(articlePath, 'utf8');
+    assert.match(content, /## Article/);
+    assert.match(content, /The article body was added after the first markdown export/);
   }, fixtures);
 });


### PR DESCRIPTION
Summary:
- Add `ft md --changed` to rewrite only markdown files whose bookmark source data is newer than the exported file.
- Include `synced_at` and `enriched_at` in markdown export rows so article gap-fill updates can trigger targeted rewrites.
- Document the new command and cover the article enrichment rewrite path with a regression test.

Verification:
- `npm run build`
- `npm test` (295 passing)
- `git diff --check`