### PR TITLE
Add skip-profile-images media option

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ On first run, `ft sync` extracts your X session from your browser and downloads 
 | `ft sync --folder <name>` | Sync a single folder by name (exact or unambiguous prefix) |
 | `ft sync --classify` | Sync then classify new bookmarks with LLM |
 | `ft sync --media` | Sync bookmarks, then download X media assets locally (photos, video posters, capped videos) |
+| `ft sync --media --skip-profile-images` | Download post media without author profile images |
 | `ft sync --api` | Sync via OAuth API (cross-platform) |
 | `ft auth` | Set up OAuth for API-based sync (optional) |
 
@@ -97,6 +98,7 @@ On first run, `ft sync` extracts your X session from your browser and downloads 
 |---------|-------------|
 | `ft index` | Rebuild search index from JSONL cache (preserves classifications) |
 | `ft fetch-media` | Backfill/download X media assets for existing bookmarks (default: all pending bookmarks) |
+| `ft fetch-media --skip-profile-images` | Download post media without author profile images |
 | `ft status` | Show sync/classification status and data location |
 | `ft path` | Print data directory path |
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fieldtheory",
-  "version": "1.3.16",
+  "version": "1.3.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fieldtheory",
-      "version": "1.3.16",
+      "version": "1.3.17",
       "license": "MIT",
       "dependencies": {
         "commander": "^14.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fieldtheory",
-  "version": "1.3.16",
+  "version": "1.3.17",
   "description": "Field Theory CLI. Self-custody for your X/Twitter bookmarks. Local sync, full-text search, classification, and terminal dashboards.",
   "type": "module",
   "bin": {

--- a/src/bookmark-media.ts
+++ b/src/bookmark-media.ts
@@ -132,6 +132,7 @@ function appendMediaTargets(
   bookmarkId: string,
   source: MediaTargetSource,
   downloadedProfileImageUrls: Set<string>,
+  skipProfileImages: boolean,
 ): void {
   const base = {
     bookmarkId,
@@ -160,7 +161,7 @@ function appendMediaTargets(
     }
   }
 
-  if (source.authorProfileImageUrl) {
+  if (source.authorProfileImageUrl && !skipProfileImages) {
     const fullUrl = source.authorProfileImageUrl.replace('_normal.', '_400x400.');
     if (!downloadedProfileImageUrls.has(fullUrl)) {
       pushTarget(targets, seenKeys, base, fullUrl, true);
@@ -171,6 +172,7 @@ function appendMediaTargets(
 function resolveMediaTargets(
   bookmark: BookmarkRecord,
   downloadedProfileImageUrls: Set<string>,
+  skipProfileImages: boolean,
 ): MediaFetchTarget[] {
   const targets: MediaFetchTarget[] = [];
   const seenKeys = new Set<string>();
@@ -183,7 +185,7 @@ function resolveMediaTargets(
     authorProfileImageUrl: bookmark.authorProfileImageUrl,
     media: bookmark.media,
     mediaObjects: bookmark.mediaObjects,
-  }, downloadedProfileImageUrls);
+  }, downloadedProfileImageUrls, skipProfileImages);
 
   if (bookmark.quotedTweet) {
     appendMediaTargets(targets, seenKeys, bookmark.id, {
@@ -194,7 +196,7 @@ function resolveMediaTargets(
       authorProfileImageUrl: bookmark.quotedTweet.authorProfileImageUrl,
       media: bookmark.quotedTweet.media,
       mediaObjects: bookmark.quotedTweet.mediaObjects,
-    }, downloadedProfileImageUrls);
+    }, downloadedProfileImageUrls, skipProfileImages);
   }
 
   return targets;
@@ -228,20 +230,22 @@ function hasPendingMediaTarget(
   bookmark: BookmarkRecord,
   coveredAssetKeys: Set<string>,
   coveredProfileImageUrls: Set<string>,
+  skipProfileImages: boolean,
 ): boolean {
-  return resolveMediaTargets(bookmark, coveredProfileImageUrls).some(({ tweetId, sourceUrl, isProfileImage }) => {
+  return resolveMediaTargets(bookmark, coveredProfileImageUrls, skipProfileImages).some(({ tweetId, sourceUrl, isProfileImage }) => {
     if (isProfileImage) return true;
     return !coveredAssetKeys.has(`${tweetId}::${sourceUrl}`);
   });
 }
 
 export async function fetchBookmarkMediaBatch(
-  options: { limit?: number; maxBytes?: number; onProgress?: (progress: MediaFetchProgress) => void } = {}
+  options: { limit?: number; maxBytes?: number; skipProfileImages?: boolean; onProgress?: (progress: MediaFetchProgress) => void } = {}
 ): Promise<MediaFetchManifest> {
   const limit = typeof options.limit === 'number' && !Number.isNaN(options.limit)
     ? Math.max(0, options.limit)
     : Infinity;
   const maxBytes = options.maxBytes ?? DEFAULT_MEDIA_MAX_BYTES;
+  const skipProfileImages = options.skipProfileImages ?? false;
   const mediaDir = bookmarkMediaDir();
   const manifestPath = bookmarkMediaManifestPath();
   await ensureDir(mediaDir);
@@ -252,7 +256,7 @@ export async function fetchBookmarkMediaBatch(
   const bookmarks = await readJsonLines<BookmarkRecord>(twitterBookmarksCachePath());
   const candidates = bookmarks
     .filter(hasMediaCandidate)
-    .filter((bookmark) => hasPendingMediaTarget(bookmark, coveredAssetKeys, coveredProfileImageUrls))
+    .filter((bookmark) => hasPendingMediaTarget(bookmark, coveredAssetKeys, coveredProfileImageUrls, skipProfileImages))
     .slice(0, limit);
   const entriesByKey = new Map((previous?.entries ?? []).map((entry) => [mediaEntryKeyFromEntry(entry), entry]));
   const cachedResultsBySourceUrl = new Map<string, CachedMediaResult>();
@@ -314,7 +318,7 @@ export async function fetchBookmarkMediaBatch(
   emitProgress();
 
   for (const bookmark of candidates) {
-    const mediaTargets = resolveMediaTargets(bookmark, coveredProfileImageUrls);
+    const mediaTargets = resolveMediaTargets(bookmark, coveredProfileImageUrls, skipProfileImages);
 
     for (const target of mediaTargets) {
       const { bookmarkId, tweetId, tweetUrl, authorHandle, authorName, sourceUrl, isProfileImage } = target;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -128,7 +128,7 @@ function printMediaFetchSummary(result: MediaFetchManifest): void {
   console.log(`  ✓ Manifest: ${bookmarkMediaManifestPath()}`);
 }
 
-async function runMediaFetchWithProgress(options: { limit?: number; maxBytes?: number } = {}): Promise<MediaFetchManifest> {
+async function runMediaFetchWithProgress(options: { limit?: number; maxBytes?: number; skipProfileImages?: boolean } = {}): Promise<MediaFetchManifest> {
   const startTime = Date.now();
   let lastMedia: MediaFetchProgress = {
     candidateBookmarks: 0,
@@ -144,6 +144,7 @@ async function runMediaFetchWithProgress(options: { limit?: number; maxBytes?: n
   const result = await runWithSpinner(spinner, () => fetchBookmarkMediaBatch({
     limit: options.limit,
     maxBytes: options.maxBytes,
+    skipProfileImages: options.skipProfileImages,
     onProgress: (progress: MediaFetchProgress) => {
       lastMedia = progress;
       spinner.update();
@@ -559,6 +560,7 @@ export function buildCli() {
     .option('--classify', 'Classify new bookmarks with LLM after syncing', false)
     .option('--media', 'Also download media assets for bookmarks after syncing', false)
     .option('--media-max-bytes <n>', 'Per-asset byte limit for --media (default: 200 MB)', (v: string) => Number(v), DEFAULT_MEDIA_MAX_BYTES)
+    .option('--skip-profile-images', 'Skip downloading author profile images (only applies with --media)', false)
     .option('--max-pages <n>', 'Max pages to fetch (default: unlimited)', (v: string) => Number(v))
     .option('--target-adds <n>', 'Stop after N new bookmarks', (v: string) => Number(v))
     .option('--delay-ms <n>', 'Delay between requests in ms', (v: string) => Number(v), 600)
@@ -725,7 +727,7 @@ export function buildCli() {
           console.log(`  \u2713 Data: ${dataDir()}\n`);
           warnIfEmpty(result.totalBookmarks);
           if (options.media) {
-            await runMediaFetchWithProgress({ maxBytes: mediaMaxBytes });
+            await runMediaFetchWithProgress({ maxBytes: mediaMaxBytes, skipProfileImages: Boolean(options.skipProfileImages) });
             console.log('');
           }
           const newCount = await rebuildIndex();
@@ -867,7 +869,7 @@ export function buildCli() {
           }
 
           if (options.media) {
-            await runMediaFetchWithProgress({ maxBytes: mediaMaxBytes });
+            await runMediaFetchWithProgress({ maxBytes: mediaMaxBytes, skipProfileImages: Boolean(options.skipProfileImages) });
             console.log('');
           }
 
@@ -1324,6 +1326,7 @@ export function buildCli() {
     .description('Download media assets for bookmarks')
     .option('--limit <n>', 'Max pending bookmarks to process (default: all)', (v: string) => Number(v))
     .option('--max-bytes <n>', 'Per-asset byte limit (default: 200 MB)', (v: string) => Number(v), DEFAULT_MEDIA_MAX_BYTES)
+    .option('--skip-profile-images', 'Skip downloading author profile images')
     .action(safe(async (options) => {
       if (!requireData()) return;
       await runMediaFetchWithProgress({
@@ -1331,6 +1334,7 @@ export function buildCli() {
         maxBytes: typeof options.maxBytes === 'number' && !Number.isNaN(options.maxBytes)
           ? options.maxBytes
           : DEFAULT_MEDIA_MAX_BYTES,
+        skipProfileImages: Boolean(options.skipProfileImages),
       });
     }));
 

--- a/tests/bookmark-media.test.ts
+++ b/tests/bookmark-media.test.ts
@@ -599,3 +599,107 @@ test('fetchBookmarkMediaBatch does not retry the same failing asset twice in one
     globalThis.fetch = originalFetch;
   }
 });
+
+test('fetchBookmarkMediaBatch with skipProfileImages skips profile images but downloads post media', async () => {
+  const photoUrl = 'https://pbs.twimg.com/media/skip-pfp-photo.jpg';
+  const quotedPhotoUrl = 'https://pbs.twimg.com/media/skip-pfp-quoted-photo.jpg';
+  const profileUrl = 'https://pbs.twimg.com/profile_images/123/avatar_normal.jpg';
+  const quotedProfileUrl = 'https://pbs.twimg.com/profile_images/456/quoted_normal.jpg';
+  const records = [{
+    id: '1',
+    tweetId: '1',
+    url: 'https://x.com/alice/status/1',
+    text: 'skip pfp test',
+    authorHandle: 'alice',
+    authorName: 'Alice',
+    authorProfileImageUrl: profileUrl,
+    syncedAt: '2026-04-09T00:00:00.000Z',
+    mediaObjects: [{ type: 'photo', url: photoUrl }],
+    quotedTweet: {
+      id: '99',
+      url: 'https://x.com/bob/status/99',
+      text: 'quoted',
+      authorHandle: 'bob',
+      authorName: 'Bob',
+      authorProfileImageUrl: quotedProfileUrl,
+      mediaObjects: [{ type: 'photo', url: quotedPhotoUrl }],
+    },
+    links: [],
+    tags: [],
+    ingestedVia: 'graphql',
+  }];
+
+  const fetchedUrls: string[] = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+    const url = String(input instanceof Request ? input.url : input);
+    const method = init?.method ?? 'GET';
+    if (method === 'HEAD') {
+      return new Response(null, {
+        status: 200,
+        headers: { 'content-length': '4', 'content-type': 'image/jpeg' },
+      });
+    }
+    fetchedUrls.push(url);
+    return new Response(Uint8Array.from([1, 2, 3, 4]), {
+      status: 200,
+      headers: { 'content-type': 'image/jpeg' },
+    });
+  };
+
+  try {
+    await withMediaDataDir(records, async () => {
+      const manifest = await fetchBookmarkMediaBatch({ limit: 10, maxBytes: 1024, skipProfileImages: true });
+
+      assert.equal(manifest.entries.filter((e) => e.sourceUrl.includes('/profile_images/')).length, 0);
+      assert.ok(!fetchedUrls.some((u) => u.includes('/profile_images/')));
+
+      const downloaded = manifest.entries
+        .filter((e) => e.status === 'downloaded')
+        .map((e) => e.sourceUrl)
+        .sort();
+      assert.deepEqual(downloaded, [photoUrl, quotedPhotoUrl].sort());
+    });
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('fetchBookmarkMediaBatch with skipProfileImages excludes pfp-only bookmarks from candidates', async () => {
+  const profileUrl = 'https://pbs.twimg.com/profile_images/123/pfp-only_normal.jpg';
+  const records = [{
+    id: '1',
+    tweetId: '1',
+    url: 'https://x.com/alice/status/1',
+    text: 'pfp only bookmark',
+    authorHandle: 'alice',
+    authorName: 'Alice',
+    authorProfileImageUrl: profileUrl,
+    syncedAt: '2026-04-09T00:00:00.000Z',
+    mediaObjects: [],
+    links: [],
+    tags: [],
+    ingestedVia: 'graphql',
+  }];
+
+  let fetchCalled = false;
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (): Promise<Response> => {
+    fetchCalled = true;
+    return new Response(Uint8Array.from([1, 2, 3, 4]), {
+      status: 200,
+      headers: { 'content-type': 'image/jpeg' },
+    });
+  };
+
+  try {
+    await withMediaDataDir(records, async () => {
+      const manifest = await fetchBookmarkMediaBatch({ limit: 10, maxBytes: 1024, skipProfileImages: true });
+      assert.equal(manifest.downloaded, 0);
+      assert.equal(manifest.processed, 0);
+      assert.equal(fetchCalled, false);
+    });
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});


### PR DESCRIPTION
Summary:
- Cherry-pick Sid Sethi's `--skip-profile-images` media option from #123, preserving default media behavior.
- Add README rows for `ft fetch-media --skip-profile-images` and `ft sync --media --skip-profile-images`.
- Bump package metadata to 1.3.17 for npm publishability.

Verification:
- `npm run build`
- `npm test` (297 passing)
- `git diff --check`
- `npm view fieldtheory version` -> 1.3.16