### PR TITLE
Fix interrupt persistence and media retry backoff

### DIFF
--- a/src/bookmark-media.ts
+++ b/src/bookmark-media.ts
@@ -72,6 +72,9 @@ interface CachedMediaResult {
   fetchedAt: string;
 }
 
+const HOUR_MS = 60 * 60_000;
+const DAY_MS = 24 * HOUR_MS;
+
 function mediaEntryKey(tweetId: string, sourceUrl: string, isProfileImage: boolean): string {
   return isProfileImage ? `profile::${sourceUrl}` : `${tweetId}::${sourceUrl}`;
 }
@@ -202,26 +205,46 @@ function resolveMediaTargets(
   return targets;
 }
 
-function isCoveredEntry(entry: MediaFetchEntry, maxBytes: number): boolean {
+function failedEntryBackoffMs(entry: MediaFetchEntry): number {
+  if (entry.reason === 'HTTP 404' && entry.sourceUrl.includes('/profile_images/')) {
+    return 365 * DAY_MS;
+  }
+  if (entry.reason === 'HTTP 403' && (entry.sourceUrl.includes('video.twimg.com') || entry.sourceUrl.includes('/amplify_video/'))) {
+    return 30 * DAY_MS;
+  }
+  if (entry.reason === 'HTTP 404' && entry.sourceUrl.includes('pbs.twimg.com/media/')) {
+    return DAY_MS;
+  }
+  return HOUR_MS;
+}
+
+function isFailedEntryCovered(entry: MediaFetchEntry, nowMs: number): boolean {
+  const fetchedAtMs = new Date(entry.fetchedAt).getTime();
+  if (Number.isNaN(fetchedAtMs)) return false;
+  return nowMs - fetchedAtMs < failedEntryBackoffMs(entry);
+}
+
+function isCoveredEntry(entry: MediaFetchEntry, maxBytes: number, retryFailed: boolean, nowMs: number): boolean {
   if (entry.status === 'downloaded') return true;
+  if (entry.status === 'failed') return !retryFailed && isFailedEntryCovered(entry, nowMs);
   if (entry.status !== 'skipped_too_large') return false;
   return typeof entry.bytes === 'number' && !Number.isNaN(entry.bytes) && entry.bytes > maxBytes;
 }
 
-function buildCoveredAssetKeys(previous: MediaFetchManifest | null, maxBytes: number): Set<string> {
+function buildCoveredAssetKeys(previous: MediaFetchManifest | null, maxBytes: number, retryFailed: boolean, nowMs: number): Set<string> {
   return new Set(
     (previous?.entries ?? [])
       .filter((entry) => !entry.sourceUrl.includes('/profile_images/'))
-      .filter((entry) => isCoveredEntry(entry, maxBytes))
+      .filter((entry) => isCoveredEntry(entry, maxBytes, retryFailed, nowMs))
       .map((entry) => `${entry.tweetId}::${entry.sourceUrl}`),
   );
 }
 
-function buildCoveredProfileImageUrls(previous: MediaFetchManifest | null, maxBytes: number): Set<string> {
+function buildCoveredProfileImageUrls(previous: MediaFetchManifest | null, maxBytes: number, retryFailed: boolean, nowMs: number): Set<string> {
   return new Set(
     (previous?.entries ?? [])
       .filter((entry) => entry.sourceUrl.includes('/profile_images/'))
-      .filter((entry) => isCoveredEntry(entry, maxBytes))
+      .filter((entry) => isCoveredEntry(entry, maxBytes, retryFailed, nowMs))
       .map((entry) => entry.sourceUrl),
   );
 }
@@ -239,20 +262,22 @@ function hasPendingMediaTarget(
 }
 
 export async function fetchBookmarkMediaBatch(
-  options: { limit?: number; maxBytes?: number; skipProfileImages?: boolean; onProgress?: (progress: MediaFetchProgress) => void } = {}
+  options: { limit?: number; maxBytes?: number; skipProfileImages?: boolean; retryFailed?: boolean; signal?: AbortSignal; onProgress?: (progress: MediaFetchProgress) => void } = {}
 ): Promise<MediaFetchManifest> {
   const limit = typeof options.limit === 'number' && !Number.isNaN(options.limit)
     ? Math.max(0, options.limit)
     : Infinity;
   const maxBytes = options.maxBytes ?? DEFAULT_MEDIA_MAX_BYTES;
   const skipProfileImages = options.skipProfileImages ?? false;
+  const retryFailed = options.retryFailed ?? false;
+  const nowMs = Date.now();
   const mediaDir = bookmarkMediaDir();
   const manifestPath = bookmarkMediaManifestPath();
   await ensureDir(mediaDir);
 
   const previous = await loadManifest();
-  const coveredAssetKeys = buildCoveredAssetKeys(previous, maxBytes);
-  const coveredProfileImageUrls = buildCoveredProfileImageUrls(previous, maxBytes);
+  const coveredAssetKeys = buildCoveredAssetKeys(previous, maxBytes, retryFailed, nowMs);
+  const coveredProfileImageUrls = buildCoveredProfileImageUrls(previous, maxBytes, retryFailed, nowMs);
   const bookmarks = await readJsonLines<BookmarkRecord>(twitterBookmarksCachePath());
   const candidates = bookmarks
     .filter(hasMediaCandidate)
@@ -318,9 +343,11 @@ export async function fetchBookmarkMediaBatch(
   emitProgress();
 
   for (const bookmark of candidates) {
+    if (options.signal?.aborted) break;
     const mediaTargets = resolveMediaTargets(bookmark, coveredProfileImageUrls, skipProfileImages);
 
     for (const target of mediaTargets) {
+      if (options.signal?.aborted) break;
       const { bookmarkId, tweetId, tweetUrl, authorHandle, authorName, sourceUrl, isProfileImage } = target;
       const key = mediaEntryKey(tweetId, sourceUrl, isProfileImage);
       if (!isProfileImage && coveredAssetKeys.has(key)) continue;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -124,7 +124,7 @@ const SPINNER = ['\u280b', '\u2819', '\u2839', '\u2838', '\u283c', '\u2834', '\u
 let spinnerIdx = 0;
 
 /** Creates a spinner that animates independently of data callbacks. */
-function createSpinner(renderLine: () => string): { update: () => void; stop: () => void } {
+function createSpinner(renderLine: () => string, options: { onSigint?: () => void } = {}): { update: () => void; stop: () => void } {
   let line = '';
   let stopped = false;
   const tick = () => {
@@ -143,6 +143,10 @@ function createSpinner(renderLine: () => string): { update: () => void; stop: ()
   // Graceful interrupt — stop spinner, show friendly message
   const onSigint = () => {
     stop();
+    if (options.onSigint) {
+      options.onSigint();
+      return;
+    }
     console.log('\n  Interrupted. Your data is safe \u2014 progress has been saved.');
     console.log('  Run the same command again to pick up where you left off.\n');
     process.exit(0);
@@ -174,6 +178,7 @@ const FRIENDLY_STOP_REASONS: Record<string, string> = {
   'max pages reached': 'Paused after reaching page limit. Run again to continue.',
   'rate limited': 'Paused by X rate limiting.',
   'target additions reached': 'Reached target bookmark count.',
+  'interrupted': 'Interrupted by user.',
 };
 
 function friendlyStopReason(raw?: string): string {
@@ -204,8 +209,9 @@ function printMediaFetchSummary(result: MediaFetchManifest): void {
   console.log(`  ✓ Manifest: ${bookmarkMediaManifestPath()}`);
 }
 
-async function runMediaFetchWithProgress(options: { limit?: number; maxBytes?: number; skipProfileImages?: boolean } = {}): Promise<MediaFetchManifest> {
+async function runMediaFetchWithProgress(options: { limit?: number; maxBytes?: number; skipProfileImages?: boolean; retryFailed?: boolean } = {}): Promise<MediaFetchManifest> {
   const startTime = Date.now();
+  const controller = new AbortController();
   let lastMedia: MediaFetchProgress = {
     candidateBookmarks: 0,
     processed: 0,
@@ -216,11 +222,18 @@ async function runMediaFetchWithProgress(options: { limit?: number; maxBytes?: n
   const spinner = createSpinner(() => {
     const elapsed = Math.round((Date.now() - startTime) / 1000);
     return `Fetching media...  ${lastMedia.processed} processed  │  ${lastMedia.downloaded} downloaded  │  ${elapsed}s`;
+  }, {
+    onSigint: () => {
+      controller.abort();
+      console.log('\n  Interrupted. Saving media progress...\n');
+    },
   });
   const result = await runWithSpinner(spinner, () => fetchBookmarkMediaBatch({
     limit: options.limit,
     maxBytes: options.maxBytes,
     skipProfileImages: options.skipProfileImages,
+    retryFailed: options.retryFailed,
+    signal: controller.signal,
     onProgress: (progress: MediaFetchProgress) => {
       lastMedia = progress;
       spinner.update();
@@ -228,6 +241,9 @@ async function runMediaFetchWithProgress(options: { limit?: number; maxBytes?: n
   }));
   console.log('');
   printMediaFetchSummary(result);
+  if (controller.signal.aborted) {
+    console.log('  Interrupted. Progress has been saved; run the same command again to continue.\n');
+  }
   return result;
 }
 
@@ -910,6 +926,7 @@ export function buildCli() {
           }
         } else {
           const startTime = Date.now();
+          const controller = new AbortController();
           let lastSync: SyncProgress = { page: 0, totalFetched: 0, newAdded: 0, running: true, done: false };
           const spinner = createSpinner(() => {
             const elapsed = Math.round((Date.now() - startTime) / 1000);
@@ -917,6 +934,11 @@ export function buildCli() {
               return `${lastSync.stopReason}  \u2502  ${lastSync.newAdded} new  \u2502  ${elapsed}s`;
             }
             return `Syncing bookmarks...  ${lastSync.newAdded} new  \u2502  page ${lastSync.page}  \u2502  ${elapsed}s`;
+          }, {
+            onSigint: () => {
+              controller.abort();
+              console.log('\n  Interrupted. Saving sync progress...\n');
+            },
           });
           const { csrfToken, cookieHeader } = parseCookieOption(options.cookies);
 
@@ -954,6 +976,7 @@ export function buildCli() {
             chromeUserDataDir: options.chromeUserDataDir ? String(options.chromeUserDataDir) : undefined,
             chromeProfileDirectory: options.chromeProfileDirectory ? String(options.chromeProfileDirectory) : undefined,
             firefoxProfileDir: options.firefoxProfileDir ? String(options.firefoxProfileDir) : undefined,
+            signal: controller.signal,
             onProgress: (status: SyncProgress) => {
               lastSync = status;
               spinner.update();
@@ -977,6 +1000,11 @@ export function buildCli() {
             console.log(`  ${result.bookmarkedAtMissing} bookmarks missing a reliable bookmark date`);
           }
           console.log(`  \u2713 Data: ${dataDir()}\n`);
+
+          if (result.stopReason === 'interrupted') {
+            console.log('  Interrupted. Progress has been saved; run ft sync --continue to resume.\n');
+            return;
+          }
 
           warnIfEmpty(result.totalBookmarks);
 
@@ -1510,6 +1538,7 @@ export function buildCli() {
     .option('--limit <n>', 'Max pending bookmarks to process (default: all)', (v: string) => Number(v))
     .option('--max-bytes <n>', 'Per-asset byte limit (default: 200 MB)', (v: string) => Number(v), DEFAULT_MEDIA_MAX_BYTES)
     .option('--skip-profile-images', 'Skip downloading author profile images')
+    .option('--retry-failed', 'Retry failed media entries without waiting for backoff')
     .action(safe(async (options) => {
       if (!requireData()) return;
       await runMediaFetchWithProgress({
@@ -1518,6 +1547,7 @@ export function buildCli() {
           ? options.maxBytes
           : DEFAULT_MEDIA_MAX_BYTES,
         skipProfileImages: Boolean(options.skipProfileImages),
+        retryFailed: Boolean(options.retryFailed),
       });
     }));
 

--- a/src/graphql-bookmarks.ts
+++ b/src/graphql-bookmarks.ts
@@ -96,6 +96,8 @@ export interface SyncOptions {
   resumeCursor?: string;
   /** Flush to disk every N pages. Default: 25 */
   checkpointEvery?: number;
+  /** Stop at the next safe loop boundary, then persist final state. */
+  signal?: AbortSignal;
 }
 
 export interface SyncProgress {
@@ -650,6 +652,10 @@ export async function syncBookmarksGraphQL(
   };
 
   while (page < maxPages) {
+    if (options.signal?.aborted) {
+      stopReason = 'interrupted';
+      break;
+    }
     if (Date.now() - started > maxMinutes * 60_000) {
       stopReason = 'max runtime reached';
       break;
@@ -745,6 +751,10 @@ export async function syncBookmarksGraphQL(
 
     // Continue paginating with no stale-page or caught-up limits
     while (page < maxPages) {
+      if (options.signal?.aborted) {
+        stopReason = 'interrupted';
+        break;
+      }
       if (Date.now() - started > maxMinutes * 60_000) {
         stopReason = 'max runtime reached';
         break;

--- a/tests/bookmark-media.test.ts
+++ b/tests/bookmark-media.test.ts
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtemp, writeFile } from 'node:fs/promises';
+import { mkdtemp, readFile, writeFile } from 'node:fs/promises';
 import { rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
@@ -294,7 +294,7 @@ test('fetchBookmarkMediaBatch deduplicates shared profile image failure within o
   }
 });
 
-test('fetchBookmarkMediaBatch retries failed profile image from previous manifest run', async () => {
+test('fetchBookmarkMediaBatch retries failed profile image when requested', async () => {
   const profileUrl = 'https://pbs.twimg.com/profile_images/123/avatar_normal.jpg';
   const fullProfileUrl = profileUrl.replace('_normal.', '_400x400.');
   const records = [{
@@ -352,7 +352,7 @@ test('fetchBookmarkMediaBatch retries failed profile image from previous manifes
         });
       };
 
-      const secondManifest = await fetchBookmarkMediaBatch({ limit: 10, maxBytes: 1024 });
+      const secondManifest = await fetchBookmarkMediaBatch({ limit: 10, maxBytes: 1024, retryFailed: true });
       const downloadedProfileEntries = secondManifest.entries.filter(
         (entry) => entry.status === 'downloaded' && entry.sourceUrl === fullProfileUrl,
       );
@@ -416,6 +416,81 @@ test('fetchBookmarkMediaBatch reports progress as assets complete', async () => 
     assert.equal(progressSnapshots[0]?.candidateBookmarks, 1);
     assert.equal(progressSnapshots.at(-1)?.processed, 1);
     assert.equal(progressSnapshots.at(-1)?.downloaded, 1);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('fetchBookmarkMediaBatch aborts at boundary and writes completed entries to manifest', async () => {
+  const firstUrl = 'https://pbs.twimg.com/media/abort-first.jpg';
+  const secondUrl = 'https://pbs.twimg.com/media/abort-second.jpg';
+  const records = [
+    {
+      id: '1',
+      tweetId: '1',
+      url: 'https://x.com/alice/status/1',
+      text: 'first',
+      authorHandle: 'alice',
+      authorName: 'Alice',
+      syncedAt: '2026-04-09T00:00:00.000Z',
+      mediaObjects: [{ type: 'photo', url: firstUrl }],
+      links: [],
+      tags: [],
+      ingestedVia: 'graphql',
+    },
+    {
+      id: '2',
+      tweetId: '2',
+      url: 'https://x.com/bob/status/2',
+      text: 'second',
+      authorHandle: 'bob',
+      authorName: 'Bob',
+      syncedAt: '2026-04-09T00:00:00.000Z',
+      mediaObjects: [{ type: 'photo', url: secondUrl }],
+      links: [],
+      tags: [],
+      ingestedVia: 'graphql',
+    },
+  ];
+
+  const fetchedUrls: string[] = [];
+  const controller = new AbortController();
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+    const url = String(input instanceof Request ? input.url : input);
+    const method = init?.method ?? 'GET';
+    if (method === 'HEAD') {
+      return new Response(null, {
+        status: 200,
+        headers: { 'content-length': '4', 'content-type': 'image/jpeg' },
+      });
+    }
+    fetchedUrls.push(url);
+    return new Response(Uint8Array.from([1, 2, 3, 4]), {
+      status: 200,
+      headers: { 'content-type': 'image/jpeg' },
+    });
+  };
+
+  try {
+    await withMediaDataDir(records, async () => {
+      const manifest = await fetchBookmarkMediaBatch({
+        maxBytes: 1024,
+        signal: controller.signal,
+        onProgress: (progress) => {
+          if (progress.processed === 1) controller.abort();
+        },
+      });
+
+      assert.equal(manifest.processed, 1);
+      assert.equal(manifest.downloaded, 1);
+      assert.deepEqual(fetchedUrls, [firstUrl]);
+
+      const saved = JSON.parse(await readFile(path.join(process.env.FT_DATA_DIR!, 'media-manifest.json'), 'utf8'));
+      assert.equal(saved.processed, 1);
+      assert.equal(saved.entries.length, 1);
+      assert.equal(saved.entries[0].sourceUrl, firstUrl);
+    });
   } finally {
     globalThis.fetch = originalFetch;
   }
@@ -486,7 +561,7 @@ test('fetchBookmarkMediaBatch applies limit after filtering out already-download
   }
 });
 
-test('fetchBookmarkMediaBatch retries failed non-profile media on later runs', async () => {
+test('fetchBookmarkMediaBatch backs off failed non-profile media unless retry is requested', async () => {
   const photoUrl = 'https://pbs.twimg.com/media/retry-photo.jpg';
   const records = [{
     id: '1',
@@ -529,13 +604,77 @@ test('fetchBookmarkMediaBatch retries failed non-profile media on later runs', a
       assert.equal(firstRun.entries.filter((entry) => entry.sourceUrl === photoUrl).length, 1);
 
       const secondRun = await fetchBookmarkMediaBatch({ maxBytes: 1024 });
-      assert.equal(secondRun.downloaded, 1);
-      assert.equal(getCalls, 2);
+      assert.equal(secondRun.downloaded, 0);
+      assert.equal(getCalls, 1);
       assert.equal(secondRun.entries.filter((entry) => entry.sourceUrl === photoUrl).length, 1);
       assert.equal(
         secondRun.entries.find((entry) => entry.sourceUrl === photoUrl)?.status,
+        'failed',
+      );
+
+      const thirdRun = await fetchBookmarkMediaBatch({ maxBytes: 1024, retryFailed: true });
+      assert.equal(thirdRun.downloaded, 1);
+      assert.equal(getCalls, 2);
+      assert.equal(thirdRun.entries.filter((entry) => entry.sourceUrl === photoUrl).length, 1);
+      assert.equal(
+        thirdRun.entries.find((entry) => entry.sourceUrl === photoUrl)?.status,
         'downloaded',
       );
+    });
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('fetchBookmarkMediaBatch retries stale failed non-profile media after backoff', async () => {
+  const photoUrl = 'https://pbs.twimg.com/media/stale-retry-photo.jpg';
+  const records = [{
+    id: '1',
+    tweetId: '1',
+    url: 'https://x.com/alice/status/1',
+    text: 'stale retry test',
+    authorHandle: 'alice',
+    authorName: 'Alice',
+    syncedAt: '2026-04-09T00:00:00.000Z',
+    mediaObjects: [{ type: 'photo', url: photoUrl }],
+    links: [],
+    tags: [],
+    ingestedVia: 'graphql',
+  }];
+
+  let getCalls = 0;
+  const originalFetch = globalThis.fetch;
+
+  try {
+    await withMediaDataDir(records, async () => {
+      globalThis.fetch = async (_input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+        const method = init?.method ?? 'GET';
+        if (method === 'HEAD') {
+          return new Response(null, {
+            status: 200,
+            headers: { 'content-length': '4', 'content-type': 'image/jpeg' },
+          });
+        }
+        getCalls += 1;
+        return getCalls === 1
+          ? new Response(null, { status: 500 })
+          : new Response(Uint8Array.from([1, 2, 3, 4]), {
+              status: 200,
+              headers: { 'content-type': 'image/jpeg' },
+            });
+      };
+
+      const firstRun = await fetchBookmarkMediaBatch({ maxBytes: 1024 });
+      assert.equal(firstRun.failed, 1);
+
+      const manifestPath = path.join(process.env.FT_DATA_DIR!, 'media-manifest.json');
+      const manifest = JSON.parse(await readFile(manifestPath, 'utf8'));
+      manifest.entries[0].fetchedAt = '2026-01-01T00:00:00.000Z';
+      await writeFile(manifestPath, JSON.stringify(manifest, null, 2));
+
+      const secondRun = await fetchBookmarkMediaBatch({ maxBytes: 1024 });
+      assert.equal(secondRun.downloaded, 1);
+      assert.equal(getCalls, 2);
     });
   } finally {
     globalThis.fetch = originalFetch;

--- a/tests/graphql-bookmarks.test.ts
+++ b/tests/graphql-bookmarks.test.ts
@@ -985,6 +985,55 @@ test('syncBookmarksGraphQL: rate limit stops cleanly and saves cursor for contin
   }, existing);
 });
 
+test('syncBookmarksGraphQL: abort stops at boundary and saves cursor for continue', async () => {
+  const page1 = makeGraphQLResponse([
+    makeTweetResult({
+      rest_id: '222',
+      legacy: {
+        id_str: '222',
+        full_text: 'Abortable bookmark',
+        created_at: 'Tue Mar 12 12:00:00 +0000 2026',
+      },
+    }),
+  ], 'cursor-after-abort');
+
+  await withIsolatedGapFillDataDir(async () => {
+    const originalFetch = globalThis.fetch;
+    const controller = new AbortController();
+    let fetchCalls = 0;
+    globalThis.fetch = (async () => {
+      fetchCalls += 1;
+      return new Response(JSON.stringify(page1), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }) as typeof fetch;
+
+    try {
+      const result = await syncBookmarksGraphQL({
+        incremental: false,
+        csrfToken: 'ct0',
+        cookieHeader: 'ct0=ct0; auth_token=auth',
+        delayMs: 0,
+        signal: controller.signal,
+        onProgress: (progress) => {
+          if (progress.page === 1) controller.abort();
+        },
+      });
+
+      assert.equal(fetchCalls, 1);
+      assert.equal(result.pages, 1);
+      assert.equal(result.stopReason, 'interrupted');
+
+      const state = JSON.parse(await readFile(path.join(process.env.FT_DATA_DIR!, 'bookmarks-backfill-state.json'), 'utf8'));
+      assert.equal(state.stopReason, 'interrupted');
+      assert.equal(state.lastCursor, 'cursor-after-abort');
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  }, []);
+});
+
 test('syncGaps: permanent quoted-tweet failure stamps quotedTweetFailedAt so reruns skip it', async () => {
   const deadQuoted: BookmarkRecord = {
     id: '222',


### PR DESCRIPTION
## summary
- make graphql sync and media fetch stop cleanly on interrupt so final state writes still run
- persist sync cursor/manifest state before telling users progress is saved
- add failed-media retry backoff plus explicit `ft fetch-media --retry-failed`

## validation
- npm run build
- npx tsx --test tests/graphql-bookmarks.test.ts tests/bookmark-media.test.ts tests/cli.test.ts
- npm test

closes #142
closes #147