### PR TITLE
Add FT_TIMEOUT_MULTIPLIER env var to scale engine call timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,17 @@ Nightly schedules are stored under `~/.fieldtheory/ideas/nightly/`. Each tick st
 
 `ft` respects standard proxy environment variables for network requests: `HTTPS_PROXY`, `HTTP_PROXY`, `ALL_PROXY`, and `NO_PROXY`.
 
+### Engine timeouts
+
+Set `FT_TIMEOUT_MULTIPLIER` to scale every engine-call deadline uniformly. Useful when the configured agent CLI has heavy startup overhead (MCP servers, session hooks, high reasoning effort) and the default per-call budgets fire before the child has responded:
+
+```bash
+export FT_TIMEOUT_MULTIPLIER=2   # doubles every timeout
+ft possible run --seed <id> --repo .
+```
+
+Applies to every `invokeEngine` / `invokeEngineAsync` call (classification, wiki compile, Possible runs). Default is `1` (no change). Non-numeric or non-positive values are ignored.
+
 ## Data
 
 Data is stored locally under `~/.fieldtheory/`:

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -289,6 +289,27 @@ const STDERR_TAIL_BYTES = 4096;     // clipped tail shown in errors/logs
 const STDERR_HARD_CAP   = 64 * 1024; // hard ceiling on in-memory stderr buffering
 const SIGKILL_GRACE_MS  = 2_000;     // grace period between SIGTERM and SIGKILL
 
