### PR TITLE
fix: preserve gap-filled metadata when merging sparse incoming records

### DIFF
--- a/src/graphql-bookmarks.ts
+++ b/src/graphql-bookmarks.ts
@@ -486,9 +486,34 @@ export function scoreRecord(record: BookmarkRecord): number {
 
 export function mergeBookmarkRecord(existing: BookmarkRecord | undefined, incoming: BookmarkRecord): BookmarkRecord {
   if (!existing) return incoming;
-  return scoreRecord(incoming) >= scoreRecord(existing)
+  
+  const base = scoreRecord(incoming) >= scoreRecord(existing)
     ? { ...existing, ...incoming }
     : { ...incoming, ...existing };
+
+  // Explicitly preserve hard-earned gap-fill data if the incoming payload dropped it.
+  if (existing.quotedStatusId && !incoming.quotedStatusId) {
+    base.quotedStatusId = existing.quotedStatusId;
+    base.quotedTweet = existing.quotedTweet;
+    base.quotedTweetFailedAt = existing.quotedTweetFailedAt;
+  }
+  if (existing.textExpandedAt && !incoming.textExpandedAt) {
+    base.textExpandedAt = existing.textExpandedAt;
+    // Don't regress to truncated text
+    if (existing.text.length > incoming.text.length) {
+      base.text = existing.text;
+    }
+  }
+  if (existing.articleText && !incoming.articleText) {
+    base.articleText = existing.articleText;
+    base.articleTitle = existing.articleTitle;
+    base.articleSite = existing.articleSite;
+  }
+  if (existing.enrichedAt && !incoming.enrichedAt) {
+    base.enrichedAt = existing.enrichedAt;
+  }
+
+  return base;
 }
 
 export function mergeRecords(

--- a/tests/graphql-bookmarks.test.ts
+++ b/tests/graphql-bookmarks.test.ts
@@ -1153,6 +1153,25 @@ test('mergeBookmarkRecord: sparser incoming does not clobber richer existing', (
   assert.ok(result.author);
 });
 
+test('mergeBookmarkRecord: sparser incoming does not clobber existing quoted tweet data', () => {
+  const existing = makeRecord({
+    text: 'Check this out',
+    quotedStatusId: '555',
+    quotedTweet: { id: '555', text: 'Original tweet' } as any
+  });
+  const incoming = makeRecord({ 
+    text: 'Check this out',
+    quotedStatusId: undefined, // X sometimes drops this in subsequent fetches
+    quotedTweet: undefined
+  });
+  
+  // We expect the merge to PRESERVE the quoted data because the existing is "richer"
+  // or at least because we shouldn't lose hard-earned backfill data.
+  const result = mergeBookmarkRecord(existing, incoming);
+  assert.equal(result.quotedStatusId, '555');
+  assert.ok(result.quotedTweet);
+});
+
 test('mergeBookmarkRecord: equal scores prefer incoming (>=)', () => {
   const existing = makeRecord({ text: 'Old', postedAt: '2026-01-01' });
   const incoming = makeRecord({ text: 'New', postedAt: '2026-02-01' });


### PR DESCRIPTION
### Description
This PR fixes a critical data-loss regression in `mergeBookmarkRecord` where expensive gap-filled data (quoted tweets, expanded text, and article content) would be silently deleted from the local database during subsequent syncs.

### The Problem
When `ft sync --gaps` or article enrichment successfully fetches a missing quoted tweet or expands truncated text, it saves that rich data into the local JSONL cache.
However, when a user later runs a standard `ft sync`, the incoming GraphQL payload from X is often "sparse" (e.g., missing the quoted status ID). Because the new `scoreRecord` logic often ranks the fresh incoming record higher (e.g., due to updated engagement stats), the incoming sparse record completely overwrote the existing local record, throwing away all the hard-earned `--gaps` data.

### The Fix
Updated `mergeBookmarkRecord` to explicitly check for and preserve these expensive fields (`quotedTweet`, `textExpandedAt`, `articleText`, etc.) from the existing local record if the incoming payload drops them.

### Testing
- Added `mergeBookmarkRecord: sparser incoming does not clobber existing quoted tweet data` to assert that quoted data survives a merge with a sparse incoming record.
