### PR TITLE
Fix quoted tweet preservation and continue sync

### DIFF
--- a/src/bookmarks-db.ts
+++ b/src/bookmarks-db.ts
@@ -49,6 +49,8 @@ export interface BookmarkTimelineItem {
   articleText?: string | null;
   articleSite?: string | null;
   enrichedAt?: string | null;
+  quotedStatusId?: string | null;
+  quotedTweet?: QuotedTweetSnapshot | null;
   mediaCount: number;
   linkCount: number;
   likeCount?: number | null;
@@ -87,6 +89,18 @@ function parseJsonArray(value: unknown): string[] {
     return Array.isArray(parsed) ? parsed.filter((entry): entry is string => typeof entry === 'string') : [];
   } catch {
     return [];
+  }
+}
+
+function parseQuotedTweet(value: unknown): QuotedTweetSnapshot | null {
+  if (typeof value !== 'string' || !value.trim()) return null;
+  try {
+    const parsed = JSON.parse(value) as Partial<QuotedTweetSnapshot>;
+    if (!parsed || typeof parsed !== 'object') return null;
+    if (typeof parsed.id !== 'string' || typeof parsed.text !== 'string' || typeof parsed.url !== 'string') return null;
+    return parsed as QuotedTweetSnapshot;
+  } catch {
+    return null;
   }
 }
 
@@ -155,6 +169,8 @@ function mapTimelineRow(row: unknown[]): BookmarkTimelineItem {
     articleSite: (row[27] as string) ?? null,
     syncedAt: (row[28] as string) ?? null,
     enrichedAt: (row[29] as string) ?? null,
+    quotedStatusId: (row[30] as string) ?? null,
+    quotedTweet: parseQuotedTweet(row[31]),
   };
 }
 
