### PR TITLE
feat: render quoted tweets in ft show

### DIFF
--- a/src/bookmarks-db.ts
+++ b/src/bookmarks-db.ts
@@ -59,6 +59,8 @@ export interface BookmarkTimelineItem {
   viewCount?: number | null;
   folderIds: string[];
   folderNames: string[];
+  quotedStatusId?: string | null;
+  quotedTweet?: any | null;
 }
 
 export interface BookmarkTimelineFilters {
@@ -155,6 +157,8 @@ function mapTimelineRow(row: unknown[]): BookmarkTimelineItem {
     articleSite: (row[27] as string) ?? null,
     syncedAt: (row[28] as string) ?? null,
     enrichedAt: (row[29] as string) ?? null,
+    quotedStatusId: (row[30] as string) ?? null,
+    quotedTweet: row[31] ? JSON.parse(row[31] as string) : null,
   };
 }
 
@@ -646,7 +650,9 @@ export async function listBookmarks(
         b.article_text,
         b.article_site,
         b.synced_at,
-        b.enriched_at
+        b.enriched_at,
+        b.quoted_status_id,
+        b.quoted_tweet_json
       FROM bookmarks b
       ${where}
       ${bookmarkSortClause(filters.sort)}
@@ -792,7 +798,9 @@ export async function getBookmarkById(id: string): Promise<BookmarkTimelineItem 
         b.article_text,
         b.article_site,
         b.synced_at,
-        b.enriched_at
+        b.enriched_at,
+        b.quoted_status_id,
+        b.quoted_tweet_json
       FROM bookmarks b
       WHERE b.id = ?
       LIMIT 1`,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1028,8 +1028,15 @@ export function buildCli() {
       console.log(`${item.id} \u00b7 ${item.authorHandle ? `@${item.authorHandle}` : '@?'}`);
       console.log(item.url);
       console.log(item.text);
-      if (item.links.length) console.log(`links: ${item.links.join(', ')}`);
-      if (item.categories) console.log(`categories: ${item.categories}`);
+      
+      if (item.quotedTweet) {
+        console.log(`\n  \u250c\u2500 Quoted: @${item.quotedTweet.authorHandle}`);
+        console.log(`  \u2502 ${item.quotedTweet.text.split('\n').join('\n  \u2502 ')}`);
+        console.log(`  \u2514\u2500 ${item.quotedTweet.url ?? `https://x.com/i/status/${item.quotedTweet.id}`}`);
+      }
+      
+      if (item.links.length) console.log(`\nlinks: ${item.links.join(', ')}`);
+      if (item.categories.length) console.log(`categories: ${item.categories.join(', ')}`);
       if (item.domains) console.log(`domains: ${item.domains}`);
     }));
 


### PR DESCRIPTION
### Description
This PR updates the `ft show <id>` command to properly hydrate and render the contents of a quoted tweet if one is attached to the bookmark. 

Previously, `ft sync --gaps` did the hard work of fetching missing quoted tweets and saving them to the JSONL cache, but they were never extracted back out of the SQLite index or rendered to the user.

### The Fix
1. **Database Hydration**: Updated `getBookmarkById` and `listBookmarks` in `src/bookmarks-db.ts` to `SELECT` the `quoted_status_id` and `quoted_tweet_json` columns.
2. **Parsing**: Updated `mapTimelineRow` to parse the JSON blob into the `quotedTweet` object on the `BookmarkTimelineItem` interface.
3. **CLI Rendering**: Updated `ft show` to detect the presence of `item.quotedTweet` and render it cleanly in an ASCII-styled box beneath the main tweet text.
