### PR TITLE
Bump version to 1.3.16

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fieldtheory",
-  "version": "1.3.15",
+  "version": "1.3.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fieldtheory",
-      "version": "1.3.15",
+      "version": "1.3.16",
       "license": "MIT",
       "dependencies": {
         "commander": "^14.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fieldtheory",
-  "version": "1.3.15",
+  "version": "1.3.16",
   "description": "Field Theory CLI. Self-custody for your X/Twitter bookmarks. Local sync, full-text search, classification, and terminal dashboards.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Summary:
- Bump package version from 1.3.15 to 1.3.16.
- Update package-lock metadata to match.

Why:
- 1.3.15 is already published on npm, so the current main branch cannot be published again without a new version.

Verification:
- `npm run build`
- `npm test` (295 passing)
- `git diff --check`
- `npm view fieldtheory version` -> 1.3.15