### PR TITLE
[codex] Add Field Theory companion CLI commands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,14 +13,14 @@ npm run start        # Run compiled dist/cli.js
 
 ## Architecture
 
-Single CLI application built with Commander.js. All data stored in `~/.ft-bookmarks/`.
+Single CLI application built with Commander.js. Bookmark data is stored in `~/.fieldtheory/bookmarks/`; markdown library output is stored in `~/.fieldtheory/library/`.
 
 ### Key files
 
 | File | Purpose |
 |------|---------|
 | `src/cli.ts` | Command definitions, progress bar, first-run UX |
-| `src/paths.ts` | Data directory resolution (`~/.ft-bookmarks/`) |
+| `src/paths.ts` | Data, library, and commands path resolution |
 | `src/graphql-bookmarks.ts` | GraphQL sync engine (Chrome session cookies) |
 | `src/bookmarks.ts` | OAuth API sync |
 | `src/bookmarks-db.ts` | SQLite FTS5 index, search, list, stats |

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ On first run, `ft sync` extracts your X session from your browser and downloads 
 | `ft commands list` | List portable commands under `~/.fieldtheory/commands` |
 | `ft commands new <name>` | Create a reusable portable command |
 | `ft commands validate [name]` | Check command shape and guardrails |
+| `ft install app` | Download and install the latest Field Theory Mac app from `afar1/field-releases` |
 
 `ft library open` targets the packaged Field Theory app by bundle id (`com.fieldtheory.app`) instead of trusting the system-wide `fieldtheory://` handler. That avoids accidentally opening a generic Electron development app when another checkout registered the same URL scheme.
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,22 @@ On first run, `ft sync` extracts your X session from your browser and downloads 
 | `ft lint` | Health-check the wiki for broken links and missing pages |
 | `ft lint --fix` | Auto-fix fixable wiki issues |
 
+### Field Theory app companion
+
+| Command | Description |
+|---------|-------------|
+| `ft paths --json` | Show canonical bookmarks, Library, Commands, and compatibility paths |
+| `ft status --json` | Show bookmark/classification status plus Field Theory paths |
+| `ft library search <query>` | Search local Field Theory Library markdown |
+| `ft library show <path>` | Print a Library page and its version metadata with `--json` |
+| `ft library create <path> --stdin` | Create a new Library page under `~/.fieldtheory/library` |
+| `ft library update <path> --stdin --expected-sha256 <hash>` | Replace a Library page with conflict protection |
+| `ft library delete <path>` | Move a Library page to Trash; the Mac app owns remote sync tombstones |
+| `ft library open <path>` | Open a Library page in the Field Theory Mac app |
+| `ft commands list` | List portable commands under `~/.fieldtheory/commands` |
+| `ft commands new <name>` | Create a reusable portable command |
+| `ft commands validate [name]` | Check command shape and guardrails |
+
 ### Agent integration
 
 | Command | Description |
@@ -145,16 +161,20 @@ Data is stored locally under `~/.fieldtheory/`:
 
 ~/.fieldtheory/library/
   index.md                # markdown knowledge base (ft wiki / ft md)
+
+~/.fieldtheory/commands/
+  *.md                    # portable commands used by Field Theory and agents
 ```
 
-Override locations with `FT_DATA_DIR` and `FT_LIBRARY_DIR`:
+Override locations with `FT_DATA_DIR`, `FT_LIBRARY_DIR`, and `FT_COMMANDS_DIR`:
 
 ```bash
 export FT_DATA_DIR=/path/to/custom/dir
 export FT_LIBRARY_DIR=/path/to/custom/library
+export FT_COMMANDS_DIR=/path/to/custom/commands
 ```
 
-To remove all data: `rm -rf ~/.fieldtheory/bookmarks ~/.fieldtheory/library`
+To remove bookmark and Library data: `rm -rf ~/.fieldtheory/bookmarks ~/.fieldtheory/library`
 
 ## Categories
 

--- a/README.md
+++ b/README.md
@@ -100,6 +100,17 @@ On first run, `ft sync` extracts your X session from your browser and downloads 
 | `ft commands new <name>` | Create a reusable portable command |
 | `ft commands validate [name]` | Check command shape and guardrails |
 
+`ft library open` targets the packaged Field Theory app by bundle id (`com.fieldtheory.app`) instead of trusting the system-wide `fieldtheory://` handler. That avoids accidentally opening a generic Electron development app when another checkout registered the same URL scheme.
+
+For local Field Theory app development, point the CLI at the dev checkout:
+
+```bash
+export FT_APP_DEV_DIR=/Users/you/dev/fieldtheory/mac-app
+ft library open notes/example.md
+```
+
+Packaged variants can override the bundle id with `FT_APP_BUNDLE_ID`. Advanced development launchers can set `FT_APP_OPEN_COMMAND` to an executable that receives the deep-link URL as its first argument.
+
 ### Agent integration
 
 | Command | Description |

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ ft categories
 ft stats
 ```
 
-On first run, `ft sync` extracts your X session from your browser and downloads your bookmarks into `~/.ft-bookmarks/`.
+On first run, `ft sync` extracts your X session from your browser and downloads your bookmarks into `~/.fieldtheory/bookmarks/`.
 
 ## Commands
 
@@ -134,24 +134,27 @@ Works with Claude Code, Codex, or any agent with shell access.
 
 ## Data
 
-All data is stored locally at `~/.ft-bookmarks/`:
+Data is stored locally under `~/.fieldtheory/`:
 
 ```
-~/.ft-bookmarks/
+~/.fieldtheory/bookmarks/
   bookmarks.jsonl         # raw bookmark cache (one per line)
   bookmarks.db            # SQLite FTS5 search index
   bookmarks-meta.json     # sync metadata
   oauth-token.json        # OAuth token (if using API mode, chmod 600)
-  md/                     # markdown knowledge base (ft wiki / ft md)
+
+~/.fieldtheory/library/
+  index.md                # markdown knowledge base (ft wiki / ft md)
 ```
 
-Override the location with `FT_DATA_DIR`:
+Override locations with `FT_DATA_DIR` and `FT_LIBRARY_DIR`:
 
 ```bash
 export FT_DATA_DIR=/path/to/custom/dir
+export FT_LIBRARY_DIR=/path/to/custom/library
 ```
 
-To remove all data: `rm -rf ~/.ft-bookmarks`
+To remove all data: `rm -rf ~/.fieldtheory/bookmarks ~/.fieldtheory/library`
 
 ## Categories
 
@@ -204,7 +207,7 @@ Session sync extracts cookies from your browser's local database. Use `ft sync -
 
 **Chrome session sync** reads cookies from Chrome's local database, uses them for the sync request, and discards them. Cookies are never stored separately.
 
-**OAuth tokens** are stored with `chmod 600` (owner-only). Treat `~/.ft-bookmarks/oauth-token.json` like a password.
+**OAuth tokens** are stored with `chmod 600` (owner-only). Treat `~/.fieldtheory/bookmarks/oauth-token.json` like a password.
 
 **The default sync uses X's internal GraphQL API**, the same API that x.com uses in your browser. For the official v2 API, use `ft auth` + `ft sync --api`.
 

--- a/src/app-install.ts
+++ b/src/app-install.ts
@@ -1,0 +1,203 @@
+import { execFile as execFileCb } from 'node:child_process';
+import { createWriteStream } from 'node:fs';
+import { access, mkdir, mkdtemp, readdir, rename, rm } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { Readable } from 'node:stream';
+import { pipeline } from 'node:stream/promises';
+import { promisify } from 'node:util';
+
+const DEFAULT_RELEASE_API_URL = 'https://api.github.com/repos/afar1/field-releases/releases/latest';
+const USER_AGENT = 'fieldtheory-cli';
+const DEFAULT_INSTALL_DIR = '/Applications';
+
+const execFile = promisify(execFileCb);
+
+type Fetcher = typeof fetch;
+type ExecFileRunner = (file: string, args: readonly string[]) => Promise<{ stdout: string; stderr: string }>;
+
+export interface FieldTheoryReleaseAsset {
+  name: string;
+  browser_download_url?: string;
+}
+
+export interface FieldTheoryRelease {
+  tag_name?: string;
+  name?: string;
+  assets?: FieldTheoryReleaseAsset[];
+}
+
+export interface FieldTheoryAppInstallOptions {
+  fetch?: Fetcher;
+  execFile?: ExecFileRunner;
+  installDir?: string;
+  open?: boolean;
+  platform?: NodeJS.Platform;
+  releaseApiUrl?: string;
+  env?: NodeJS.ProcessEnv;
+  onProgress?: (message: string) => void;
+}
+
+export interface FieldTheoryAppInstallResult {
+  appPath: string;
+  assetName: string;
+  release: string;
+  downloadUrl: string;
+}
+
+function assertOkResponse(response: Response, context: string): void {
+  if (!response.ok) {
+    throw new Error(`${context} failed: HTTP ${response.status} ${response.statusText}`);
+  }
+}
+
+function authHeaders(env: NodeJS.ProcessEnv): Record<string, string> {
+  const token = env.GITHUB_TOKEN ?? env.GH_TOKEN;
+  return token ? { Authorization: `Bearer ${token}` } : {};
+}
+
+export function selectFieldTheoryDmgAsset(release: FieldTheoryRelease): FieldTheoryReleaseAsset {
+  const assets = release.assets ?? [];
+  const dmgAssets = assets.filter((asset) =>
+    asset.browser_download_url && asset.name.toLowerCase().endsWith('.dmg')
+  );
+  const preferred = dmgAssets.find((asset) => /\barm64\b/i.test(asset.name)) ?? dmgAssets[0];
+  if (!preferred) {
+    const names = assets.map((asset) => asset.name).join(', ') || 'none';
+    throw new Error(`Latest Field Theory release has no downloadable DMG asset. Assets: ${names}`);
+  }
+  return preferred;
+}
+
+async function fetchLatestRelease(fetcher: Fetcher, releaseApiUrl: string, env: NodeJS.ProcessEnv): Promise<FieldTheoryRelease> {
+  const response = await fetcher(releaseApiUrl, {
+    headers: {
+      Accept: 'application/vnd.github+json',
+      'User-Agent': USER_AGENT,
+      ...authHeaders(env),
+    },
+  });
+  assertOkResponse(response, 'Fetching latest Field Theory release');
+  return await response.json() as FieldTheoryRelease;
+}
+
+async function downloadFile(fetcher: Fetcher, url: string, destination: string): Promise<void> {
+  const response = await fetcher(url, {
+    headers: { 'User-Agent': USER_AGENT },
+  });
+  assertOkResponse(response, 'Downloading Field Theory DMG');
+  if (!response.body) throw new Error('Downloading Field Theory DMG failed: empty response body');
+  await pipeline(Readable.fromWeb(response.body as any), createWriteStream(destination));
+}
+
+async function findAppBundle(dir: string): Promise<string> {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const direct = entries.find((entry) => entry.isDirectory() && entry.name.endsWith('.app'));
+  if (direct) return path.join(dir, direct.name);
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const nestedDir = path.join(dir, entry.name);
+    const nestedEntries = await readdir(nestedDir, { withFileTypes: true }).catch(() => []);
+    const nested = nestedEntries.find((nestedEntry) => nestedEntry.isDirectory() && nestedEntry.name.endsWith('.app'));
+    if (nested) return path.join(nestedDir, nested.name);
+  }
+
+  throw new Error('Mounted Field Theory DMG did not contain an .app bundle.');
+}
+
+async function pathExists(filePath: string): Promise<boolean> {
+  try {
+    await access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function replaceAppBundle(sourceApp: string, installDir: string, run: ExecFileRunner): Promise<string> {
+  await mkdir(installDir, { recursive: true });
+
+  const appName = path.basename(sourceApp);
+  const targetApp = path.join(installDir, appName);
+  const tempApp = path.join(installDir, `.${appName}.installing-${process.pid}-${Date.now()}`);
+  const backupApp = path.join(installDir, `.${appName}.previous-${process.pid}-${Date.now()}`);
+
+  await rm(tempApp, { recursive: true, force: true });
+  await run('ditto', [sourceApp, tempApp]);
+
+  const hadExisting = await pathExists(targetApp);
+  if (hadExisting) await rename(targetApp, backupApp);
+
+  try {
+    await rename(tempApp, targetApp);
+  } catch (error) {
+    if (hadExisting && await pathExists(backupApp) && !await pathExists(targetApp)) {
+      await rename(backupApp, targetApp);
+    }
+    throw error;
+  }
+
+  if (hadExisting) await rm(backupApp, { recursive: true, force: true });
+  return targetApp;
+}
+
+export async function installFieldTheoryApp(options: FieldTheoryAppInstallOptions = {}): Promise<FieldTheoryAppInstallResult> {
+  const platform = options.platform ?? process.platform;
+  if (platform !== 'darwin') {
+    throw new Error('Field Theory app install is only supported on macOS.');
+  }
+
+  const fetcher = options.fetch ?? fetch;
+  const run = options.execFile ?? execFile;
+  const installDir = path.resolve(options.installDir ?? DEFAULT_INSTALL_DIR);
+  const releaseApiUrl = options.releaseApiUrl ?? DEFAULT_RELEASE_API_URL;
+  const env = options.env ?? process.env;
+  const progress = options.onProgress ?? (() => undefined);
+
+  progress('Checking latest Field Theory release...');
+  const release = await fetchLatestRelease(fetcher, releaseApiUrl, env);
+  const asset = selectFieldTheoryDmgAsset(release);
+  const downloadUrl = asset.browser_download_url!;
+  const releaseName = release.tag_name ?? release.name ?? 'latest';
+
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), 'fieldtheory-app-install-'));
+  const mountPoint = path.join(tempDir, 'mount');
+  const dmgPath = path.join(tempDir, asset.name);
+  let mounted = false;
+
+  try {
+    progress(`Downloading ${asset.name}...`);
+    await downloadFile(fetcher, downloadUrl, dmgPath);
+
+    await mkdir(mountPoint, { recursive: true });
+    progress('Mounting installer image...');
+    await run('hdiutil', ['attach', '-nobrowse', '-readonly', '-mountpoint', mountPoint, dmgPath]);
+    mounted = true;
+
+    const sourceApp = await findAppBundle(mountPoint);
+    progress(`Installing ${path.basename(sourceApp)} to ${installDir}...`);
+    const appPath = await replaceAppBundle(sourceApp, installDir, run);
+
+    if (options.open) {
+      progress('Opening Field Theory...');
+      await run('open', [appPath]);
+    }
+
+    return {
+      appPath,
+      assetName: asset.name,
+      release: releaseName,
+      downloadUrl,
+    };
+  } finally {
+    if (mounted) {
+      try {
+        await run('hdiutil', ['detach', mountPoint]);
+      } catch {
+        progress(`Could not detach ${mountPoint}; macOS may detach it after restart.`);
+      }
+    }
+    await rm(tempDir, { recursive: true, force: true });
+  }
+}

