### PR TITLE
feat: expose bookmark IDs in search results and improve sync messages

### DIFF
--- a/src/bookmarks-db.ts
+++ b/src/bookmarks-db.ts
@@ -1231,7 +1231,8 @@ export function formatSearchResults(results: SearchResult[]): string {
       const author = r.authorHandle ? `@${r.authorHandle}` : 'unknown';
       const date = r.postedAt ? r.postedAt.slice(0, 10) : '?';
       const text = r.text.length > 140 ? r.text.slice(0, 140) + '...' : r.text;
-      return `${i + 1}. [${date}] ${author}\n   ${text}\n   ${r.url}`;
+      const id = r.id;
+      return `${i + 1}. [${date}] ${author} (ID: ${id})\n   ${text}\n   ${r.url}`;
     })
     .join('\n\n');
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -102,8 +102,13 @@ const FRIENDLY_STOP_REASONS: Record<string, string> = {
   'target additions reached': 'Reached target bookmark count.',
 };
 
-function friendlyStopReason(raw?: string): string {
+function friendlyStopReason(raw?: string, addedCount: number = 0): string {
   if (!raw) return 'Sync complete.';
+  if (raw === 'caught up to newest stored bookmark') {
+    return addedCount > 0
+      ? 'Sync complete \u2014 caught up to previously stored bookmarks.'
+      : 'All caught up \u2014 no new bookmarks since last sync.';
+  }
   return FRIENDLY_STOP_REASONS[raw] ?? `Sync complete \u2014 ${raw}`;
 }
 
@@ -819,7 +824,7 @@ export function buildCli() {
           }));
 
           console.log(`\n  \u2713 ${result.added} new bookmarks synced (${result.totalBookmarks} total)`);
-          console.log(`  ${friendlyStopReason(result.stopReason)}`);
+          console.log(`  ${friendlyStopReason(result.stopReason, result.added)}`);
           if (result.stopReason === 'rate limited') {
             const retryAfter = formatRetryAfter(result.retryAfterSec);
             if (retryAfter) {

--- a/tests/bookmarks-db.test.ts
+++ b/tests/bookmarks-db.test.ts
@@ -273,13 +273,14 @@ test('getStats returns chronological date range for legacy Twitter timestamps', 
   }, fixtures);
 });
 
-test('formatSearchResults: formats results with author, date, text, url', () => {
+test('formatSearchResults: formats results with author, date, ID, text, url', () => {
   const results = [
-    { id: '1', url: 'https://x.com/test/status/1', text: 'Hello world', authorHandle: 'test', authorName: 'Test', postedAt: '2026-01-15T00:00:00Z', score: -1.5 },
+    { id: '2040535589771149379', url: 'https://x.com/test/status/1', text: 'Hello world', authorHandle: 'test', authorName: 'Test', postedAt: '2026-01-15T00:00:00Z', score: -1.5 },
   ];
   const formatted = formatSearchResults(results);
   assert.ok(formatted.includes('@test'));
   assert.ok(formatted.includes('2026-01-15'));
+  assert.ok(formatted.includes('(ID: 2040535589771149379)'));
   assert.ok(formatted.includes('Hello world'));
   assert.ok(formatted.includes('https://x.com/test/status/1'));
 });


### PR DESCRIPTION
### Description
This PR addresses two minor UX friction points to make the CLI feel a bit more polished and composable for daily use.

1. **Expose IDs in Search**: When running `ft search`, the output now includes `(ID: <id>)` in the result header. This saves users from having to manually extract the ID from the URL if they want to immediately run `ft show <id>` or `ft show <id> --open`.
2. **Context-Aware Sync Messages**: The generic "caught up to newest stored bookmark" stop reason has been split into two friendlier variants depending on whether new bookmarks were actually fetched or if the cache was already up to date.

### Testing
- Updated `formatSearchResults` unit test to assert the presence of the `(ID: ...)` substring.