@@ -646,7 +662,9 @@ export async function listBookmarks(
         b.article_text,
         b.article_site,
         b.synced_at,
-        b.enriched_at
+        b.enriched_at,
+        b.quoted_status_id,
+        b.quoted_tweet_json
       FROM bookmarks b
       ${where}
       ${bookmarkSortClause(filters.sort)}
@@ -792,7 +810,9 @@ export async function getBookmarkById(id: string): Promise<BookmarkTimelineItem 
         b.article_text,
         b.article_site,
         b.synced_at,
-        b.enriched_at
+        b.enriched_at,
+        b.quoted_status_id,
+        b.quoted_tweet_json
       FROM bookmarks b
       WHERE b.id = ?
       LIMIT 1`,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,7 +5,7 @@ import { getBookmarkStatusView, formatBookmarkStatus } from './bookmarks-service
 import { runTwitterOAuthFlow } from './xauth.js';
 import { syncBookmarksGraphQL, syncGaps, syncBookmarkFolders } from './graphql-bookmarks.js';
 import type { SyncProgress, GapFillProgress, FolderSyncProgress } from './graphql-bookmarks.js';
-import type { BookmarkFolder } from './types.js';
+import type { BookmarkFolder, QuotedTweetSnapshot } from './types.js';
 import { DEFAULT_MEDIA_MAX_BYTES, fetchBookmarkMediaBatch } from './bookmark-media.js';
 import type { MediaFetchManifest, MediaFetchProgress } from './bookmark-media.js';
 import {
@@ -462,6 +462,19 @@ export function sanitizeForDisplay(value: string): string {
   return value.replace(/[\x00-\x1f\x7f-\x9f]/g, '?');
 }
 
+function formatQuotedTweetLines(quoted: QuotedTweetSnapshot): string[] {
+  const author = quoted.authorHandle ? `@${quoted.authorHandle}` : (quoted.authorName ?? 'quoted tweet');
+  const date = quoted.postedAt ? ` · ${quoted.postedAt.slice(0, 10)}` : '';
+  const text = quoted.text.split(/\r?\n/).map((line) => `  | ${sanitizeForDisplay(line)}`);
+  return [
+    '',
+    'quoted tweet',
+    `  | ${sanitizeForDisplay(author)}${date}`,
+    ...text,
+    `  | ${quoted.url}`,
+  ];
+}
+
 export function formatFolderMirrorStats(stats: { added: number; tagged: number; untagged: number; unchanged: number }): string {
   const parts: string[] = [];
   if (stats.added > 0) parts.push(`${stats.added} new`);
@@ -774,16 +787,15 @@ export function buildCli() {
             }
           }
 
-          // When continuing without a cursor, disable stale page limit so we can
-          // page through all existing bookmarks to reach the ones beyond the old cap.
-          // With a saved cursor we skip straight to where we left off, so the normal
-          // stale limit is fine.
+          // When continuing without a cursor, give the scan enough runway to
+          // pass small local gaps, but still stop if every fetched page is old.
           const continueWithoutCursor = Boolean(options.continue) && !resumeCursor;
 
           const result = await runWithSpinner(spinner, () => syncBookmarksGraphQL({
             incremental: !Boolean(options.rebuild) && !Boolean(options.continue),
             resumeCursor,
-            stalePageLimit: continueWithoutCursor ? Infinity : undefined,
+            stalePageLimit: continueWithoutCursor ? 20 : undefined,
+            staleWhenNoNewRecords: continueWithoutCursor,
             maxPages: options.maxPages != null ? Number(options.maxPages) : undefined,
             targetAdds: typeof options.targetAdds === 'number' && !Number.isNaN(options.targetAdds) ? options.targetAdds : undefined,
             delayMs: Number(options.delayMs) || 600,
@@ -1028,6 +1040,9 @@ export function buildCli() {
       console.log(`${item.id} \u00b7 ${item.authorHandle ? `@${item.authorHandle}` : '@?'}`);
       console.log(item.url);
       console.log(item.text);
+      if (item.quotedTweet) {
+        console.log(formatQuotedTweetLines(item.quotedTweet).join('\n'));
+      }
       if (item.links.length) console.log(`links: ${item.links.join(', ')}`);
       if (item.categories) console.log(`categories: ${item.categories}`);
       if (item.domains) console.log(`domains: ${item.domains}`);

--- a/src/graphql-bookmarks.ts
+++ b/src/graphql-bookmarks.ts
@@ -74,6 +74,8 @@ export interface SyncOptions {
   maxMinutes?: number;
   /** Consecutive pages with 0 new bookmarks before stopping. Default: 3 */
   stalePageLimit?: number;
+  /** Count old pages as stale when they add no new local records. */
+  staleWhenNoNewRecords?: boolean;
   /** Bookmarks per page (1–100). Default: 20 */
   pageSize?: number;
   /** Browser id (e.g. 'chrome', 'firefox', 'brave'). */
@@ -486,9 +488,48 @@ export function scoreRecord(record: BookmarkRecord): number {
 
 export function mergeBookmarkRecord(existing: BookmarkRecord | undefined, incoming: BookmarkRecord): BookmarkRecord {
   if (!existing) return incoming;
-  return scoreRecord(incoming) >= scoreRecord(existing)
+  const merged = scoreRecord(incoming) >= scoreRecord(existing)
     ? { ...existing, ...incoming }
     : { ...incoming, ...existing };
+
+  if (existing.quotedStatusId && !incoming.quotedStatusId) {
+    merged.quotedStatusId = existing.quotedStatusId;
+  }
+  if (incoming.quotedStatusId && incoming.quotedStatusId !== existing.quotedStatusId && !incoming.quotedTweet) {
+    delete merged.quotedTweet;
+  }
+  if (
+    existing.quotedTweet &&
+    !incoming.quotedTweet &&
+    (!incoming.quotedStatusId || incoming.quotedStatusId === existing.quotedStatusId)
+  ) {
+    merged.quotedTweet = existing.quotedTweet;
+  }
+  if (existing.quotedTweetFailedAt && !incoming.quotedTweetFailedAt) {
+    merged.quotedTweetFailedAt = existing.quotedTweetFailedAt;
+  }
+  if (existing.textExpandedAt && !incoming.textExpandedAt) {
+    merged.textExpandedAt = existing.textExpandedAt;
+    if ((existing.text?.length ?? 0) > (incoming.text?.length ?? 0)) {
+      merged.text = existing.text;
+    }
+  }
+  if (existing.articleText && !incoming.articleText) {
+    merged.articleTitle = existing.articleTitle;
+    merged.articleText = existing.articleText;
+    merged.articleSite = existing.articleSite;
+  }
+  if (existing.enrichedAt && !incoming.enrichedAt) {
+    merged.enrichedAt = existing.enrichedAt;
+  }
+  if ((existing.mediaObjects?.length ?? 0) > 0 && (incoming.mediaObjects?.length ?? 0) === 0) {
+    merged.mediaObjects = existing.mediaObjects;
+  }
+  if ((existing.media?.length ?? 0) > 0 && (incoming.media?.length ?? 0) === 0) {
+    merged.media = existing.media;
+  }
+
+  return merged;
 }
 
 export function mergeRecords(
@@ -629,7 +670,11 @@ export async function syncBookmarksGraphQL(
     result.records.forEach((r) => allSeenIds.push(r.id));
     const reachedLatestStored = Boolean(newestKnownId) && result.records.some((record) => record.id === newestKnownId);
 
-    stalePages = (incremental ? added === 0 : result.records.length === 0) ? stalePages + 1 : 0;
+    const noNewLocalRecords = added === 0;
+    const noRemoteRecords = result.records.length === 0;
+    stalePages = (incremental || options.staleWhenNoNewRecords ? noNewLocalRecords : noRemoteRecords)
+      ? stalePages + 1
+      : 0;
 
     options.onProgress?.({
       page,

--- a/src/types.ts
+++ b/src/types.ts
@@ -71,6 +71,10 @@ export interface BookmarkRecord {
   inReplyToUserId?: string;
   quotedStatusId?: string;
   quotedTweet?: QuotedTweetSnapshot;
+  articleTitle?: string | null;
+  articleText?: string | null;
+  articleSite?: string | null;
+  enrichedAt?: string | null;
   language?: string;
   sourceApp?: string;
   possiblySensitive?: boolean;

--- a/tests/bookmarks-db.test.ts
+++ b/tests/bookmarks-db.test.ts
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 import { mkdtemp, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
-import { buildIndex, searchBookmarks, getStats, formatSearchResults, getBookmarkById, sanitizeFtsQuery, getCategoryCounts, sampleByCategory, getClassificationProgress } from '../src/bookmarks-db.js';
+import { buildIndex, searchBookmarks, getStats, formatSearchResults, getBookmarkById, listBookmarks, sanitizeFtsQuery, getCategoryCounts, sampleByCategory, getClassificationProgress } from '../src/bookmarks-db.js';
 import { openDb, saveDb } from '../src/db.js';
 import { twitterBookmarksIndexPath } from '../src/paths.js';
 
@@ -80,6 +80,32 @@ test('buildIndex refreshes existing rows without dropping classifications', asyn
     assert.equal(bookmark.primaryDomain, 'example.com');
     assert.deepEqual(bookmark.githubUrls, ['https://github.com/openai/test']);
   });
+});
+
+test('getBookmarkById and listBookmarks hydrate quoted tweets', async () => {
+  const fixtures = [{
+    ...FIXTURES[0],
+    quotedStatusId: '55',
+    quotedTweet: {
+      id: '55',
+      text: 'Quoted tweet body',
+      authorHandle: 'quoted',
+      postedAt: '2026-01-01T10:00:00.000Z',
+      url: 'https://x.com/quoted/status/55',
+    },
+  }];
+
+  await withIsolatedDataDir(async () => {
+    await buildIndex();
+
+    const byId = await getBookmarkById('1');
+    assert.equal(byId?.quotedStatusId, '55');
+    assert.equal(byId?.quotedTweet?.text, 'Quoted tweet body');
+
+    const listed = await listBookmarks({ limit: 1 });
+    assert.equal(listed[0]?.quotedStatusId, '55');
+    assert.equal(listed[0]?.quotedTweet?.authorHandle, 'quoted');
+  }, fixtures);
 });
 
 test('searchBookmarks: full-text search returns matching results', async () => {

--- a/tests/graphql-bookmarks.test.ts
+++ b/tests/graphql-bookmarks.test.ts
@@ -875,6 +875,48 @@ test('syncBookmarksGraphQL: rebuild mode does not treat merged-only pages as sta
   }, existing);
 });
 
+test('syncBookmarksGraphQL: continue scans stop when old pages add no local records', async () => {
+  const oldPage = makeGraphQLResponse([makeTweetResult()], 'cursor-2');
+  const existing = [
+    makeRecord({
+      id: '1234567890',
+      tweetId: '1234567890',
+      text: 'Existing bookmark',
+      postedAt: 'Tue Mar 10 12:00:00 +0000 2026',
+    }),
+  ];
+
+  await withIsolatedGapFillDataDir(async () => {
+    const originalFetch = globalThis.fetch;
+    let fetchCalls = 0;
+    globalThis.fetch = (async () => {
+      fetchCalls += 1;
+      return new Response(JSON.stringify(oldPage), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }) as typeof fetch;
+
+    try {
+      const result = await syncBookmarksGraphQL({
+        incremental: false,
+        csrfToken: 'ct0',
+        cookieHeader: 'ct0=ct0; auth_token=auth',
+        delayMs: 0,
+        stalePageLimit: 1,
+        staleWhenNoNewRecords: true,
+      });
+
+      assert.equal(fetchCalls, 1);
+      assert.equal(result.pages, 1);
+      assert.equal(result.added, 0);
+      assert.equal(result.stopReason, 'no new bookmarks (stale)');
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  }, existing);
+});
+
 test('syncBookmarksGraphQL: rate limit stops cleanly and saves cursor for continue', async () => {
   const page1 = makeGraphQLResponse([makeTweetResult()], 'cursor-2');
 
@@ -1151,6 +1193,49 @@ test('mergeBookmarkRecord: sparser incoming does not clobber richer existing', (
   const result = mergeBookmarkRecord(existing, incoming);
   assert.equal(result.text, 'Rich');
   assert.ok(result.author);
+});
+
+test('mergeBookmarkRecord: sparse incoming preserves expensive gap-filled fields', () => {
+  const existing = makeRecord({
+    text: 'Expanded text from gap fill with much more context',
+    quotedStatusId: '555',
+    quotedTweet: { id: '555', text: 'Quoted context', url: 'https://x.com/quoted/status/555' },
+    textExpandedAt: '2026-04-14T00:00:00.000Z',
+    articleTitle: 'Deep dive',
+    articleText: 'Article body fetched during gap fill',
+    articleSite: 'Example',
+    enrichedAt: '2026-04-14T00:00:00.000Z',
+    mediaObjects: [{ type: 'video', url: 'https://pbs.twimg.com/amplify_video_thumb/example.jpg' }],
+  });
+  const incoming = makeRecord({
+    text: 'Sparse',
+    engagement: { likeCount: 100 },
+  });
+
+  const result = mergeBookmarkRecord(existing, incoming);
+  assert.equal(result.quotedStatusId, '555');
+  assert.equal(result.quotedTweet?.text, 'Quoted context');
+  assert.equal(result.textExpandedAt, '2026-04-14T00:00:00.000Z');
+  assert.equal(result.text, existing.text);
+  assert.equal(result.articleText, existing.articleText);
+  assert.equal(result.enrichedAt, existing.enrichedAt);
+  assert.equal(result.mediaObjects?.[0]?.url, existing.mediaObjects?.[0]?.url);
+  assert.equal(result.engagement?.likeCount, 100);
+});
+
+test('mergeBookmarkRecord: changed quote id does not keep stale quoted tweet', () => {
+  const existing = makeRecord({
+    quotedStatusId: '555',
+    quotedTweet: { id: '555', text: 'Old quoted context', url: 'https://x.com/quoted/status/555' },
+  });
+  const incoming = makeRecord({
+    quotedStatusId: '777',
+    engagement: { likeCount: 100 },
+  });
+
+  const result = mergeBookmarkRecord(existing, incoming);
+  assert.equal(result.quotedStatusId, '777');
+  assert.equal(result.quotedTweet, undefined);
 });
 
 test('mergeBookmarkRecord: equal scores prefer incoming (>=)', () => {


### PR DESCRIPTION
## Summary

This takes the small bug-fix batch from the backlog review and keeps it maintainer-owned while crediting the contributor PRs that pointed at the problems.

- Preserve gap-filled data when later GraphQL sync payloads are sparse, including quoted tweets, expanded text, article enrichment, and media objects.
- Hydrate `quoted_status_id` / `quoted_tweet_json` through `getBookmarkById` and `listBookmarks`, then render quoted tweet context in `ft show`.
- Make `ft sync --continue` without a saved cursor stop after old pages add no local records instead of crawling indefinitely.

Fixes #129.
Fixes #131.
Fixes #133.

Supersedes the core fixes proposed in #128, #130, and #132. Thanks to @ccage-simp for the clear reports and draft implementations.

## Tests

- `npx tsx --test tests/graphql-bookmarks.test.ts tests/bookmarks-db.test.ts`
- `npm run build`
- `npm test`