+/** Optional global multiplier applied to every engine-call timeout.
+ *  Set FT_TIMEOUT_MULTIPLIER to scale the per-call deadlines uniformly when
+ *  the configured engine has heavy startup overhead (MCP servers, session
+ *  hooks, high reasoning effort) and the default budgets fire before the
+ *  child has responded. Applies to caller-supplied opts.timeout and to the
+ *  DEFAULT_TIMEOUT fallback. Non-numeric or non-positive values are ignored.
+ *  Read on every call so tests and one-off env overrides take effect without
+ *  re-importing the module. */
+function timeoutMultiplier(): number {
+  const raw = process.env.FT_TIMEOUT_MULTIPLIER;
+  if (raw === undefined || raw === '') return 1;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n <= 0) return 1;
+  return n;
+}
+
+function resolveTimeout(callerTimeout: number | undefined): number {
+  const base = callerTimeout ?? DEFAULT_TIMEOUT;
+  return Math.round(base * timeoutMultiplier());
+}
+
 /** Clip the tail of a buffer to a byte budget — engines put the "what went
  *  wrong" line at the end of stderr. */
 function tailString(buf: Buffer, bytes: number): string {
@@ -358,7 +379,7 @@ function buildMessage(
  */
 export function invokeEngine(engine: ResolvedEngine, prompt: string, opts: InvokeOptions = {}): string {
   const { bin, args } = engine.config;
-  const timeout   = opts.timeout   ?? DEFAULT_TIMEOUT;
+  const timeout   = resolveTimeout(opts.timeout);
   const maxBuffer = opts.maxBuffer ?? DEFAULT_MAXBUF;
 
   const result = spawnSync(bin, args(prompt, engine), {
@@ -425,7 +446,7 @@ export function invokeEngine(engine: ResolvedEngine, prompt: string, opts: Invok
  */
 export function invokeEngineAsync(engine: ResolvedEngine, prompt: string, opts: InvokeOptions = {}): Promise<string> {
   const { bin, args } = engine.config;
-  const timeout   = opts.timeout   ?? DEFAULT_TIMEOUT;
+  const timeout   = resolveTimeout(opts.timeout);
   const maxBuffer = opts.maxBuffer ?? DEFAULT_MAXBUF;
 
   return new Promise((resolve, reject) => {

--- a/tests/engine-invoke.test.ts
+++ b/tests/engine-invoke.test.ts
@@ -96,3 +96,42 @@ test('invokeEngineAsync: captures multi-line stderr in the error message', async
     },
   );
 });
+
+function withEnv(key: string, value: string | undefined, fn: () => Promise<void>): Promise<void> {
+  const prior = process.env[key];
+  if (value === undefined) delete process.env[key];
+  else process.env[key] = value;
+  return fn().finally(() => {
+    if (prior === undefined) delete process.env[key];
+    else process.env[key] = prior;
+  });
+}
+
+test('invokeEngineAsync: FT_TIMEOUT_MULTIPLIER scales the per-call deadline', async () => {
+  const { invokeEngineAsync } = await import('../src/engine.js');
+  // Caller asks for 200ms; multiplier 5 → effective 1000ms. A 500ms sleep
+  // would have timed out under the raw 200ms deadline, but completes when
+  // the multiplier widens it.
+  await withEnv('FT_TIMEOUT_MULTIPLIER', '5', async () => {
+    const out = await invokeEngineAsync(
+      shEngine('fake-fits-under-multiplier', 'sleep 0.5; printf "ok\\n"'),
+      'ignored',
+      { timeout: 200 },
+    );
+    assert.equal(out, 'ok');
+  });
+});
+
+test('invokeEngineAsync: invalid FT_TIMEOUT_MULTIPLIER values fall back to 1', async () => {
+  const { invokeEngineAsync } = await import('../src/engine.js');
+  // Garbage values must not crash and must not silently change the deadline.
+  for (const bad of ['not-a-number', '0', '-2', '']) {
+    await withEnv('FT_TIMEOUT_MULTIPLIER', bad, async () => {
+      await assert.rejects(
+        () => invokeEngineAsync(shEngine('fake-slow', 'sleep 5'), 'ignored', { timeout: 200 }),
+        /timed out after 200ms/,
+        `bad value ${JSON.stringify(bad)} should fall back to multiplier=1`,
+      );
+    });
+  }
+});


### PR DESCRIPTION
## Why

Engine call timeouts (`DEFAULT_TIMEOUT` in `src/engine.ts`, the per-depth `timeoutMs` values in `src/adjacent/prompts.ts`, the wiki-compile timeout in `src/md.ts`) are sized for a baseline local CLI with no startup overhead.

In environments where the configured engine has heavy startup cost — MCP servers, SessionStart hooks, high reasoning effort, packaged plugin/skill loaders — the deadlines fire before the child has responded. The failure mode is non-deterministic `claude/codex timed out after Ns` even on small prompts.

Concrete repro from my setup: `ft possible run --depth quick --engine claude` against a 30-file repo. Claude Code with my normal MCP fleet + SessionStart hooks takes ~140s to return the first candidate-generation pass, so `quick` (120s) deterministically aborts at the "Generating candidates" step. `standard` (180s) is on the edge. `deep` (300s) is the only reliable depth, which defeats the point of having tiers.

## What

Single uniform multiplier applied at the engine layer so every caller (classification, wiki compile, Possible runs) inherits it without per-site changes.

```bash
export FT_TIMEOUT_MULTIPLIER=2   # doubles every engine deadline
ft possible run --seed <id> --repo .
```

Default is `1` (no change in behavior). Non-numeric or non-positive values fall back to `1` silently. Read on every call so tests and one-off env overrides take effect without re-importing the module.

## Diff shape

- `src/engine.ts` — add `timeoutMultiplier()` and `resolveTimeout()` helpers, replace `opts.timeout ?? DEFAULT_TIMEOUT` at the two consumption sites (`invokeEngine` and `invokeEngineAsync`). +23 / -2.
- `tests/engine-invoke.test.ts` — two new tests using the existing `shEngine` shell fake: one pins the scaling behavior (multiplier 5 lets a 500ms sleep complete inside a 200ms caller timeout), one pins input validation (`'not-a-number'`, `'0'`, `'-2'`, `''` all fall back to multiplier 1).
- `README.md` — new "Engine timeouts" subsection adjacent to the existing proxy-env-var paragraph.

No default change. Opt-in only.

## Verification

```
> fieldtheory@1.3.20 test
ℹ tests 545
ℹ pass 545
ℹ fail 0
```

The existing `invokeEngineAsync: timeout kills the child promptly` test is unchanged and still passes — with no env var set, multiplier is 1 and 200ms stays 200ms.

## Why a multiplier and not per-tier env vars

Considered `FT_ENGINE_TIMEOUT_MS` / `FT_DEPTH_TIMEOUT_QUICK_MS` / `FT_DEPTH_TIMEOUT_STANDARD_MS` / `FT_DEPTH_TIMEOUT_DEEP_MS` / etc. Rejected as too much surface for a single failure mode (children that are uniformly slower than the author's reference machine). One knob, documented in one place, scales the existing tier shape rather than letting users invert it accidentally.