--- a/src/app-open.ts
+++ b/src/app-open.ts
@@ -3,7 +3,12 @@ import path from 'node:path';
 import { canonicalCommandsDir, canonicalLibraryDir } from './paths.js';
 import { isPathInside, resolveMarkdownPath } from './document-ops.js';
 
+const DEFAULT_FIELD_THEORY_BUNDLE_ID = 'com.fieldtheory.app';
+
 export type FieldTheoryOpenKind = 'library' | 'command';
+
+type SpawnResult = Pick<ReturnType<typeof spawnSync>, 'status' | 'error'>;
+type SpawnRunner = (command: string, args: string[], options: { cwd?: string; stdio: 'ignore' }) => SpawnResult;
 
 export interface FieldTheoryOpenTarget {
   kind: FieldTheoryOpenKind;
@@ -11,6 +16,17 @@ export interface FieldTheoryOpenTarget {
   url: string | null;
   supported: boolean;
   note?: string;
+}
+
+export interface FieldTheoryLaunchResult {
+  launched: boolean;
+  method: 'bundle' | 'dev-dir' | 'command' | 'unsupported';
+}
+
+export interface FieldTheoryLaunchOptions {
+  env?: NodeJS.ProcessEnv;
+  platform?: NodeJS.Platform;
+  spawn?: SpawnRunner;
 }
 
 export function inferOpenKind(filePath: string): FieldTheoryOpenKind | null {
@@ -52,8 +68,43 @@ export function buildFieldTheoryOpenTarget(inputPath: string, kind?: FieldTheory
   };
 }
 
-export function openFieldTheoryTarget(target: FieldTheoryOpenTarget): void {
-  if (!target.supported || !target.url) return;
-  if (process.platform !== 'darwin') return;
-  spawnSync('open', [target.url], { stdio: 'ignore' });
+function runLauncher(spawn: SpawnRunner, command: string, args: string[], method: FieldTheoryLaunchResult['method'], cwd?: string): FieldTheoryLaunchResult {
+  const result = spawn(command, args, { cwd, stdio: 'ignore' });
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    throw new Error(`Could not open Field Theory with ${method} launcher.`);
+  }
+  return { launched: true, method };
+}
+
+export function openFieldTheoryTarget(target: FieldTheoryOpenTarget, options: FieldTheoryLaunchOptions = {}): FieldTheoryLaunchResult {
+  if (!target.supported || !target.url) return { launched: false, method: 'unsupported' };
+
+  const env = options.env ?? process.env;
+  const platform = options.platform ?? process.platform;
+  const spawn = options.spawn ?? spawnSync;
+
+  if (env.FT_APP_OPEN_COMMAND) {
+    return runLauncher(spawn, env.FT_APP_OPEN_COMMAND, [target.url], 'command');
+  }
+
+  if (env.FT_APP_DEV_DIR) {
+    const devDir = path.resolve(env.FT_APP_DEV_DIR);
+    const electronBin = env.FT_APP_DEV_ELECTRON ?? path.join(devDir, 'node_modules', '.bin', 'electron');
+    return runLauncher(spawn, electronBin, [devDir, target.url], 'dev-dir', devDir);
+  }
+
+  if (platform !== 'darwin') return { launched: false, method: 'unsupported' };
+
+  const bundleId = env.FT_APP_BUNDLE_ID ?? DEFAULT_FIELD_THEORY_BUNDLE_ID;
+  try {
+    return runLauncher(spawn, 'open', ['-b', bundleId, target.url], 'bundle');
+  } catch (error) {
+    throw new Error(
+      `Could not open Field Theory using bundle id ${bundleId}. ` +
+      'Use --no-launch to print the URL, set FT_APP_BUNDLE_ID for packaged variants, ' +
+      'or set FT_APP_DEV_DIR for a local development checkout.',
+      { cause: error },
+    );
+  }
 }

--- a/src/app-open.ts
+++ b/src/app-open.ts
@@ -1,0 +1,59 @@
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+import { canonicalCommandsDir, canonicalLibraryDir } from './paths.js';
+import { isPathInside, resolveMarkdownPath } from './document-ops.js';
+
+export type FieldTheoryOpenKind = 'library' | 'command';
+
+export interface FieldTheoryOpenTarget {
+  kind: FieldTheoryOpenKind;
+  path: string;
+  url: string | null;
+  supported: boolean;
+  note?: string;
+}
+
+export function inferOpenKind(filePath: string): FieldTheoryOpenKind | null {
+  const resolved = path.resolve(filePath);
+  if (isPathInside(path.resolve(canonicalLibraryDir()), resolved)) return 'library';
+  if (isPathInside(path.resolve(canonicalCommandsDir()), resolved)) return 'command';
+  return null;
+}
+
+export function buildFieldTheoryOpenTarget(inputPath: string, kind?: FieldTheoryOpenKind): FieldTheoryOpenTarget {
+  const resolvedKind = kind ?? inferOpenKind(inputPath);
+  if (!resolvedKind) {
+    throw new Error('Could not infer target kind. Pass --kind library or --kind command.');
+  }
+  if (resolvedKind !== 'library' && resolvedKind !== 'command') {
+    throw new Error(`Unknown target kind: ${String(resolvedKind)}`);
+  }
+
+  const root = resolvedKind === 'library' ? canonicalLibraryDir() : canonicalCommandsDir();
+  const resolvedPath = resolveMarkdownPath(root, inputPath);
+  if (!resolvedPath) throw new Error(`Path is outside the ${resolvedKind} root or is not markdown.`);
+
+  if (resolvedKind === 'library') {
+    const params = new URLSearchParams({ file: resolvedPath, immersive: 'true' });
+    return {
+      kind: resolvedKind,
+      path: resolvedPath,
+      url: `fieldtheory://wiki/open?${params.toString()}`,
+      supported: true,
+    };
+  }
+
+  return {
+    kind: resolvedKind,
+    path: resolvedPath,
+    url: null,
+    supported: false,
+    note: 'Field Theory does not expose a command-file deep link yet; open this path in the Commands view.',
+  };
+}
+
+export function openFieldTheoryTarget(target: FieldTheoryOpenTarget): void {
+  if (!target.supported || !target.url) return;
+  if (process.platform !== 'darwin') return;
+  spawnSync('open', [target.url], { stdio: 'ignore' });
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -36,6 +36,8 @@ import { configureHttpProxyFromEnv } from './http-proxy.js';
 import { dataDir, ensureDataDir, isFirstRun, twitterBookmarksIndexPath, twitterBackfillStatePath, mdDir, bookmarkMediaDir, bookmarkMediaManifestPath } from './paths.js';
 import { PromptCancelledError, promptText } from './prompt.js';
 import { skillWithFrontmatter, installSkill, uninstallSkill } from './skill.js';
+import { registerCompanionCommands } from './companion-cli.js';
+import { getPathReport } from './field-status.js';
 import fs from 'node:fs';
 import path from 'node:path';
 import { createRequire } from 'node:module';
@@ -176,6 +178,10 @@ function warnIfEmpty(totalBookmarks: number): void {
   console.log(`    \u2022 Keychain/keyring access was denied`);
   console.log(`    \u2022 You may be logged into a different profile than the one with X/Twitter`);
   console.log(`    \u2022 Try: ft sync --cookies <ct0> <auth_token>  (paste from DevTools)\n`);
+}
+
+function printJson(value: unknown): void {
+  console.log(JSON.stringify(value, null, 2));
 }
 
 // ── Update checker ────────────────────────────────────────────────────────
@@ -936,6 +942,7 @@ export function buildCli() {
     .option('--after <date>', 'Bookmarks posted after this date (YYYY-MM-DD)')
     .option('--before <date>', 'Bookmarks posted before this date (YYYY-MM-DD)')
     .option('--limit <n>', 'Max results', (v: string) => Number(v), 20)
+    .option('--json', 'JSON output')
     .action(safe(async (query: string, options) => {
       if (!requireIndex()) return;
       const results = await searchBookmarks({
@@ -945,6 +952,10 @@ export function buildCli() {
         before: options.before ? String(options.before) : undefined,
         limit: Number(options.limit) || 20,
       });
+      if (options.json) {
+        printJson(results);
+        return;
+      }
       console.log(formatSearchResults(results));
     }));
 
@@ -1038,9 +1049,14 @@ export function buildCli() {
   program
     .command('stats')
     .description('Aggregate statistics from your bookmarks')
-    .action(safe(async () => {
+    .option('--json', 'JSON output')
+    .action(safe(async (options) => {
       if (!requireIndex()) return;
       const stats = await getStats();
+      if (options.json) {
+        printJson(stats);
+        return;
+      }
       console.log(`Bookmarks: ${stats.totalBookmarks}`);
       console.log(`Unique authors: ${stats.uniqueAuthors}`);
       console.log(`Date range: ${stats.dateRange.earliest?.slice(0, 10) ?? '?'} to ${stats.dateRange.latest?.slice(0, 10) ?? '?'}`);
@@ -1284,9 +1300,16 @@ export function buildCli() {
   program
     .command('status')
     .description('Show sync status and data location')
-    .action(safe(async () => {
-      if (!requireData()) return;
+    .option('--json', 'JSON output')
+    .action(safe(async (options) => {
       const view = await getBookmarkStatusView();
+      if (options.json) {
+        printJson({
+          bookmarks: view,
+          paths: getPathReport(),
+        });
+        return;
+      }
       console.log(formatBookmarkStatus(view));
     }));
 
@@ -1296,6 +1319,8 @@ export function buildCli() {
     .command('path')
     .description('Print the data directory path')
     .action(() => { console.log(dataDir()); });
+
+  registerCompanionCommands(program, safe);
 
   // ── sample ──────────────────────────────────────────────────────────────
 

--- a/src/commands-files.ts
+++ b/src/commands-files.ts
@@ -1,0 +1,181 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { canonicalCommandsDir } from './paths.js';
+import {
+  createMarkdownFile,
+  DocumentVersion,
+  moveToTrash,
+  normalizeMarkdownFileName,
+  readContentInput,
+  readMarkdownDocument,
+  relativeMarkdownPath,
+  renameMarkdownFile,
+  resolveMarkdownPath,
+  TrashedDocument,
+  updateMarkdownFile,
+} from './document-ops.js';
+
+export interface CommandDocumentSummary {
+  path: string;
+  relPath: string;
+  name: string;
+  updatedAt: string;
+  size: number;
+}
+
+export interface CommandDocument extends CommandDocumentSummary {
+  content: string;
+  version: DocumentVersion;
+}
+
+export interface CommandValidationResult {
+  path: string;
+  relPath: string;
+  ok: boolean;
+  issues: string[];
+}
+
+export interface CommandWriteInput {
+  stdin?: boolean;
+  file?: string;
+  content?: string;
+}
+
+export interface CommandUpdateInput extends CommandWriteInput {
+  expectedSha256?: string;
+  force?: boolean;
+}
+
+function commandsRoot(): string {
+  return canonicalCommandsDir();
+}
+
+function resolveCommandPath(target: string): string {
+  const fileName = normalizeMarkdownFileName(target, { rejectLeadingUnderscore: true });
+  const resolved = fileName
+    ? path.join(commandsRoot(), fileName)
+    : resolveMarkdownPath(commandsRoot(), target);
+  if (!resolved) throw new Error(`Invalid command path: ${target}`);
+  return resolved;
+}
+
+function commandNameFromPath(filePath: string): string {
+  return path.basename(filePath).replace(/\.(md|markdown)$/i, '');
+}
+
+function summaryForFile(filePath: string): CommandDocumentSummary {
+  const stats = fs.statSync(filePath);
+  return {
+    path: filePath,
+    relPath: relativeMarkdownPath(commandsRoot(), filePath),
+    name: commandNameFromPath(filePath),
+    updatedAt: new Date(stats.mtimeMs).toISOString(),
+    size: stats.size,
+  };
+}
+
+function walkCommandFiles(): string[] {
+  if (!fs.existsSync(commandsRoot())) return [];
+  return fs.readdirSync(commandsRoot(), { withFileTypes: true })
+    .filter((entry) => entry.isFile() && /\.(md|markdown)$/i.test(entry.name) && !entry.name.startsWith('.') && !entry.name.startsWith('_'))
+    .map((entry) => path.join(commandsRoot(), entry.name))
+    .sort();
+}
+
+function defaultCommandContent(name: string): string {
+  return [
+    `# ${name}`,
+    '',
+    'Describe what this command does in one clear sentence.',
+    '',
+    'Use this when ...',
+    '',
+    '## Steps',
+    '',
+    '1. Do the first concrete thing.',
+    '2. Do the second concrete thing.',
+    '3. Verify the result.',
+    '',
+    '## Guardrails',
+    '',
+    '- Do not include secrets.',
+    '- Ask before destructive actions.',
+    '',
+    '## Verification',
+    '',
+    '- Confirm the intended result is visible or testable.',
+    '',
+  ].join('\n');
+}
+
+export function listCommandDocuments(): CommandDocumentSummary[] {
+  return walkCommandFiles().map((filePath) => summaryForFile(filePath));
+}
+
+export async function showCommandDocument(target: string): Promise<CommandDocument> {
+  const filePath = resolveCommandPath(target);
+  const { content, version } = await readMarkdownDocument(filePath);
+  return { ...summaryForFile(filePath), content, version };
+}
+
+export async function createCommandDocument(name: string, input: CommandWriteInput): Promise<CommandDocument> {
+  const fileName = normalizeMarkdownFileName(name, { rejectLeadingUnderscore: true });
+  if (!fileName) throw new Error(`Invalid command name: ${name}`);
+  const filePath = path.join(commandsRoot(), fileName);
+  const stem = commandNameFromPath(filePath);
+  const content = await readContentInput({
+    stdin: input.stdin,
+    file: input.file,
+    fallback: input.content ?? defaultCommandContent(stem),
+  });
+  await createMarkdownFile(filePath, content);
+  return showCommandDocument(filePath);
+}
+
+export async function updateCommandDocument(target: string, input: CommandUpdateInput): Promise<CommandDocument> {
+  const filePath = resolveCommandPath(target);
+  const content = await readContentInput({ stdin: input.stdin, file: input.file, fallback: input.content });
+  await updateMarkdownFile(filePath, content, {
+    expectedSha256: input.expectedSha256,
+    force: input.force,
+  });
+  return showCommandDocument(filePath);
+}
+
+export async function renameCommandDocument(target: string, nextName: string): Promise<CommandDocument> {
+  const oldPath = resolveCommandPath(target);
+  const fileName = normalizeMarkdownFileName(nextName, { rejectLeadingUnderscore: true });
+  if (!fileName) throw new Error(`Invalid command name: ${nextName}`);
+  const newPath = path.join(commandsRoot(), fileName);
+  await renameMarkdownFile(oldPath, newPath);
+  return showCommandDocument(newPath);
+}
+
+export function deleteCommandDocument(target: string): TrashedDocument {
+  return moveToTrash(resolveCommandPath(target));
+}
+
+export function validateCommandContent(content: string): string[] {
+  const issues: string[] = [];
+  if (!/^#\s+\S/m.test(content)) issues.push('Missing top-level heading.');
+  if (!/\bUse this when\b/i.test(content)) issues.push('Missing "Use this when" guidance.');
+  if (!/^##\s+Steps\b/im.test(content)) issues.push('Missing ## Steps section.');
+  if (!/^##\s+(Guardrails|Safety)\b/im.test(content)) issues.push('Missing ## Guardrails or ## Safety section.');
+  if (!/(verify|verification|confirm|test)/i.test(content)) issues.push('Missing concrete verification guidance.');
+  if (/(api[_-]?key|secret|token)\s*[:=]\s*\S+/i.test(content)) issues.push('Possible secret-like value present.');
+  return issues;
+}
+
+export function validateCommandDocument(target?: string): CommandValidationResult[] {
+  const paths = target ? [resolveCommandPath(target)] : walkCommandFiles();
+  return paths.map((filePath) => {
+    const content = fs.readFileSync(filePath, 'utf-8');
+    const issues = validateCommandContent(content);
+    return {
+      path: filePath,
+      relPath: relativeMarkdownPath(commandsRoot(), filePath),
+      ok: issues.length === 0,
+      issues,
+    };
+  });
+}

--- a/src/companion-cli.ts
+++ b/src/companion-cli.ts
@@ -1,0 +1,357 @@
+import type { Command } from 'commander';
+import { buildFieldTheoryOpenTarget, inferOpenKind, openFieldTheoryTarget, type FieldTheoryOpenKind } from './app-open.js';
+import {
+  createCommandDocument,
+  deleteCommandDocument,
+  listCommandDocuments,
+  renameCommandDocument,
+  showCommandDocument,
+  updateCommandDocument,
+  validateCommandDocument,
+} from './commands-files.js';
+import { getPathReport, formatPathReport } from './field-status.js';
+import {
+  createLibraryDocument,
+  deleteLibraryDocument,
+  listLibraryDocuments,
+  renameLibraryDocument,
+  searchLibraryDocuments,
+  showLibraryDocument,
+  updateLibraryDocument,
+} from './library.js';
+
+type SafeAction = (fn: (...args: any[]) => Promise<void>) => (...args: any[]) => Promise<void>;
+
+function printJson(value: unknown): void {
+  console.log(JSON.stringify(value, null, 2));
+}
+
+function parseOpenKind(value: unknown): FieldTheoryOpenKind | undefined {
+  if (value === undefined) return undefined;
+  const kind = String(value);
+  if (kind === 'library' || kind === 'command') return kind;
+  throw new Error(`Unknown target kind: ${kind}`);
+}
+
+export function registerCompanionCommands(program: Command, safe: SafeAction): void {
+  program
+    .command('paths')
+    .description('Show Field Theory data, library, commands, and compatibility paths')
+    .option('--json', 'JSON output')
+    .action((options) => {
+      const report = getPathReport();
+      if (options.json) {
+        printJson(report);
+        return;
+      }
+      console.log(formatPathReport(report));
+    });
+
+  const library = program
+    .command('library')
+    .description('Inspect and manage Field Theory Library markdown');
+
+  library
+    .command('list')
+    .description('List Library markdown files')
+    .option('--limit <n>', 'Max files', (v: string) => Number(v))
+    .option('--json', 'JSON output')
+    .action((options) => {
+      const docs = listLibraryDocuments({
+        limit: typeof options.limit === 'number' && !Number.isNaN(options.limit) ? options.limit : undefined,
+      });
+      if (options.json) {
+        printJson(docs);
+        return;
+      }
+      for (const doc of docs) console.log(`${doc.relPath}  ${doc.title}`);
+    });
+
+  library
+    .command('search')
+    .description('Search Library markdown files')
+    .argument('<query>', 'Text to search for')
+    .option('--limit <n>', 'Max results', (v: string) => Number(v), 20)
+    .option('--json', 'JSON output')
+    .action((query: string, options) => {
+      const results = searchLibraryDocuments(query, { limit: Number(options.limit) || 20 });
+      if (options.json) {
+        printJson(results);
+        return;
+      }
+      for (const result of results) {
+        console.log(`${result.relPath}  ${result.title}`);
+        console.log(`  ${result.snippet}`);
+      }
+    });
+
+  library
+    .command('show')
+    .description('Show one Library markdown file')
+    .argument('<path>', 'Relative or absolute markdown path')
+    .option('--json', 'JSON output')
+    .action(safe(async (targetPath: string, options) => {
+      const doc = await showLibraryDocument(targetPath);
+      if (options.json) {
+        printJson(doc);
+        return;
+      }
+      console.log(doc.content);
+    }));
+
+  library
+    .command('create')
+    .description('Create a Library markdown file')
+    .argument('<path>', 'Relative markdown path under the Library')
+    .option('--title <title>', 'Create a simple heading when no content input is passed')
+    .option('--stdin', 'Read markdown content from stdin')
+    .option('--file <path>', 'Read markdown content from a file')
+    .option('--json', 'JSON output')
+    .action(safe(async (targetPath: string, options) => {
+      const doc = await createLibraryDocument(targetPath, {
+        stdin: Boolean(options.stdin),
+        file: options.file ? String(options.file) : undefined,
+        title: options.title ? String(options.title) : undefined,
+      });
+      if (options.json) {
+        printJson(doc);
+        return;
+      }
+      console.log(`Created: ${doc.path}`);
+    }));
+
+  library
+    .command('update')
+    .description('Replace a Library markdown file with stdin or file content')
+    .argument('<path>', 'Relative or absolute markdown path')
+    .option('--stdin', 'Read markdown content from stdin')
+    .option('--file <path>', 'Read markdown content from a file')
+    .option('--expected-sha256 <hash>', 'Only update if the current file hash matches')
+    .option('--force', 'Overwrite without an expected hash')
+    .option('--json', 'JSON output')
+    .action(safe(async (targetPath: string, options) => {
+      if (!options.stdin && !options.file) throw new Error('Pass --stdin or --file for update content.');
+      const doc = await updateLibraryDocument(targetPath, {
+        stdin: Boolean(options.stdin),
+        file: options.file ? String(options.file) : undefined,
+        expectedSha256: options.expectedSha256 ? String(options.expectedSha256) : undefined,
+        force: Boolean(options.force),
+      });
+      if (options.json) {
+        printJson(doc);
+        return;
+      }
+      console.log(`Updated: ${doc.path}`);
+      console.log(`sha256: ${doc.version.sha256}`);
+    }));
+
+  library
+    .command('rename')
+    .description('Rename a Library markdown file')
+    .argument('<path>', 'Current relative or absolute markdown path')
+    .argument('<new-path>', 'New relative markdown path under the Library')
+    .option('--json', 'JSON output')
+    .action(safe(async (targetPath: string, newPath: string, options) => {
+      const doc = await renameLibraryDocument(targetPath, newPath);
+      if (options.json) {
+        printJson(doc);
+        return;
+      }
+      console.log(`Renamed: ${doc.path}`);
+    }));
+
+  library
+    .command('delete')
+    .description('Move a Library markdown file to Trash')
+    .argument('<path>', 'Relative or absolute markdown path')
+    .option('--json', 'JSON output')
+    .action(safe(async (targetPath: string, options) => {
+      const result = deleteLibraryDocument(targetPath);
+      if (options.json) {
+        printJson(result);
+        return;
+      }
+      console.log(`Moved to Trash: ${result.trashPath}`);
+    }));
+
+  library
+    .command('open')
+    .description('Open a Library markdown file in Field Theory')
+    .argument('<path>', 'Relative or absolute markdown path')
+    .option('--no-launch', 'Print target without launching the app')
+    .option('--json', 'JSON output')
+    .action(safe(async (targetPath: string, options) => {
+      const target = buildFieldTheoryOpenTarget(targetPath, 'library');
+      if (options.launch !== false) openFieldTheoryTarget(target);
+      if (options.json) {
+        printJson(target);
+        return;
+      }
+      console.log(target.url ?? target.path);
+    }));
+
+  const portableCommands = program
+    .command('commands')
+    .description('Inspect and manage Field Theory portable commands');
+
+  portableCommands
+    .command('list')
+    .description('List portable command files')
+    .option('--json', 'JSON output')
+    .action((options) => {
+      const docs = listCommandDocuments();
+      if (options.json) {
+        printJson(docs);
+        return;
+      }
+      for (const doc of docs) console.log(`${doc.name}  ${doc.relPath}`);
+    });
+
+  portableCommands
+    .command('show')
+    .description('Show one portable command')
+    .argument('<name>', 'Command name or markdown path')
+    .option('--json', 'JSON output')
+    .action(safe(async (name: string, options) => {
+      const doc = await showCommandDocument(name);
+      if (options.json) {
+        printJson(doc);
+        return;
+      }
+      console.log(doc.content);
+    }));
+
+  portableCommands
+    .command('new')
+    .description('Create a portable command file')
+    .argument('<name>', 'Short command name')
+    .option('--stdin', 'Read command content from stdin')
+    .option('--file <path>', 'Read command content from a file')
+    .option('--json', 'JSON output')
+    .action(safe(async (name: string, options) => {
+      const doc = await createCommandDocument(name, {
+        stdin: Boolean(options.stdin),
+        file: options.file ? String(options.file) : undefined,
+      });
+      if (options.json) {
+        printJson(doc);
+        return;
+      }
+      console.log(`Created: ${doc.path}`);
+    }));
+
+  portableCommands
+    .command('update')
+    .description('Replace a portable command with stdin or file content')
+    .argument('<name>', 'Command name or markdown path')
+    .option('--stdin', 'Read command content from stdin')
+    .option('--file <path>', 'Read command content from a file')
+    .option('--expected-sha256 <hash>', 'Only update if the current file hash matches')
+    .option('--force', 'Overwrite without an expected hash')
+    .option('--json', 'JSON output')
+    .action(safe(async (name: string, options) => {
+      if (!options.stdin && !options.file) throw new Error('Pass --stdin or --file for update content.');
+      const doc = await updateCommandDocument(name, {
+        stdin: Boolean(options.stdin),
+        file: options.file ? String(options.file) : undefined,
+        expectedSha256: options.expectedSha256 ? String(options.expectedSha256) : undefined,
+        force: Boolean(options.force),
+      });
+      if (options.json) {
+        printJson(doc);
+        return;
+      }
+      console.log(`Updated: ${doc.path}`);
+      console.log(`sha256: ${doc.version.sha256}`);
+    }));
+
+  portableCommands
+    .command('rename')
+    .description('Rename a portable command file')
+    .argument('<name>', 'Current command name or markdown path')
+    .argument('<new-name>', 'New command name')
+    .option('--json', 'JSON output')
+    .action(safe(async (name: string, newName: string, options) => {
+      const doc = await renameCommandDocument(name, newName);
+      if (options.json) {
+        printJson(doc);
+        return;
+      }
+      console.log(`Renamed: ${doc.path}`);
+    }));
+
+  portableCommands
+    .command('delete')
+    .description('Move a portable command file to Trash')
+    .argument('<name>', 'Command name or markdown path')
+    .option('--json', 'JSON output')
+    .action(safe(async (name: string, options) => {
+      const result = deleteCommandDocument(name);
+      if (options.json) {
+        printJson(result);
+        return;
+      }
+      console.log(`Moved to Trash: ${result.trashPath}`);
+    }));
+
+  portableCommands
+    .command('validate')
+    .description('Validate one command or all command files')
+    .argument('[name]', 'Optional command name or markdown path')
+    .option('--json', 'JSON output')
+    .action(safe(async (name: string | undefined, options) => {
+      const results = validateCommandDocument(name);
+      if (options.json) {
+        printJson(results);
+      } else {
+        for (const result of results) {
+          console.log(`${result.ok ? 'ok' : 'issues'}  ${result.relPath}`);
+          for (const issue of result.issues) console.log(`  - ${issue}`);
+        }
+      }
+      if (results.some((result) => !result.ok)) process.exitCode = 1;
+    }));
+
+  portableCommands
+    .command('open')
+    .description('Print a portable command file path for Field Theory')
+    .argument('<name>', 'Command name or markdown path')
+    .option('--no-launch', 'Accepted for parity with library open')
+    .option('--json', 'JSON output')
+    .action(safe(async (name: string, options) => {
+      const doc = await showCommandDocument(name);
+      const target = buildFieldTheoryOpenTarget(doc.path, 'command');
+      if (options.json) {
+        printJson(target);
+        return;
+      }
+      console.log(target.note ?? target.path);
+      console.log(target.path);
+    }));
+
+  const appCommand = program
+    .command('app')
+    .description('Open Field Theory app targets');
+
+  appCommand
+    .command('open')
+    .description('Open or print a Field Theory app target')
+    .argument('<path>', 'Markdown path')
+    .option('--kind <kind>', 'Target kind: library or command')
+    .option('--no-launch', 'Print target without launching the app')
+    .option('--json', 'JSON output')
+    .action(safe(async (targetPath: string, options) => {
+      const kind = parseOpenKind(options.kind) ?? inferOpenKind(targetPath) ?? undefined;
+      const target = buildFieldTheoryOpenTarget(targetPath, kind);
+      if (options.launch !== false) openFieldTheoryTarget(target);
+      if (options.json) {
+        printJson(target);
+        return;
+      }
+      if (target.url) console.log(target.url);
+      else {
+        console.log(target.note ?? 'No app deep link available for this target.');
+        console.log(target.path);
+      }
+    }));
+}

--- a/src/companion-cli.ts
+++ b/src/companion-cli.ts
@@ -182,9 +182,9 @@ export function registerCompanionCommands(program: Command, safe: SafeAction): v
     .option('--json', 'JSON output')
     .action(safe(async (targetPath: string, options) => {
       const target = buildFieldTheoryOpenTarget(targetPath, 'library');
-      if (options.launch !== false) openFieldTheoryTarget(target);
+      const launch = options.launch !== false ? openFieldTheoryTarget(target) : undefined;
       if (options.json) {
-        printJson(target);
+        printJson(launch ? { ...target, launch } : target);
         return;
       }
       console.log(target.url ?? target.path);
@@ -343,9 +343,9 @@ export function registerCompanionCommands(program: Command, safe: SafeAction): v
     .action(safe(async (targetPath: string, options) => {
       const kind = parseOpenKind(options.kind) ?? inferOpenKind(targetPath) ?? undefined;
       const target = buildFieldTheoryOpenTarget(targetPath, kind);
-      if (options.launch !== false) openFieldTheoryTarget(target);
+      const launch = options.launch !== false ? openFieldTheoryTarget(target) : undefined;
       if (options.json) {
-        printJson(target);
+        printJson(launch ? { ...target, launch } : target);
         return;
       }
       if (target.url) console.log(target.url);

--- a/src/companion-cli.ts
+++ b/src/companion-cli.ts
@@ -1,5 +1,6 @@
 import type { Command } from 'commander';
 import { buildFieldTheoryOpenTarget, inferOpenKind, openFieldTheoryTarget, type FieldTheoryOpenKind } from './app-open.js';
+import { installFieldTheoryApp } from './app-install.js';
 import {
   createCommandDocument,
   deleteCommandDocument,
@@ -353,5 +354,28 @@ export function registerCompanionCommands(program: Command, safe: SafeAction): v
         console.log(target.note ?? 'No app deep link available for this target.');
         console.log(target.path);
       }
+    }));
+
+  const install = program
+    .command('install')
+    .description('Install Field Theory components');
+
+  install
+    .command('app')
+    .description('Download and install the latest Field Theory Mac app')
+    .option('--install-dir <path>', 'Directory to install the app into', '/Applications')
+    .option('--open', 'Open Field Theory after installing')
+    .option('--json', 'JSON output')
+    .action(safe(async (options) => {
+      const result = await installFieldTheoryApp({
+        installDir: String(options.installDir),
+        open: Boolean(options.open),
+        onProgress: options.json ? undefined : (message) => console.log(message),
+      });
+      if (options.json) {
+        printJson(result);
+        return;
+      }
+      console.log(`Installed Field Theory ${result.release}: ${result.appPath}`);
     }));
 }

--- a/src/document-ops.ts
+++ b/src/document-ops.ts
@@ -1,0 +1,160 @@
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { ensureDir, pathExists, readMd, writeMd } from './fs.js';
+
+export interface DocumentVersion {
+  mtimeMs: number;
+  size: number;
+  sha256: string;
+}
+
+export interface DocumentUpdateOptions {
+  expectedSha256?: string;
+  force?: boolean;
+}
+
+export interface DocumentUpdateResult {
+  path: string;
+  version: DocumentVersion;
+}
+
+export interface TrashedDocument {
+  originalPath: string;
+  trashPath: string;
+}
+
+export function sha256(value: string): string {
+  return crypto.createHash('sha256').update(value, 'utf8').digest('hex');
+}
+
+export function isPathInside(parentPath: string, childPath: string): boolean {
+  const relPath = path.relative(parentPath, childPath);
+  return relPath === '' || (!!relPath && !relPath.startsWith(`..${path.sep}`) && !path.isAbsolute(relPath));
+}
+
+export function normalizeMarkdownFileName(name: string, options: { rejectLeadingUnderscore?: boolean } = {}): string | null {
+  const trimmed = name.trim();
+  if (!trimmed || trimmed.includes('\0') || /[\\/]/.test(trimmed)) return null;
+
+  const withoutExt = trimmed.replace(/\.(md|markdown)$/i, '').trim();
+  if (!withoutExt || withoutExt === '.' || withoutExt === '..' || withoutExt.startsWith('.')) return null;
+  if (options.rejectLeadingUnderscore && withoutExt.startsWith('_')) return null;
+
+  const fileName = /\.(md|markdown)$/i.test(trimmed) ? trimmed : `${trimmed}.md`;
+  return path.basename(fileName) === fileName ? fileName : null;
+}
+
+export function normalizeMarkdownRelPath(input: string, options: { rejectHiddenSegments?: boolean } = {}): string | null {
+  const trimmed = input.trim();
+  if (!trimmed || trimmed.includes('\0') || path.isAbsolute(trimmed)) return null;
+
+  const parts = trimmed.split(/[\\/]+/).map((part) => part.trim()).filter(Boolean);
+  if (parts.length === 0) return null;
+  if (parts.some((part) => part === '.' || part === '..' || part.startsWith('.'))) return null;
+  if (options.rejectHiddenSegments && parts.some((part) => part.startsWith('_'))) return null;
+
+  const last = parts[parts.length - 1];
+  if (!/\.(md|markdown)$/i.test(last)) parts[parts.length - 1] = `${last}.md`;
+  return parts.join('/');
+}
+
+export function resolveMarkdownPath(rootDir: string, target: string): string | null {
+  const root = path.resolve(rootDir);
+  const raw = target.trim();
+  if (!raw || raw.includes('\0')) return null;
+
+  const candidate = path.isAbsolute(raw)
+    ? path.resolve(raw)
+    : path.resolve(root, normalizeMarkdownRelPath(raw) ?? '');
+
+  if (!isPathInside(root, candidate)) return null;
+  if (!/\.(md|markdown)$/i.test(path.basename(candidate))) return null;
+  return candidate;
+}
+
+export function relativeMarkdownPath(rootDir: string, filePath: string): string {
+  return path.relative(rootDir, filePath).split(path.sep).join('/');
+}
+
+export function readDocumentVersion(filePath: string): DocumentVersion {
+  const content = fs.readFileSync(filePath, 'utf-8');
+  const stats = fs.statSync(filePath);
+  return {
+    mtimeMs: stats.mtimeMs,
+    size: stats.size,
+    sha256: sha256(content),
+  };
+}
+
+export async function readStdin(): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk)));
+  }
+  return Buffer.concat(chunks).toString('utf-8');
+}
+
+export async function readContentInput(options: { stdin?: boolean; file?: string; fallback?: string }): Promise<string> {
+  if (options.stdin && options.file) {
+    throw new Error('--stdin and --file cannot be used together.');
+  }
+  if (options.stdin) return readStdin();
+  if (options.file) return fs.readFileSync(options.file, 'utf-8');
+  return options.fallback ?? '';
+}
+
+export async function createMarkdownFile(filePath: string, content: string): Promise<DocumentUpdateResult> {
+  if (await pathExists(filePath)) {
+    throw new Error(`File already exists: ${filePath}`);
+  }
+  await writeMd(filePath, content);
+  return { path: filePath, version: readDocumentVersion(filePath) };
+}
+
+export async function updateMarkdownFile(filePath: string, content: string, options: DocumentUpdateOptions): Promise<DocumentUpdateResult> {
+  if (!await pathExists(filePath)) {
+    throw new Error(`File not found: ${filePath}`);
+  }
+  const current = readDocumentVersion(filePath);
+  if (options.expectedSha256 && current.sha256 !== options.expectedSha256) {
+    throw new Error(`File changed on disk. Expected ${options.expectedSha256}, found ${current.sha256}.`);
+  }
+  if (!options.force && !options.expectedSha256) {
+    throw new Error('Refusing to overwrite without --expected-sha256 or --force.');
+  }
+  await writeMd(filePath, content);
+  return { path: filePath, version: readDocumentVersion(filePath) };
+}
+
+export async function renameMarkdownFile(oldPath: string, newPath: string): Promise<DocumentUpdateResult> {
+  if (!await pathExists(oldPath)) throw new Error(`File not found: ${oldPath}`);
+  if (await pathExists(newPath)) throw new Error(`Target already exists: ${newPath}`);
+  await ensureDir(path.dirname(newPath));
+  fs.renameSync(oldPath, newPath);
+  return { path: newPath, version: readDocumentVersion(newPath) };
+}
+
+export function moveToTrash(filePath: string): TrashedDocument {
+  if (!fs.existsSync(filePath)) throw new Error(`File not found: ${filePath}`);
+  const stats = fs.statSync(filePath);
+  if (!stats.isFile()) throw new Error(`Not a file: ${filePath}`);
+
+  const trashDir = path.join(os.homedir(), '.Trash');
+  fs.mkdirSync(trashDir, { recursive: true });
+
+  const parsed = path.parse(filePath);
+  let trashPath = path.join(trashDir, path.basename(filePath));
+  if (fs.existsSync(trashPath)) {
+    trashPath = path.join(trashDir, `${parsed.name} ${Date.now()}${parsed.ext}`);
+  }
+
+  fs.renameSync(filePath, trashPath);
+  return { originalPath: filePath, trashPath };
+}
+
+export async function readMarkdownDocument(filePath: string): Promise<{ content: string; version: DocumentVersion }> {
+  const content = await readMd(filePath);
+  return { content, version: readDocumentVersion(filePath) };
+}

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -2,7 +2,7 @@
  * LLM engine detection, selection, and invocation.
  *
  * Knows how to call `claude` and `codex` out of the box.
- * Remembers the user's choice in ~/.ft-bookmarks/.preferences.
+ * Remembers the user's choice in the bookmark data directory's .preferences file.
  */
 
 import { spawn, spawnSync } from 'node:child_process';
@@ -250,7 +250,7 @@ function tailString(buf: Buffer, bytes: number): string {
  *
  * `claude` / `codex` don't currently echo secrets to stderr, but this is
  * defense-in-depth: if an engine ever does, we don't want the raw token in
- * `~/.ft-bookmarks/md/log.md` forever.
+ * `~/.fieldtheory/library/log.md` forever.
  */
 export function redactSecrets(s: string): string {
   return s

--- a/src/field-status.ts
+++ b/src/field-status.ts
@@ -1,0 +1,95 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import {
+  bookmarkMediaDir,
+  bookmarkMediaManifestPath,
+  canonicalCommandsDir,
+  canonicalDataDir,
+  canonicalLibraryDir,
+  commandsDir,
+  dataDir,
+  fieldTheoryDir,
+  legacyDataDir,
+  libraryDir,
+  twitterBookmarksCachePath,
+  twitterBookmarksIndexPath,
+} from './paths.js';
+
+export interface FieldTheoryPathReport {
+  fieldTheoryDir: string;
+  active: {
+    bookmarksDir: string;
+    libraryDir: string;
+    commandsDir: string;
+    mediaDir: string;
+    mediaManifestPath: string;
+    bookmarksCachePath: string;
+    bookmarksIndexPath: string;
+  };
+  canonical: {
+    bookmarksDir: string;
+    libraryDir: string;
+    commandsDir: string;
+  };
+  env: {
+    FT_DATA_DIR?: string;
+    FT_LIBRARY_DIR?: string;
+    FT_COMMANDS_DIR?: string;
+  };
+  legacy: {
+    bookmarksDir: string;
+    exists: boolean;
+    mdDir: string;
+    mdExists: boolean;
+  };
+}
+
+export function getPathReport(): FieldTheoryPathReport {
+  const legacyDir = legacyDataDir();
+  const legacyMdDir = path.join(legacyDir, 'md');
+  return {
+    fieldTheoryDir: fieldTheoryDir(),
+    active: {
+      bookmarksDir: dataDir(),
+      libraryDir: libraryDir(),
+      commandsDir: commandsDir(),
+      mediaDir: bookmarkMediaDir(),
+      mediaManifestPath: bookmarkMediaManifestPath(),
+      bookmarksCachePath: twitterBookmarksCachePath(),
+      bookmarksIndexPath: twitterBookmarksIndexPath(),
+    },
+    canonical: {
+      bookmarksDir: canonicalDataDir(),
+      libraryDir: canonicalLibraryDir(),
+      commandsDir: canonicalCommandsDir(),
+    },
+    env: {
+      FT_DATA_DIR: process.env.FT_DATA_DIR,
+      FT_LIBRARY_DIR: process.env.FT_LIBRARY_DIR,
+      FT_COMMANDS_DIR: process.env.FT_COMMANDS_DIR,
+    },
+    legacy: {
+      bookmarksDir: legacyDir,
+      exists: fs.existsSync(legacyDir),
+      mdDir: legacyMdDir,
+      mdExists: fs.existsSync(legacyMdDir),
+    },
+  };
+}
+
+export function formatPathReport(report: FieldTheoryPathReport): string {
+  const lines = [
+    'Field Theory paths',
+    `  bookmarks: ${report.canonical.bookmarksDir}`,
+    `  library:   ${report.canonical.libraryDir}`,
+    `  commands:  ${report.canonical.commandsDir}`,
+    `  media:     ${report.active.mediaDir}`,
+  ];
+  if (report.legacy.exists || report.legacy.mdExists) {
+    lines.push('');
+    lines.push('Legacy data detected (report-only):');
+    if (report.legacy.exists) lines.push(`  ${report.legacy.bookmarksDir}`);
+    if (report.legacy.mdExists) lines.push(`  ${report.legacy.mdDir}`);
+  }
+  return lines.join('\n');
+}

--- a/src/fs.ts
+++ b/src/fs.ts
@@ -87,7 +87,7 @@ export async function readJsonLines<T>(filePath: string): Promise<T[]> {
 
 export async function writeMd(filePath: string, content: string): Promise<void> {
   await mkdir(path.dirname(filePath), { recursive: true });
-  await writeFile(filePath, content, 'utf8');
+  await writeFileDurable(filePath, content, 0o644);
 }
 
 export async function readMd(filePath: string): Promise<string> {

--- a/src/library.ts
+++ b/src/library.ts
@@ -1,0 +1,166 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { canonicalLibraryDir } from './paths.js';
+import {
+  createMarkdownFile,
+  DocumentVersion,
+  moveToTrash,
+  readContentInput,
+  readMarkdownDocument,
+  relativeMarkdownPath,
+  renameMarkdownFile,
+  resolveMarkdownPath,
+  TrashedDocument,
+  updateMarkdownFile,
+} from './document-ops.js';
+
+export interface LibraryDocumentSummary {
+  path: string;
+  relPath: string;
+  title: string;
+  updatedAt: string;
+  size: number;
+}
+
+export interface LibrarySearchResult extends LibraryDocumentSummary {
+  snippet: string;
+}
+
+export interface LibraryDocument extends LibraryDocumentSummary {
+  content: string;
+  version: DocumentVersion;
+}
+
+export interface LibraryWriteInput {
+  stdin?: boolean;
+  file?: string;
+  content?: string;
+  title?: string;
+}
+
+export interface LibraryUpdateInput extends LibraryWriteInput {
+  expectedSha256?: string;
+  force?: boolean;
+}
+
+function libraryRoot(): string {
+  return canonicalLibraryDir();
+}
+
+function titleFromContent(filePath: string, content: string): string {
+  const heading = content.split('\n').find((line) => /^#\s+/.test(line));
+  if (heading) return heading.replace(/^#\s+/, '').trim();
+  return path.basename(filePath, path.extname(filePath));
+}
+
+function summaryForFile(filePath: string): LibraryDocumentSummary {
+  const content = fs.readFileSync(filePath, 'utf-8');
+  const stats = fs.statSync(filePath);
+  return {
+    path: filePath,
+    relPath: relativeMarkdownPath(libraryRoot(), filePath),
+    title: titleFromContent(filePath, content),
+    updatedAt: new Date(stats.mtimeMs).toISOString(),
+    size: stats.size,
+  };
+}
+
+function walkMarkdownFiles(dirPath: string): string[] {
+  const files: string[] = [];
+  if (!fs.existsSync(dirPath)) return files;
+
+  function walk(current: string): void {
+    for (const entry of fs.readdirSync(current, { withFileTypes: true })) {
+      const absPath = path.join(current, entry.name);
+      if (entry.isDirectory()) {
+        walk(absPath);
+      } else if (entry.isFile() && /\.(md|markdown)$/i.test(entry.name)) {
+        files.push(absPath);
+      }
+    }
+  }
+
+  walk(dirPath);
+  return files.sort();
+}
+
+function snippetFor(content: string, query: string): string {
+  const compact = content.replace(/\s+/g, ' ').trim();
+  const idx = compact.toLowerCase().indexOf(query.toLowerCase());
+  if (idx < 0) return compact.slice(0, 180);
+  const start = Math.max(0, idx - 70);
+  const end = Math.min(compact.length, idx + query.length + 110);
+  return `${start > 0 ? '...' : ''}${compact.slice(start, end)}${end < compact.length ? '...' : ''}`;
+}
+
+function resolveLibraryPath(target: string): string {
+  const resolved = resolveMarkdownPath(libraryRoot(), target);
+  if (!resolved) throw new Error(`Invalid Library path: ${target}`);
+  return resolved;
+}
+
+function defaultContent(targetPath: string, input: LibraryWriteInput): string {
+  if (input.content !== undefined) return input.content;
+  if (!input.title) return '';
+  return `# ${input.title.trim() || path.basename(targetPath, path.extname(targetPath))}\n`;
+}
+
+export function listLibraryDocuments(options: { limit?: number } = {}): LibraryDocumentSummary[] {
+  const docs = walkMarkdownFiles(libraryRoot()).map((filePath) => summaryForFile(filePath));
+  return docs.slice(0, options.limit ?? docs.length);
+}
+
+export function searchLibraryDocuments(query: string, options: { limit?: number } = {}): LibrarySearchResult[] {
+  const needle = query.trim();
+  if (!needle) return [];
+
+  const results: LibrarySearchResult[] = [];
+  for (const filePath of walkMarkdownFiles(libraryRoot())) {
+    const content = fs.readFileSync(filePath, 'utf-8');
+    if (!content.toLowerCase().includes(needle.toLowerCase())) continue;
+    results.push({
+      ...summaryForFile(filePath),
+      snippet: snippetFor(content, needle),
+    });
+    if (results.length >= (options.limit ?? 20)) break;
+  }
+  return results;
+}
+
+export async function showLibraryDocument(target: string): Promise<LibraryDocument> {
+  const filePath = resolveLibraryPath(target);
+  const { content, version } = await readMarkdownDocument(filePath);
+  return {
+    ...summaryForFile(filePath),
+    content,
+    version,
+  };
+}
+
+export async function createLibraryDocument(target: string, input: LibraryWriteInput): Promise<LibraryDocument> {
+  const filePath = resolveLibraryPath(target);
+  const content = await readContentInput({ stdin: input.stdin, file: input.file, fallback: defaultContent(filePath, input) });
+  await createMarkdownFile(filePath, content);
+  return showLibraryDocument(filePath);
+}
+
+export async function updateLibraryDocument(target: string, input: LibraryUpdateInput): Promise<LibraryDocument> {
+  const filePath = resolveLibraryPath(target);
+  const content = await readContentInput({ stdin: input.stdin, file: input.file, fallback: input.content });
+  await updateMarkdownFile(filePath, content, {
+    expectedSha256: input.expectedSha256,
+    force: input.force,
+  });
+  return showLibraryDocument(filePath);
+}
+
+export async function renameLibraryDocument(target: string, nextTarget: string): Promise<LibraryDocument> {
+  const oldPath = resolveLibraryPath(target);
+  const newPath = resolveLibraryPath(nextTarget);
+  await renameMarkdownFile(oldPath, newPath);
+  return showLibraryDocument(newPath);
+}
+
+export function deleteLibraryDocument(target: string): TrashedDocument {
+  return moveToTrash(resolveLibraryPath(target));
+}

--- a/src/md-export.ts
+++ b/src/md-export.ts
@@ -7,7 +7,7 @@
  * full tweet text, and [[wikilinks]] to wiki category/domain/entity pages.
  * No LLM required — fast, deterministic, portable.
  *
- * Output: ~/.ft-bookmarks/md/bookmarks/<date>-<author>-<slug>.md
+ * Output: ~/.fieldtheory/library/bookmarks/<date>-<author>-<slug>.md
  */
 
 import fs from 'node:fs';

--- a/src/md.ts
+++ b/src/md.ts
@@ -4,7 +4,7 @@
  * ft md [--full]
  *
  * Builds/updates a Karpathy-style LLM wiki from the bookmarks database.
- * Output lives in ~/.ft-bookmarks/md/ as plain markdown with [[wikilinks]],
+ * Output lives in ~/.fieldtheory/library/ as plain markdown with [[wikilinks]],
  * compatible with Atomic and other markdown knowledge graph tools.
  *
  * Incremental by default: only pages whose source bookmark count changed are
@@ -135,7 +135,7 @@ Edit it to evolve how the LLM maintains wiki pages.
 ## Directory Structure
 
 \`\`\`
-~/.ft-bookmarks/md/
+~/.fieldtheory/library/
 ├── index.md          # Content catalog (auto-generated, do not edit)
 ├── log.md            # Append-only compile + query log
 ├── md-state.json     # Internal compilation state

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -11,6 +11,26 @@ export function dataDir(): string {
   return legacy;
 }
 
+export function fieldTheoryDir(): string {
+  return path.join(os.homedir(), '.fieldtheory');
+}
+
+export function legacyDataDir(): string {
+  return path.join(os.homedir(), '.ft-bookmarks');
+}
+
+export function canonicalDataDir(): string {
+  return process.env.FT_DATA_DIR ?? path.join(fieldTheoryDir(), 'bookmarks');
+}
+
+export function canonicalLibraryDir(): string {
+  return process.env.FT_LIBRARY_DIR ?? path.join(fieldTheoryDir(), 'library');
+}
+
+export function canonicalCommandsDir(): string {
+  return process.env.FT_COMMANDS_DIR ?? path.join(fieldTheoryDir(), 'commands');
+}
+
 export function libraryDir(): string {
   const override = process.env.FT_LIBRARY_DIR;
   if (override) return override;
@@ -22,7 +42,7 @@ export function libraryDir(): string {
 }
 
 export function commandsDir(): string {
-  return process.env.FT_COMMANDS_DIR ?? path.join(os.homedir(), '.fieldtheory', 'commands');
+  return canonicalCommandsDir();
 }
 
 function ensureDirSync(dir: string): void {

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -5,7 +5,24 @@ import fs from 'node:fs';
 export function dataDir(): string {
   const override = process.env.FT_DATA_DIR;
   if (override) return override;
-  return path.join(os.homedir(), '.ft-bookmarks');
+  const canonical = path.join(os.homedir(), '.fieldtheory', 'bookmarks');
+  const legacy = path.join(os.homedir(), '.ft-bookmarks');
+  if (fs.existsSync(canonical) || !fs.existsSync(legacy)) return canonical;
+  return legacy;
+}
+
+export function libraryDir(): string {
+  const override = process.env.FT_LIBRARY_DIR;
+  if (override) return override;
+  if (process.env.FT_DATA_DIR) return path.join(process.env.FT_DATA_DIR, 'md');
+  const canonical = path.join(os.homedir(), '.fieldtheory', 'library');
+  const legacy = path.join(os.homedir(), '.ft-bookmarks', 'md');
+  if (fs.existsSync(canonical) || !fs.existsSync(legacy)) return canonical;
+  return legacy;
+}
+
+export function commandsDir(): string {
+  return process.env.FT_COMMANDS_DIR ?? path.join(os.homedir(), '.fieldtheory', 'commands');
 }
 
 function ensureDirSync(dir: string): void {
@@ -59,7 +76,7 @@ export function isFirstRun(): boolean {
 // ── Markdown wiki paths ──────────────────────────────────────────────────
 
 export function mdDir(): string {
-  return path.join(dataDir(), 'md');
+  return libraryDir();
 }
 
 export function mdIndexPath(): string {
@@ -75,7 +92,7 @@ export function mdStatePath(): string {
 }
 
 export function mdSchemaPath(): string {
-  return path.join(dataDir(), 'schema.md');
+  return path.join(mdDir(), 'schema.md');
 }
 
 export function mdCategoriesDir(): string {

--- a/src/skill.ts
+++ b/src/skill.ts
@@ -7,33 +7,44 @@ import { promptText } from './prompt.js';
 
 const FRONTMATTER = `---
 name: fieldtheory
-description: Search the user's local X/Twitter bookmarks for content relevant to their current work. Trigger when the user mentions bookmarks, saved tweets, wants to find something they saved, or asks questions their bookmark history could answer.
+description: Use the user's local Field Theory data, Library markdown, and portable commands. Trigger when the user mentions Field Theory, bookmarks, saved tweets, Library notes, wiki pages, reusable commands, or wants prior local context.
 ---`;
 
 const BODY = `
-# Field Theory — Contextual Bookmark Search
+# Field Theory — Local Context
 
-Search the user's local X/Twitter bookmark archive for content relevant to the current task.
+Use the Field Theory CLI to inspect and work with the user's local context.
+
+Field Theory has three main local surfaces:
+
+- bookmarks: raw synced X/Twitter bookmark data
+- library: readable markdown knowledge and authored notes
+- commands: portable markdown actions in \`~/.fieldtheory/commands\`
 
 ## When to trigger
 
+- User mentions Field Theory, the Library, wiki pages, portable commands, or reusable workflows
 - User mentions bookmarks, saved tweets, or X/Twitter content they saved
 - User asks to find something they bookmarked ("find that tweet about...")
 - User asks a question their bookmarks could answer ("what AI tools have I been looking at?")
-- User wants bookmark stats, patterns, or insights
-- Starting a task where the user's reading history adds context
+- User wants prior notes, local decisions, command files, stats, patterns, or insights
+- Starting non-trivial work where local history may add context
 
 ## Workflow
 
-1. Look at what the user is working on (conversation, open files, branch name)
-2. Generate 2-3 targeted search queries
-3. Run \`ft search <query>\` for each
-4. Narrow with filters if needed
-5. Summarize what you found — highlight relevant bookmarks, note patterns
+1. Check paths and status when setup matters: \`ft paths --json\`, \`ft status --json\`
+2. Search durable notes first when prior project knowledge matters: \`ft library search <query> --json\`
+3. Search bookmarks when reading history or saved X/Twitter posts matter: \`ft search <query> --json\`
+4. Inspect exact files or bookmarks with \`ft library show <path> --json\`, \`ft show <id> --json\`, or \`ft commands show <name> --json\`
+5. Create or update durable Library notes and portable commands only when the user asks for a saved artifact
+6. Open useful Library pages in the Mac app with \`ft library open <path>\`
 
 ## Commands
 
 \`\`\`bash
+ft paths --json                # Canonical bookmarks, library, commands paths
+ft status --json               # Bookmark/classification status plus paths
+
 ft search <query>              # Full-text BM25 search ("exact phrase", AND, OR, NOT)
 ft list --category <cat>       # tool, technique, research, opinion, launch, security, commerce
 ft list --domain <dom>         # ai, web-dev, startups, finance, design, devops, marketing, etc.
@@ -42,16 +53,29 @@ ft list --after/--before DATE  # Date range (YYYY-MM-DD)
 ft stats                       # Collection overview
 ft viz                         # Terminal dashboard
 ft show <id>                   # Full detail for one bookmark
+
+ft library search <query>      # Search Field Theory Library markdown
+ft library show <path>         # Read one Library page
+ft library create <path>       # Create a Library page
+ft library update <path>       # Replace a Library page with --stdin/--file plus guard
+ft library open <path>         # Open a Library page in the Mac app
+
+ft commands list               # List portable command markdown files
+ft commands show <name>        # Read one command
+ft commands new <name>         # Create a new command
+ft commands validate [name]    # Check command shape
 \`\`\`
 
 Combine filters: \`ft list --category tool --domain ai --limit 10\`
 
 ## Guidelines
 
-- Start broad, narrow with filters
-- Don't dump raw output — summarize and connect findings to the user's current work
+- Prefer JSON output when you need to inspect or cite exact fields
+- Start with Library pages for durable project knowledge, then search bookmarks for source material
+- Don't dump raw output; summarize and connect findings to the user's current work
 - Cross-reference multiple queries to build a complete picture
-- Look for recurring authors, topic clusters, and connections between bookmarks
+- For updates, use \`--expected-sha256\` from a prior \`show --json\` result or pass \`--force\` only when explicitly appropriate
+- Deletes move local files to Trash; the Mac app owns Library sync and remote tombstones
 `;
 
 /** Full skill file with YAML frontmatter (for Claude Code commands). */

--- a/src/skill.ts
+++ b/src/skill.ts
@@ -75,6 +75,7 @@ Combine filters: \`ft list --category tool --domain ai --limit 10\`
 - Don't dump raw output; summarize and connect findings to the user's current work
 - Cross-reference multiple queries to build a complete picture
 - For updates, use \`--expected-sha256\` from a prior \`show --json\` result or pass \`--force\` only when explicitly appropriate
+- In local app development, set \`FT_APP_DEV_DIR\` before \`ft library open\` so the CLI targets the Field Theory dev checkout instead of a generic Electron URL handler
 - Deletes move local files to Trash; the Mac app owns Library sync and remote tombstones
 `;
 

--- a/tests/app-install.test.ts
+++ b/tests/app-install.test.ts
@@ -1,0 +1,109 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { installFieldTheoryApp, selectFieldTheoryDmgAsset } from '../src/app-install.js';
+
+test('selectFieldTheoryDmgAsset prefers the arm64 DMG', () => {
+  const asset = selectFieldTheoryDmgAsset({
+    tag_name: 'v0.1.103',
+    assets: [
+      { name: 'Field.Theory-0.1.103-arm64-mac.zip', browser_download_url: 'https://example.com/app.zip' },
+      { name: 'Field.Theory-0.1.103.dmg', browser_download_url: 'https://example.com/app-universal.dmg' },
+      { name: 'Field.Theory-0.1.103-arm64.dmg', browser_download_url: 'https://example.com/app-arm64.dmg' },
+    ],
+  });
+
+  assert.equal(asset.name, 'Field.Theory-0.1.103-arm64.dmg');
+});
+
+test('selectFieldTheoryDmgAsset reports available assets when no DMG exists', () => {
+  assert.throws(() => selectFieldTheoryDmgAsset({
+    tag_name: 'v0.1.103',
+    assets: [
+      { name: 'Field.Theory-0.1.103-arm64-mac.zip', browser_download_url: 'https://example.com/app.zip' },
+      { name: 'latest-mac.yml', browser_download_url: 'https://example.com/latest-mac.yml' },
+    ],
+  }), /no downloadable DMG asset.*latest-mac\.yml/);
+});
+
+test('installFieldTheoryApp rejects non-macOS before network or installer work', async () => {
+  let fetched = false;
+  let executed = false;
+
+  await assert.rejects(() => installFieldTheoryApp({
+    platform: 'linux',
+    fetch: (async () => {
+      fetched = true;
+      throw new Error('should not fetch');
+    }) as typeof fetch,
+    execFile: async () => {
+      executed = true;
+      return { stdout: '', stderr: '' };
+    },
+  }), /only supported on macOS/);
+
+  assert.equal(fetched, false);
+  assert.equal(executed, false);
+});
+
+test('installFieldTheoryApp downloads, mounts, copies, and detaches with injected runners', async () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ft-app-install-test-'));
+  const installDir = path.join(tmpDir, 'Applications');
+  const calls: Array<{ file: string; args: readonly string[] }> = [];
+
+  const fetcher = (async (url: string) => {
+    if (url === 'https://example.com/latest') {
+      return new Response(JSON.stringify({
+        tag_name: 'v1.2.3',
+        assets: [
+          {
+            name: 'Field.Theory-1.2.3-arm64.dmg',
+            browser_download_url: 'https://example.com/Field.Theory-1.2.3-arm64.dmg',
+          },
+        ],
+      }), { status: 200 });
+    }
+    if (url === 'https://example.com/Field.Theory-1.2.3-arm64.dmg') {
+      return new Response('fake dmg bytes', { status: 200 });
+    }
+    return new Response('not found', { status: 404, statusText: 'Not Found' });
+  }) as typeof fetch;
+
+  const execFile = async (file: string, args: readonly string[]) => {
+    calls.push({ file, args });
+    if (file === 'hdiutil' && args[0] === 'attach') {
+      const mountPoint = String(args[args.indexOf('-mountpoint') + 1]);
+      const appContents = path.join(mountPoint, 'Field Theory.app', 'Contents');
+      fs.mkdirSync(appContents, { recursive: true });
+      fs.writeFileSync(path.join(appContents, 'Info.plist'), 'fake plist');
+    }
+    if (file === 'ditto') {
+      fs.cpSync(String(args[0]), String(args[1]), { recursive: true });
+    }
+    return { stdout: '', stderr: '' };
+  };
+
+  try {
+    const result = await installFieldTheoryApp({
+      platform: 'darwin',
+      fetch: fetcher,
+      execFile,
+      installDir,
+      releaseApiUrl: 'https://example.com/latest',
+      env: {},
+    });
+
+    assert.equal(result.release, 'v1.2.3');
+    assert.equal(result.assetName, 'Field.Theory-1.2.3-arm64.dmg');
+    assert.equal(result.appPath, path.join(installDir, 'Field Theory.app'));
+    assert.equal(fs.existsSync(path.join(result.appPath, 'Contents', 'Info.plist')), true);
+    assert.deepEqual(calls.map((call) => call.file), ['hdiutil', 'ditto', 'hdiutil']);
+    assert.equal(calls[0].args[0], 'attach');
+    assert.equal(calls[2].args[0], 'detach');
+    assert.ok(String(calls[1].args[0]).endsWith(path.join('mount', 'Field Theory.app')));
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});

--- a/tests/app-open.test.ts
+++ b/tests/app-open.test.ts
@@ -1,0 +1,35 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { buildFieldTheoryOpenTarget } from '../src/app-open.js';
+
+test('app-open builds Field Theory wiki URL for library paths', () => {
+  const previous = process.env.FT_LIBRARY_DIR;
+  process.env.FT_LIBRARY_DIR = '/tmp/ft-library';
+  try {
+    const target = buildFieldTheoryOpenTarget('entries/hello', 'library');
+    assert.equal(target.kind, 'library');
+    assert.equal(target.supported, true);
+    assert.equal(target.path, path.join('/tmp/ft-library', 'entries', 'hello.md'));
+    assert.ok(target.url?.startsWith('fieldtheory://wiki/open?'));
+    assert.ok(target.url?.includes('immersive=true'));
+  } finally {
+    if (previous === undefined) delete process.env.FT_LIBRARY_DIR;
+    else process.env.FT_LIBRARY_DIR = previous;
+  }
+});
+
+test('app-open reports command paths as unsupported deep links', () => {
+  const previous = process.env.FT_COMMANDS_DIR;
+  process.env.FT_COMMANDS_DIR = '/tmp/ft-commands';
+  try {
+    const target = buildFieldTheoryOpenTarget('review', 'command');
+    assert.equal(target.kind, 'command');
+    assert.equal(target.supported, false);
+    assert.equal(target.url, null);
+    assert.equal(target.path, path.join('/tmp/ft-commands', 'review.md'));
+  } finally {
+    if (previous === undefined) delete process.env.FT_COMMANDS_DIR;
+    else process.env.FT_COMMANDS_DIR = previous;
+  }
+});

--- a/tests/app-open.test.ts
+++ b/tests/app-open.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import path from 'node:path';
-import { buildFieldTheoryOpenTarget } from '../src/app-open.js';
+import { buildFieldTheoryOpenTarget, openFieldTheoryTarget } from '../src/app-open.js';
 
 test('app-open builds Field Theory wiki URL for library paths', () => {
   const previous = process.env.FT_LIBRARY_DIR;
@@ -32,4 +32,55 @@ test('app-open reports command paths as unsupported deep links', () => {
     if (previous === undefined) delete process.env.FT_COMMANDS_DIR;
     else process.env.FT_COMMANDS_DIR = previous;
   }
+});
+
+test('app-open targets packaged Field Theory bundle instead of bare URL handler', () => {
+  const target = {
+    kind: 'library' as const,
+    path: '/tmp/ft-library/page.md',
+    url: 'fieldtheory://wiki/open?file=%2Ftmp%2Fft-library%2Fpage.md&immersive=true',
+    supported: true,
+  };
+  const calls: Array<{ command: string; args: string[] }> = [];
+
+  const result = openFieldTheoryTarget(target, {
+    platform: 'darwin',
+    env: {},
+    spawn: (command, args) => {
+      calls.push({ command, args });
+      return { status: 0 };
+    },
+  });
+
+  assert.deepEqual(result, { launched: true, method: 'bundle' });
+  assert.deepEqual(calls, [{
+    command: 'open',
+    args: ['-b', 'com.fieldtheory.app', target.url],
+  }]);
+});
+
+test('app-open supports explicit development checkout launcher', () => {
+  const target = {
+    kind: 'library' as const,
+    path: '/tmp/ft-library/page.md',
+    url: 'fieldtheory://wiki/open?file=%2Ftmp%2Fft-library%2Fpage.md&immersive=true',
+    supported: true,
+  };
+  const calls: Array<{ command: string; args: string[]; cwd?: string }> = [];
+
+  const result = openFieldTheoryTarget(target, {
+    platform: 'darwin',
+    env: { FT_APP_DEV_DIR: '/tmp/fieldtheory/mac-app' },
+    spawn: (command, args, options) => {
+      calls.push({ command, args, cwd: options.cwd });
+      return { status: 0 };
+    },
+  });
+
+  assert.deepEqual(result, { launched: true, method: 'dev-dir' });
+  assert.deepEqual(calls, [{
+    command: path.join('/tmp/fieldtheory/mac-app', 'node_modules', '.bin', 'electron'),
+    args: ['/tmp/fieldtheory/mac-app', target.url],
+    cwd: '/tmp/fieldtheory/mac-app',
+  }]);
 });

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -73,11 +73,23 @@ test('ft search, stats, and status expose --json', () => {
   }
 });
 
-test('ft paths, library, commands, and app command groups are registered', () => {
+test('ft paths, library, commands, app, and install command groups are registered', () => {
   const program = buildCli();
-  for (const name of ['paths', 'library', 'commands', 'app']) {
+  for (const name of ['paths', 'library', 'commands', 'app', 'install']) {
     assert.ok(program.commands.find((c: any) => c.name() === name), `${name} command should be registered`);
   }
+});
+
+test('ft install app command is registered', () => {
+  const program = buildCli();
+  const installCmd = program.commands.find((c: any) => c.name() === 'install');
+  assert.ok(installCmd, 'install command should be registered');
+  const appCmd = installCmd.commands.find((c: any) => c.name() === 'app');
+  assert.ok(appCmd, 'install app command should be registered');
+  const opts = appCmd.options.map((o: any) => o.long);
+  assert.ok(opts.includes('--install-dir'));
+  assert.ok(opts.includes('--open'));
+  assert.ok(opts.includes('--json'));
 });
 
 test('ft sync: media is on by default and exposes --no-media', () => {

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -63,6 +63,23 @@ test('ft wiki: --engine option is registered', () => {
   assert.ok(opts.includes('--engine'), `expected --engine among ${opts.join(', ')}`);
 });
 
+test('ft search, stats, and status expose --json', () => {
+  const program = buildCli();
+  for (const name of ['search', 'stats', 'status']) {
+    const cmd = program.commands.find((c: any) => c.name() === name);
+    assert.ok(cmd, `${name} command should be registered`);
+    const opts = cmd.options.map((o: any) => o.long);
+    assert.ok(opts.includes('--json'), `expected --json on ft ${name}`);
+  }
+});
+
+test('ft paths, library, commands, and app command groups are registered', () => {
+  const program = buildCli();
+  for (const name of ['paths', 'library', 'commands', 'app']) {
+    assert.ok(program.commands.find((c: any) => c.name() === name), `${name} command should be registered`);
+  }
+});
+
 test('ft sync: media is on by default and exposes --no-media', () => {
   const program = buildCli();
   const syncCmd = program.commands.find((c: any) => c.name() === 'sync');
@@ -96,6 +113,36 @@ test('ft path: prints only the data directory', async () => {
     assert.equal(output, `${dataDir()}\n`);
   } finally {
     process.env.FT_DATA_DIR = origEnv;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test('ft paths --json prints canonical roots', async () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ft-paths-'));
+  const origEnv = {
+    FT_DATA_DIR: process.env.FT_DATA_DIR,
+    FT_LIBRARY_DIR: process.env.FT_LIBRARY_DIR,
+    FT_COMMANDS_DIR: process.env.FT_COMMANDS_DIR,
+  };
+  process.env.FT_DATA_DIR = path.join(tmpDir, 'bookmarks');
+  process.env.FT_LIBRARY_DIR = path.join(tmpDir, 'library');
+  process.env.FT_COMMANDS_DIR = path.join(tmpDir, 'commands');
+  fs.mkdirSync(process.env.FT_DATA_DIR, { recursive: true });
+  fs.writeFileSync(path.join(process.env.FT_DATA_DIR, '.update-check'), '0.0.0');
+
+  try {
+    const output = await captureStdout(async () => {
+      await buildCli().parseAsync(['node', 'ft', 'paths', '--json']);
+    });
+    const parsed = JSON.parse(output);
+    assert.equal(parsed.canonical.bookmarksDir, process.env.FT_DATA_DIR);
+    assert.equal(parsed.canonical.libraryDir, process.env.FT_LIBRARY_DIR);
+    assert.equal(parsed.canonical.commandsDir, process.env.FT_COMMANDS_DIR);
+  } finally {
+    for (const [key, value] of Object.entries(origEnv)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
     fs.rmSync(tmpDir, { recursive: true, force: true });
   }
 });

--- a/tests/commands-files.test.ts
+++ b/tests/commands-files.test.ts
@@ -1,0 +1,108 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  createCommandDocument,
+  deleteCommandDocument,
+  listCommandDocuments,
+  renameCommandDocument,
+  showCommandDocument,
+  updateCommandDocument,
+  validateCommandContent,
+  validateCommandDocument,
+} from '../src/commands-files.js';
+
+async function withCommandsRoot(fn: (root: string, home: string) => Promise<void>): Promise<void> {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'ft-commands-'));
+  const root = path.join(tmp, 'commands');
+  const home = path.join(tmp, 'home');
+  const previous = {
+    FT_COMMANDS_DIR: process.env.FT_COMMANDS_DIR,
+    HOME: process.env.HOME,
+  };
+  process.env.FT_COMMANDS_DIR = root;
+  process.env.HOME = home;
+  try {
+    await fn(root, home);
+  } finally {
+    if (previous.FT_COMMANDS_DIR === undefined) delete process.env.FT_COMMANDS_DIR;
+    else process.env.FT_COMMANDS_DIR = previous.FT_COMMANDS_DIR;
+    if (previous.HOME === undefined) delete process.env.HOME;
+    else process.env.HOME = previous.HOME;
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+}
+
+const goodCommand = [
+  '# review',
+  '',
+  'Review the current work.',
+  '',
+  'Use this when checking a change.',
+  '',
+  '## Steps',
+  '',
+  '1. Inspect the diff.',
+  '2. Run focused tests.',
+  '',
+  '## Guardrails',
+  '',
+  '- Do not include secrets.',
+  '',
+  '## Verification',
+  '',
+  '- Confirm the tests pass.',
+  '',
+].join('\n');
+
+test('commands CRUD stays under canonical commands root and validates shape', async () => {
+  await withCommandsRoot(async (root, home) => {
+    const created = await createCommandDocument('review', { content: goodCommand });
+    assert.equal(created.name, 'review');
+    assert.equal(created.relPath, 'review.md');
+
+    const listed = listCommandDocuments();
+    assert.equal(listed.length, 1);
+    assert.equal(listed[0].name, 'review');
+
+    const validation = validateCommandDocument('review');
+    assert.equal(validation.length, 1);
+    assert.equal(validation[0].ok, true);
+
+    await assert.rejects(
+      updateCommandDocument('review', { content: '# Changed\n' }),
+      /Refusing to overwrite/,
+    );
+
+    const shown = await showCommandDocument('review');
+    const updated = await updateCommandDocument('review', {
+      content: goodCommand.replace('Review the current work.', 'Review recent work.'),
+      expectedSha256: shown.version.sha256,
+    });
+    assert.match(updated.content, /Review recent work/);
+
+    const renamed = await renameCommandDocument('review', 'second-review');
+    assert.equal(renamed.name, 'second-review');
+    assert.equal(fs.existsSync(path.join(root, 'review.md')), false);
+
+    const trashed = deleteCommandDocument('second-review');
+    assert.equal(path.dirname(trashed.trashPath), path.join(home, '.Trash'));
+    assert.equal(fs.existsSync(trashed.trashPath), true);
+  });
+});
+
+test('commands reject unsafe names and flag weak command content', async () => {
+  await withCommandsRoot(async () => {
+    await assert.rejects(createCommandDocument('../escape', { content: 'bad' }), /Invalid command name/);
+    await assert.rejects(createCommandDocument('.hidden', { content: 'bad' }), /Invalid command name/);
+    await assert.rejects(createCommandDocument('_hidden', { content: 'bad' }), /Invalid command name/);
+    assert.deepEqual(validateCommandContent('# weak\n'), [
+      'Missing "Use this when" guidance.',
+      'Missing ## Steps section.',
+      'Missing ## Guardrails or ## Safety section.',
+      'Missing concrete verification guidance.',
+    ]);
+  });
+});

--- a/tests/engine.test.ts
+++ b/tests/engine.test.ts
@@ -479,7 +479,7 @@ sleep 30
 // ── Secret redaction ──────────────────────────────────────────────────
 //
 // Defense-in-depth: child stderr can in principle contain a secret, and we
-// write stderr tails to ~/.ft-bookmarks/md/log.md. Redact high-confidence
+// write stderr tails to ~/.fieldtheory/library/log.md. Redact high-confidence
 // shapes before they're stored on EngineInvocationError or logged.
 
 test('redactSecrets: masks provider-prefixed API keys', async () => {

--- a/tests/library.test.ts
+++ b/tests/library.test.ts
@@ -1,0 +1,81 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  createLibraryDocument,
+  deleteLibraryDocument,
+  listLibraryDocuments,
+  renameLibraryDocument,
+  searchLibraryDocuments,
+  showLibraryDocument,
+  updateLibraryDocument,
+} from '../src/library.js';
+
+async function withLibraryRoot(fn: (root: string, home: string) => Promise<void>): Promise<void> {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'ft-library-'));
+  const root = path.join(tmp, 'library');
+  const home = path.join(tmp, 'home');
+  const previous = {
+    FT_LIBRARY_DIR: process.env.FT_LIBRARY_DIR,
+    HOME: process.env.HOME,
+  };
+  process.env.FT_LIBRARY_DIR = root;
+  process.env.HOME = home;
+  try {
+    await fn(root, home);
+  } finally {
+    if (previous.FT_LIBRARY_DIR === undefined) delete process.env.FT_LIBRARY_DIR;
+    else process.env.FT_LIBRARY_DIR = previous.FT_LIBRARY_DIR;
+    if (previous.HOME === undefined) delete process.env.HOME;
+    else process.env.HOME = previous.HOME;
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+}
+
+test('library CRUD stays under canonical library root and uses conflict guards', async () => {
+  await withLibraryRoot(async (root, home) => {
+    const created = await createLibraryDocument('entries/test-note', { content: '# Test Note\n\nhello world\n' });
+    assert.equal(created.relPath, 'entries/test-note.md');
+    assert.equal(created.content.includes('hello world'), true);
+
+    const listed = listLibraryDocuments();
+    assert.equal(listed.length, 1);
+    assert.equal(listed[0].relPath, 'entries/test-note.md');
+
+    const searched = searchLibraryDocuments('hello');
+    assert.equal(searched.length, 1);
+    assert.match(searched[0].snippet, /hello world/);
+
+    await assert.rejects(
+      updateLibraryDocument('entries/test-note', { content: '# Changed\n' }),
+      /Refusing to overwrite/,
+    );
+
+    const shown = await showLibraryDocument('entries/test-note');
+    const updated = await updateLibraryDocument('entries/test-note', {
+      content: '# Changed\n',
+      expectedSha256: shown.version.sha256,
+    });
+    assert.equal(updated.content, '# Changed\n');
+
+    const renamed = await renameLibraryDocument('entries/test-note', 'scratchpad/renamed-note');
+    assert.equal(renamed.relPath, 'scratchpad/renamed-note.md');
+    assert.equal(fs.existsSync(path.join(root, 'entries', 'test-note.md')), false);
+
+    const trashed = deleteLibraryDocument('scratchpad/renamed-note');
+    assert.equal(fs.existsSync(path.join(root, 'scratchpad', 'renamed-note.md')), false);
+    assert.equal(path.dirname(trashed.trashPath), path.join(home, '.Trash'));
+    assert.equal(fs.existsSync(trashed.trashPath), true);
+  });
+});
+
+test('library rejects traversal paths', async () => {
+  await withLibraryRoot(async () => {
+    await assert.rejects(
+      createLibraryDocument('../escape', { content: 'bad' }),
+      /Invalid Library path/,
+    );
+  });
+});

--- a/tests/paths.test.ts
+++ b/tests/paths.test.ts
@@ -1,0 +1,56 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import os from 'node:os';
+import { dataDir, libraryDir, mdDir, commandsDir, mdSchemaPath } from '../src/paths.js';
+
+function withEnv(env: Record<string, string | undefined>, fn: () => void): void {
+  const previous: Record<string, string | undefined> = {};
+  for (const key of Object.keys(env)) {
+    previous[key] = process.env[key];
+    if (env[key] === undefined) delete process.env[key];
+    else process.env[key] = env[key];
+  }
+  try {
+    fn();
+  } finally {
+    for (const key of Object.keys(env)) {
+      if (previous[key] === undefined) delete process.env[key];
+      else process.env[key] = previous[key];
+    }
+  }
+}
+
+test('paths: env overrides split data, library, and commands roots', () => {
+  withEnv({
+    FT_DATA_DIR: '/tmp/ft-data',
+    FT_LIBRARY_DIR: '/tmp/ft-library',
+    FT_COMMANDS_DIR: '/tmp/ft-commands',
+  }, () => {
+    assert.equal(dataDir(), '/tmp/ft-data');
+    assert.equal(libraryDir(), '/tmp/ft-library');
+    assert.equal(mdDir(), '/tmp/ft-library');
+    assert.equal(commandsDir(), '/tmp/ft-commands');
+    assert.equal(mdSchemaPath(), path.join('/tmp/ft-library', 'schema.md'));
+  });
+});
+
+test('paths: FT_DATA_DIR keeps the legacy md child unless FT_LIBRARY_DIR is set', () => {
+  withEnv({
+    FT_DATA_DIR: '/tmp/ft-data',
+    FT_LIBRARY_DIR: undefined,
+    FT_COMMANDS_DIR: undefined,
+  }, () => {
+    assert.equal(dataDir(), '/tmp/ft-data');
+    assert.equal(libraryDir(), '/tmp/ft-data/md');
+    assert.equal(mdDir(), '/tmp/ft-data/md');
+  });
+});
+
+test('paths: default command root is under ~/.fieldtheory', () => {
+  withEnv({
+    FT_COMMANDS_DIR: undefined,
+  }, () => {
+    assert.equal(commandsDir(), path.join(os.homedir(), '.fieldtheory', 'commands'));
+  });
+});

--- a/tests/paths.test.ts
+++ b/tests/paths.test.ts
@@ -2,7 +2,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import path from 'node:path';
 import os from 'node:os';
-import { dataDir, libraryDir, mdDir, commandsDir, mdSchemaPath } from '../src/paths.js';
+import { canonicalCommandsDir, canonicalDataDir, canonicalLibraryDir, dataDir, libraryDir, mdDir, commandsDir, mdSchemaPath } from '../src/paths.js';
 
 function withEnv(env: Record<string, string | undefined>, fn: () => void): void {
   const previous: Record<string, string | undefined> = {};
@@ -31,6 +31,9 @@ test('paths: env overrides split data, library, and commands roots', () => {
     assert.equal(libraryDir(), '/tmp/ft-library');
     assert.equal(mdDir(), '/tmp/ft-library');
     assert.equal(commandsDir(), '/tmp/ft-commands');
+    assert.equal(canonicalDataDir(), '/tmp/ft-data');
+    assert.equal(canonicalLibraryDir(), '/tmp/ft-library');
+    assert.equal(canonicalCommandsDir(), '/tmp/ft-commands');
     assert.equal(mdSchemaPath(), path.join('/tmp/ft-library', 'schema.md'));
   });
 });

--- a/tests/skill.test.ts
+++ b/tests/skill.test.ts
@@ -20,10 +20,16 @@ describe('skill content', () => {
 
   it('both versions include key commands', () => {
     for (const content of [skillWithFrontmatter(), skillBody()]) {
+      assert.ok(content.includes('ft paths --json'));
+      assert.ok(content.includes('ft status --json'));
       assert.ok(content.includes('ft search'));
       assert.ok(content.includes('ft list'));
       assert.ok(content.includes('ft stats'));
       assert.ok(content.includes('ft show'));
+      assert.ok(content.includes('ft library search'));
+      assert.ok(content.includes('ft library show'));
+      assert.ok(content.includes('ft commands list'));
+      assert.ok(content.includes('ft commands validate'));
     }
   });
 


### PR DESCRIPTION
## Summary
- Use the Field Theory path contract for bookmarks, Library markdown, and portable commands, while preserving legacy fallbacks.
- Add app-companion CLI surfaces for paths/status JSON, Library search/show/create/update/delete/open, portable command CRUD/validation, and app open targets.
- Add `ft install app` to fetch the latest DMG from `afar1/field-releases`, mount it, replace the installed app bundle, and optionally open Field Theory.
- Update the generated Field Theory skill and README so agents and humans know how to use the new surfaces.

## Commits
- 7f74889 Use Field Theory path contract
- 079b62c Add Field Theory companion CLI commands
- 58bf728 Avoid generic Electron URL launches
- 8e2de65 Add Field Theory app install command

## Checks
- npm run build
- npm run test (321 passing)
- node dist/cli.js paths --json
- node dist/cli.js app open /Users/afar/.fieldtheory/library/example.md --kind library --no-launch --json
- node dist/cli.js install app --help
- Live GitHub release lookup selected `v0.1.104` / `Field.Theory-0.1.104-arm64.dmg`