### PR TITLE
[codex] Add ft recent agent context

### DIFF
--- a/src/agent-context.ts
+++ b/src/agent-context.ts
@@ -71,6 +71,16 @@ function collectFallbackFiles(dir: string, root: string, limit: number, depth = 
 
 export function getAgentContext(repoPath = process.cwd(), limit = 10): AgentContext {
   const cwd = path.resolve(repoPath);
+  let stat: fs.Stats;
+  try {
+    stat = fs.statSync(cwd);
+  } catch {
+    throw new Error(`Repo path not found: ${cwd}`);
+  }
+  if (!stat.isDirectory()) {
+    throw new Error(`Repo path is not a directory: ${cwd}`);
+  }
+
   const candidates = tryGitFiles(cwd);
   const relPaths = candidates.length > 0 ? candidates : collectFallbackFiles(cwd, cwd, 500);
   const recentFiles = relPaths

--- a/src/agent-context.ts
+++ b/src/agent-context.ts
@@ -1,0 +1,113 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { execFileSync } from 'node:child_process';
+
+const SKIP_DIRS = new Set([
+  '.git', 'node_modules', '.next', 'dist', 'build', 'out', 'coverage',
+  '.turbo', '.cache', '__pycache__', '.venv', 'venv', 'DerivedData',
+]);
+
+const SKIP_EXTENSIONS = new Set([
+  '.png', '.jpg', '.jpeg', '.gif', '.webp', '.avif', '.mp4', '.mov',
+  '.mp3', '.wav', '.pdf', '.zip', '.tar', '.gz', '.wasm', '.bin',
+]);
+
+export type AgentContextFile = {
+  path: string;
+  modifiedAt: string;
+};
+
+export type AgentContext = {
+  cwd: string;
+  lastModifiedFile: AgentContextFile | null;
+  recentFiles: AgentContextFile[];
+};
+
+function tryGitFiles(repoPath: string): string[] {
+  try {
+    return execFileSync('git', ['ls-files', '-co', '--exclude-standard'], {
+      cwd: repoPath,
+      encoding: 'utf-8',
+      timeout: 10_000,
+      stdio: ['pipe', 'pipe', 'ignore'],
+    })
+      .split('\n')
+      .map((line) => line.trim())
+      .filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
+function shouldSkipFile(relPath: string): boolean {
+  const parts = relPath.split(path.sep);
+  if (parts.some((part) => SKIP_DIRS.has(part))) return true;
+  return SKIP_EXTENSIONS.has(path.extname(relPath).toLowerCase());
+}
+
+function collectFallbackFiles(dir: string, root: string, limit: number, depth = 0): string[] {
+  if (depth > 6) return [];
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+
+  const results: string[] = [];
+  for (const entry of entries) {
+    if (results.length >= limit) break;
+    const fullPath = path.join(dir, entry.name);
+    const relPath = path.relative(root, fullPath);
+    if (entry.isDirectory()) {
+      if (SKIP_DIRS.has(entry.name) || entry.name.startsWith('.')) continue;
+      results.push(...collectFallbackFiles(fullPath, root, limit - results.length, depth + 1));
+    } else if (entry.isFile() && !shouldSkipFile(relPath)) {
+      results.push(relPath);
+    }
+  }
+  return results;
+}
+
+export function getAgentContext(repoPath = process.cwd(), limit = 10): AgentContext {
+  const cwd = path.resolve(repoPath);
+  const candidates = tryGitFiles(cwd);
+  const relPaths = candidates.length > 0 ? candidates : collectFallbackFiles(cwd, cwd, 500);
+  const recentFiles = relPaths
+    .filter((relPath) => !shouldSkipFile(relPath))
+    .map((relPath) => {
+      try {
+        const stat = fs.statSync(path.join(cwd, relPath));
+        if (!stat.isFile()) return null;
+        return {
+          path: relPath,
+          modifiedAt: stat.mtime.toISOString(),
+        };
+      } catch {
+        return null;
+      }
+    })
+    .filter((file): file is AgentContextFile => file !== null)
+    .sort((a, b) => b.modifiedAt.localeCompare(a.modifiedAt))
+    .slice(0, limit);
+
+  return {
+    cwd,
+    lastModifiedFile: recentFiles[0] ?? null,
+    recentFiles,
+  };
+}
+
+export function formatAgentContext(context: AgentContext): string {
+  const lines = [`cwd: ${context.cwd}`];
+  lines.push(`lastModifiedFile: ${context.lastModifiedFile?.path ?? '(none)'}`);
+  lines.push('recentFiles:');
+  if (context.recentFiles.length === 0) {
+    lines.push('  (none)');
+  } else {
+    for (const file of context.recentFiles) {
+      lines.push(`  ${file.modifiedAt}  ${file.path}`);
+    }
+  }
+  return `${lines.join('\n')}\n`;
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { Command, Option } from 'commander';
+import { Command, InvalidArgumentError, Option } from 'commander';
 import { syncTwitterBookmarks } from './bookmarks.js';
 import { getBookmarkStatusView, formatBookmarkStatus } from './bookmarks-service.js';
 import { runTwitterOAuthFlow } from './xauth.js';
@@ -655,6 +655,14 @@ function safe(fn: (...args: any[]) => Promise<void>): (...args: any[]) => Promis
       process.exitCode = 1;
     }
   };
+}
+
+function parsePositiveInteger(value: string): number {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 1) {
+    throw new InvalidArgumentError('value must be a positive integer');
+  }
+  return parsed;
 }
 
 // ── CLI ─────────────────────────────────────────────────────────────────────
@@ -1482,16 +1490,16 @@ export function buildCli() {
     .command('recent')
     .description('Show the current repo files an agent can use for "that file" references')
     .option('--repo <path>', 'Repo path to inspect (default: cwd)')
-    .option('--limit <n>', 'Number of recent files to show', (v: string) => Number(v), 10)
+    .option('--limit <n>', 'Number of recent files to show', parsePositiveInteger, 10)
     .option('--json', 'JSON output')
-    .action((options) => {
-      const context = getAgentContext(options.repo ?? process.cwd(), Number(options.limit) || 10);
+    .action(safe(async (options) => {
+      const context = getAgentContext(options.repo ?? process.cwd(), options.limit);
       if (options.json) {
         printJson(context);
         return;
       }
       process.stdout.write(formatAgentContext(context));
-    });
+    }));
 
   registerCompanionCommands(program, safe);
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -38,6 +38,7 @@ import { PromptCancelledError, promptText } from './prompt.js';
 import { skillWithFrontmatter, installSkill, uninstallSkill } from './skill.js';
 import { registerCompanionCommands } from './companion-cli.js';
 import { getPathReport } from './field-status.js';
+import { formatAgentContext, getAgentContext } from './agent-context.js';
 import {
   formatIdeasIntro,
   formatRunList,
@@ -423,7 +424,7 @@ function isInternalWorkerCommand(command: Command): boolean {
 function shouldSkipCommandChrome(command: Command): boolean {
   if (isInternalWorkerCommand(command)) return true;
   if (command.opts().json) return true;
-  if (command.name() === 'path' || command.name() === 'paths') return true;
+  if (command.name() === 'path' || command.name() === 'paths' || command.name() === 'recent') return true;
   if (command.name() === 'show' && command.parent?.name() === 'skill') return true;
   return false;
 }
@@ -1476,6 +1477,21 @@ export function buildCli() {
     .command('path')
     .description('Print the data directory path')
     .action(() => { console.log(dataDir()); });
+
+  program
+    .command('recent')
+    .description('Show the current repo files an agent can use for "that file" references')
+    .option('--repo <path>', 'Repo path to inspect (default: cwd)')
+    .option('--limit <n>', 'Number of recent files to show', (v: string) => Number(v), 10)
+    .option('--json', 'JSON output')
+    .action((options) => {
+      const context = getAgentContext(options.repo ?? process.cwd(), Number(options.limit) || 10);
+      if (options.json) {
+        printJson(context);
+        return;
+      }
+      process.stdout.write(formatAgentContext(context));
+    });
 
   registerCompanionCommands(program, safe);
 

--- a/src/skill.ts
+++ b/src/skill.ts
@@ -19,7 +19,7 @@ Field Theory has three main local surfaces:
 
 - bookmarks: raw synced X/Twitter bookmark data
 - library: readable markdown knowledge and authored notes
-- commands: portable markdown actions in \`~/.fieldtheory/commands\`
+- commands: portable markdown actions in \`~/.fieldtheory/library/Commands\`
 
 ## When to trigger
 
@@ -35,11 +35,12 @@ Field Theory has three main local surfaces:
 ## Search Workflow
 
 1. Check paths and status when setup matters: \`ft paths --json\`, \`ft status --json\`
-2. Search durable notes first when prior project knowledge matters: \`ft library search <query> --json\`
-3. Search bookmarks when reading history or saved X/Twitter posts matter: \`ft search <query> --json\`
-4. Inspect exact files or bookmarks with \`ft library show <path> --json\`, \`ft show <id> --json\`, or \`ft commands show <name> --json\`
-5. Create or update durable Library notes and portable commands only when the user asks for a saved artifact
-6. Open useful Library pages in the Mac app with \`ft library open <path>\`
+2. When the user says "that file" or "the recent file", inspect current repo recency with \`ft recent --json\`
+3. Search durable notes first when prior project knowledge matters: \`ft library search <query> --json\`
+4. Search bookmarks when reading history or saved X/Twitter posts matter: \`ft search <query> --json\`
+5. Inspect exact files or bookmarks with \`ft library show <path> --json\`, \`ft show <id> --json\`, or \`ft commands show <name> --json\`
+6. Create or update durable Library notes and portable commands only when the user asks for a saved artifact
+7. Open useful Library pages in the Mac app with \`ft library open <path>\`
 
 ## Possible Roadmap Workflow
 
@@ -86,6 +87,7 @@ If the user says "debate", use the existing \`ft possible\` pipeline as generate
 \`\`\`bash
 ft paths --json                # Canonical bookmarks, library, commands paths
 ft status --json               # Bookmark/classification status plus paths
+ft recent --json               # Current repo last-modified file and recent files for agent references
 
 ft search <query>              # Full-text BM25 search ("exact phrase", AND, OR, NOT)
 ft list --category <cat>       # tool, technique, research, opinion, launch, security, commerce

--- a/tests/agent-context.test.ts
+++ b/tests/agent-context.test.ts
@@ -1,0 +1,29 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import { formatAgentContext, getAgentContext } from '../src/agent-context.js';
+
+test('getAgentContext returns last modified file and recent files', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ft-agent-context-'));
+  try {
+    const older = path.join(tmpDir, 'older.md');
+    const newer = path.join(tmpDir, 'newer.md');
+    fs.writeFileSync(older, 'old');
+    fs.writeFileSync(newer, 'new');
+    const oldTime = new Date('2026-01-01T00:00:00.000Z');
+    const newTime = new Date('2026-01-02T00:00:00.000Z');
+    fs.utimesSync(older, oldTime, oldTime);
+    fs.utimesSync(newer, newTime, newTime);
+
+    const context = getAgentContext(tmpDir, 2);
+    assert.equal(context.cwd, tmpDir);
+    assert.equal(context.lastModifiedFile?.path, 'newer.md');
+    assert.deepEqual(context.recentFiles.map((file) => file.path), ['newer.md', 'older.md']);
+    assert.match(formatAgentContext(context), /lastModifiedFile: newer\.md/);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});

--- a/tests/agent-context.test.ts
+++ b/tests/agent-context.test.ts
@@ -27,3 +27,25 @@ test('getAgentContext returns last modified file and recent files', () => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   }
 });
+
+test('getAgentContext rejects a missing repo path', () => {
+  const missing = path.join(os.tmpdir(), `ft-agent-context-missing-${Date.now()}`);
+  assert.throws(
+    () => getAgentContext(missing, 2),
+    /Repo path not found/,
+  );
+});
+
+test('getAgentContext rejects a file repo path', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ft-agent-context-file-'));
+  try {
+    const filePath = path.join(tmpDir, 'not-a-directory.md');
+    fs.writeFileSync(filePath, 'hello');
+    assert.throws(
+      () => getAgentContext(filePath, 2),
+      /Repo path is not a directory/,
+    );
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -73,9 +73,9 @@ test('ft search, stats, and status expose --json', () => {
   }
 });
 
-test('ft paths, library, commands, app, and install command groups are registered', () => {
+test('ft paths, recent, library, commands, app, and install command groups are registered', () => {
   const program = buildCli();
-  for (const name of ['paths', 'library', 'commands', 'app', 'install']) {
+  for (const name of ['paths', 'recent', 'library', 'commands', 'app', 'install']) {
     assert.ok(program.commands.find((c: any) => c.name() === name), `${name} command should be registered`);
   }
 });


### PR DESCRIPTION
## Summary
- Adds a direct `ft recent` command that reports the current repo, last modified file, and recent files for agent references like “that file”.
- Supports `--repo`, `--limit`, and `--json`.
- Updates the installed Field Theory skill text to point agents at `ft recent --json`.

## Validation
- npm run build
- npm test -- tests/agent-context.test.ts tests/cli.test.ts
- npm run dev -- recent --repo /Users/afar/dev/fieldtheory --limit 3 --json
