### PR TITLE
Add Field Theory navigation commands

### DIFF
--- a/src/agent-context.ts
+++ b/src/agent-context.ts
@@ -39,6 +39,38 @@ function tryGitFiles(repoPath: string): string[] {
   }
 }
 
+function parseGitStatusPorcelain(output: string): string[] {
+  const entries = output.split('\0');
+  const files: string[] = [];
+  for (let i = 0; i < entries.length; i += 1) {
+    const entry = entries[i];
+    if (!entry) continue;
+    const status = entry.slice(0, 2);
+    const filePath = entry.slice(3);
+    if (status.includes('R') || status.includes('C')) {
+      const renamedPath = entries[i + 1];
+      i += 1;
+      if (renamedPath) files.push(renamedPath);
+    } else if (!status.includes('D')) {
+      files.push(filePath);
+    }
+  }
+  return [...new Set(files)];
+}
+
+function tryGitChangedFiles(repoPath: string): string[] {
+  try {
+    return parseGitStatusPorcelain(execFileSync('git', ['status', '--porcelain=v1', '-z', '--untracked-files=all'], {
+      cwd: repoPath,
+      encoding: 'utf-8',
+      timeout: 10_000,
+      stdio: ['pipe', 'pipe', 'ignore'],
+    }));
+  } catch {
+    return [];
+  }
+}
+
 function shouldSkipFile(relPath: string): boolean {
   const parts = relPath.split(path.sep);
   if (parts.some((part) => SKIP_DIRS.has(part))) return true;
@@ -71,17 +103,8 @@ function collectFallbackFiles(dir: string, root: string, limit: number, depth = 
 
 export function getAgentContext(repoPath = process.cwd(), limit = 10): AgentContext {
   const cwd = path.resolve(repoPath);
-  let stat: fs.Stats;
-  try {
-    stat = fs.statSync(cwd);
-  } catch {
-    throw new Error(`Repo path not found: ${cwd}`);
-  }
-  if (!stat.isDirectory()) {
-    throw new Error(`Repo path is not a directory: ${cwd}`);
-  }
-
-  const candidates = tryGitFiles(cwd);
+  const changedCandidates = tryGitChangedFiles(cwd);
+  const candidates = changedCandidates.length > 0 ? changedCandidates : tryGitFiles(cwd);
   const relPaths = candidates.length > 0 ? candidates : collectFallbackFiles(cwd, cwd, 500);
   const recentFiles = relPaths
     .filter((relPath) => !shouldSkipFile(relPath))

--- a/src/app-open.ts
+++ b/src/app-open.ts
@@ -31,8 +31,8 @@ export interface FieldTheoryLaunchOptions {
 
 export function inferOpenKind(filePath: string): FieldTheoryOpenKind | null {
   const resolved = path.resolve(filePath);
-  if (isPathInside(path.resolve(canonicalLibraryDir()), resolved)) return 'library';
   if (isPathInside(path.resolve(canonicalCommandsDir()), resolved)) return 'command';
+  if (isPathInside(path.resolve(canonicalLibraryDir()), resolved)) return 'library';
   return null;
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -39,6 +39,37 @@ import { skillWithFrontmatter, installSkill, uninstallSkill } from './skill.js';
 import { registerCompanionCommands } from './companion-cli.js';
 import { getPathReport } from './field-status.js';
 import { formatAgentContext, getAgentContext } from './agent-context.js';
+import { formatCurrentDocumentSummary, readCurrentDocumentContext, readCurrentDocumentSummary } from './current.js';
+import {
+  appendNavigationDocument,
+  backNavigation,
+  buildNavigationWikiLink,
+  cdNavigation,
+  createNavigationDocument,
+  createNavigationNote,
+  findNavigationEntries,
+  formatNavigationContext,
+  formatNavigationEntries,
+  formatNavigationHead,
+  formatNavigationLinks,
+  formatNavigationMeta,
+  formatNavigationPlaces,
+  formatNavigationPwd,
+  formatNavigationSearchResults,
+  formatNavigationState,
+  formatNavigationTags,
+  grepNavigationContent,
+  listNavigationBacklinks,
+  listNavigationEntries,
+  listNavigationLinks,
+  listNavigationPlaces,
+  listNavigationTagged,
+  listNavigationTags,
+  openNavigationDocument,
+  readNavigationDocument,
+  renameNavigationDocument,
+  type NavigationPlace,
+} from './navigation.js';
 import {
   formatIdeasIntro,
   formatRunList,
@@ -275,6 +306,14 @@ function printJson(value: unknown): void {
   console.log(JSON.stringify(value, null, 2));
 }
 
+function parseNavigationPlace(value: string): NavigationPlace {
+  const place = value.toLowerCase();
+  if (listNavigationPlaces().some((candidate) => candidate.name === place)) {
+    return place as NavigationPlace;
+  }
+  throw new Error(`Unknown Field Theory place: ${value}`);
+}
+
 // ── Update checker ────────────────────────────────────────────────────────
 
 const UPDATE_CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000; // 1 day
@@ -440,7 +479,11 @@ function isInternalWorkerCommand(command: Command): boolean {
 function shouldSkipCommandChrome(command: Command): boolean {
   if (isInternalWorkerCommand(command)) return true;
   if (command.opts().json) return true;
-  if (command.name() === 'path' || command.name() === 'paths' || command.name() === 'recent') return true;
+  if ([
+    'path', 'paths', 'current', 'recent', 'ls', 'tree', 'find', 'grep', 'cat',
+    'head', 'meta', 'pwd', 'context', 'open', 'tab', 'reveal', 'link', 'links',
+    'backlinks', 'tags', 'tagged', 'new', 'append', 'note', 'rename', 'cd', 'back',
+  ].includes(command.name())) return true;
   if (command.name() === 'show' && command.parent?.name() === 'skill') return true;
   return false;
 }
@@ -1527,6 +1570,326 @@ export function buildCli() {
         return;
       }
       process.stdout.write(formatAgentContext(context));
+    }));
+
+  program
+    .command('ls')
+    .description('List Field Theory places or files inside one place')
+    .argument('[place]', 'Field Theory place such as library, commands, briefs, scratchpad, wikis, debates, recent, or current')
+    .option('--limit <n>', 'Max files', parsePositiveInteger)
+    .option('--json', 'JSON output')
+    .action(safe(async (place: string | undefined, options) => {
+      if (!place) {
+        const places = listNavigationPlaces();
+        if (options.json) printJson(places);
+        else process.stdout.write(formatNavigationPlaces());
+        return;
+      }
+      const parsedPlace = parseNavigationPlace(place);
+      if (parsedPlace === 'recent') {
+        const context = getAgentContext(process.cwd(), options.limit ?? 10);
+        if (options.json) printJson(context);
+        else process.stdout.write(formatAgentContext(context));
+        return;
+      }
+      if (parsedPlace === 'current') {
+        const summary = readCurrentDocumentSummary();
+        if (options.json) printJson(summary);
+        else process.stdout.write(formatCurrentDocumentSummary(summary));
+        return;
+      }
+      const entries = listNavigationEntries(parsedPlace, options.limit);
+      if (options.json) printJson(entries);
+      else process.stdout.write(formatNavigationEntries(entries));
+    }));
+
+  program
+    .command('tree')
+    .description('Show a compact Field Theory Library tree')
+    .option('--limit <n>', 'Max files', parsePositiveInteger, 80)
+    .option('--json', 'JSON output')
+    .action(safe(async (options) => {
+      const entries = listNavigationEntries('library', options.limit);
+      if (options.json) printJson(entries.map((entry) => entry.relPath));
+      else process.stdout.write(entries.length ? `${entries.map((entry) => entry.relPath).join('\n')}\n` : '(none)\n');
+    }));
+
+  program
+    .command('find')
+    .description('Search Field Theory document titles and paths')
+    .argument('<query>', 'Title or filename query')
+    .option('--limit <n>', 'Max results', parsePositiveInteger, 20)
+    .option('--json', 'JSON output')
+    .action(safe(async (query: string, options) => {
+      const entries = findNavigationEntries(query, options.limit);
+      if (options.json) printJson(entries);
+      else process.stdout.write(formatNavigationEntries(entries));
+    }));
+
+  program
+    .command('grep')
+    .description('Search inside Field Theory markdown content')
+    .argument('<query>', 'Content query')
+    .option('--limit <n>', 'Max results', parsePositiveInteger, 20)
+    .option('--json', 'JSON output')
+    .action(safe(async (query: string, options) => {
+      const entries = grepNavigationContent(query, options.limit);
+      if (options.json) printJson(entries);
+      else process.stdout.write(formatNavigationSearchResults(entries));
+    }));
+
+  program
+    .command('cat')
+    .description('Print a Field Theory Library or command document')
+    .argument('<file>', 'Relative or absolute markdown path')
+    .option('--json', 'JSON output')
+    .action(safe(async (targetPath: string, options) => {
+      const doc = await readNavigationDocument(targetPath);
+      if (options.json) printJson(doc);
+      else process.stdout.write(doc.content.endsWith('\n') ? doc.content : `${doc.content}\n`);
+    }));
+
+  program
+    .command('head')
+    .description('Print the first lines of a Field Theory Library or command document')
+    .argument('<file>', 'Relative or absolute markdown path')
+    .option('--lines <n>', 'Number of lines', parsePositiveInteger, 40)
+    .option('--json', 'JSON output')
+    .action(safe(async (targetPath: string, options) => {
+      const doc = await readNavigationDocument(targetPath);
+      if (options.json) printJson({ ...doc, content: formatNavigationHead(doc.content, options.lines) });
+      else process.stdout.write(formatNavigationHead(doc.content, options.lines));
+    }));
+
+  program
+    .command('meta')
+    .description('Show metadata for a Field Theory Library or command document')
+    .argument('<file>', 'Relative or absolute markdown path')
+    .option('--json', 'JSON output')
+    .action(safe(async (targetPath: string, options) => {
+      const doc = await readNavigationDocument(targetPath);
+      const { content: _content, ...entry } = doc;
+      if (options.json) printJson(entry);
+      else process.stdout.write(formatNavigationMeta(entry));
+    }));
+
+  program
+    .command('open')
+    .description('Open a Field Theory Library document in the app')
+    .argument('[file]', 'Relative or absolute markdown path, title, or filename')
+    .option('--query <query>', 'Find one matching document and open it')
+    .option('--no-launch', 'Print target without launching the app')
+    .option('--json', 'JSON output')
+    .action(safe(async (targetPath: string | undefined, options) => {
+      if (!targetPath && !options.query) throw new Error('Pass a file/title or --query.');
+      const result = await openNavigationDocument(targetPath ?? '', {
+        launch: options.launch !== false,
+        query: options.query ? String(options.query) : undefined,
+      });
+      if (options.json) {
+        printJson(result);
+        return;
+      }
+      console.log(result.url ?? result.path);
+    }));
+
+  program
+    .command('tab')
+    .description('Open a Field Theory Library document as a tab when the app supports it')
+    .argument('<file>', 'Relative or absolute markdown path, title, or filename')
+    .option('--no-launch', 'Print target without launching the app')
+    .option('--json', 'JSON output')
+    .action(safe(async (targetPath: string, options) => {
+      const result = await openNavigationDocument(targetPath, { launch: options.launch !== false, action: 'tab' });
+      if (options.json) printJson(result);
+      else console.log(result.url ?? result.path);
+    }));
+
+  program
+    .command('reveal')
+    .description('Reveal a Field Theory Library document in app navigation when the app supports it')
+    .argument('<file>', 'Relative or absolute markdown path, title, or filename')
+    .option('--no-launch', 'Print target without launching the app')
+    .option('--json', 'JSON output')
+    .action(safe(async (targetPath: string, options) => {
+      const result = await openNavigationDocument(targetPath, { launch: options.launch !== false, action: 'reveal' });
+      if (options.json) printJson(result);
+      else console.log(result.url ?? result.path);
+    }));
+
+  program
+    .command('pwd')
+    .description('Show the current Field Theory location')
+    .action(safe(async () => {
+      process.stdout.write(formatNavigationPwd());
+    }));
+
+  program
+    .command('context')
+    .description('Show current Field Theory document plus recent repo files')
+    .option('--repo <path>', 'Repo path to inspect (default: cwd)')
+    .option('--limit <n>', 'Number of recent files to show', parsePositiveInteger, 8)
+    .action(safe(async (options) => {
+      process.stdout.write(formatNavigationContext(options.repo ?? process.cwd(), options.limit));
+    }));
+
+  program
+    .command('link')
+    .description('Print the canonical wiki link for a Field Theory document or command')
+    .argument('<target>', 'Relative markdown path, title, command name, or filename')
+    .option('--alias <text>', 'Display text for the wikilink')
+    .option('--json', 'JSON output')
+    .action(safe(async (targetPath: string, options) => {
+      const result = buildNavigationWikiLink(targetPath, options.alias ? String(options.alias) : undefined);
+      if (options.json) printJson(result);
+      else console.log(result.link);
+    }));
+
+  program
+    .command('links')
+    .description('List wiki-style links from a Field Theory document')
+    .argument('<file>', 'Relative markdown path, title, or filename')
+    .option('--json', 'JSON output')
+    .action(safe(async (targetPath: string, options) => {
+      const links = listNavigationLinks(targetPath);
+      if (options.json) printJson(links);
+      else process.stdout.write(formatNavigationLinks(links));
+    }));
+
+  program
+    .command('backlinks')
+    .description('List documents that link to a Field Theory document')
+    .argument('<file>', 'Relative markdown path, title, or filename')
+    .option('--json', 'JSON output')
+    .action(safe(async (targetPath: string, options) => {
+      const entries = listNavigationBacklinks(targetPath);
+      if (options.json) printJson(entries);
+      else process.stdout.write(formatNavigationEntries(entries));
+    }));
+
+  program
+    .command('tags')
+    .description('List tags found in Field Theory markdown')
+    .option('--json', 'JSON output')
+    .action(safe(async (options) => {
+      const tags = listNavigationTags();
+      if (options.json) printJson(tags);
+      else process.stdout.write(formatNavigationTags(tags));
+    }));
+
+  program
+    .command('tagged')
+    .description('List Field Theory documents with a tag')
+    .argument('<tag>', 'Tag name, with or without #')
+    .option('--json', 'JSON output')
+    .action(safe(async (tag: string, options) => {
+      const entries = listNavigationTagged(tag);
+      if (options.json) printJson(entries);
+      else process.stdout.write(formatNavigationEntries(entries));
+    }));
+
+  program
+    .command('new')
+    .description('Create a Field Theory document')
+    .argument('<type>', 'brief, command, scratchpad, wiki, or debate')
+    .argument('<title>', 'Document title')
+    .option('--stdin', 'Read markdown content from stdin')
+    .option('--file <path>', 'Read markdown content from a file')
+    .option('--json', 'JSON output')
+    .action(safe(async (type: string, title: string, options) => {
+      const entry = await createNavigationDocument(type, title, {
+        stdin: Boolean(options.stdin),
+        file: options.file ? String(options.file) : undefined,
+      });
+      if (options.json) printJson(entry);
+      else console.log(`Created: ${entry.path}`);
+    }));
+
+  program
+    .command('append')
+    .description('Append text to a Field Theory document')
+    .argument('<file>', 'Relative markdown path, title, or filename')
+    .argument('[text]', 'Text to append')
+    .option('--content <text>', 'Text to append')
+    .option('--stdin', 'Read markdown content from stdin')
+    .option('--file <path>', 'Read markdown content from a file')
+    .option('--json', 'JSON output')
+    .action(safe(async (targetPath: string, textArg: string | undefined, options) => {
+      const content = options.content ? String(options.content) : textArg;
+      const entry = await appendNavigationDocument(targetPath, {
+        stdin: Boolean(options.stdin),
+        file: options.file ? String(options.file) : undefined,
+        content,
+      });
+      if (options.json) printJson(entry);
+      else console.log(`Appended: ${entry.path}`);
+    }));
+
+  program
+    .command('note')
+    .description('Append a quick note to today’s Scratchpad file')
+    .argument('<text>', 'Note text')
+    .option('--title <title>', 'Scratchpad title when creating today’s file')
+    .option('--json', 'JSON output')
+    .action(safe(async (text: string, options) => {
+      const entry = await createNavigationNote(text, options.title ? String(options.title) : undefined);
+      if (options.json) printJson(entry);
+      else console.log(`Noted: ${entry.path}`);
+    }));
+
+  program
+    .command('rename')
+    .description('Rename a Field Theory document using Field Theory places')
+    .argument('<file>', 'Relative markdown path, title, or filename')
+    .argument('<title>', 'New title')
+    .option('--json', 'JSON output')
+    .action(safe(async (targetPath: string, title: string, options) => {
+      const entry = await renameNavigationDocument(targetPath, title);
+      if (options.json) printJson(entry);
+      else console.log(`Renamed: ${entry.path}`);
+    }));
+
+  program
+    .command('cd')
+    .description('Move the CLI Field Theory location state')
+    .argument('<ft-path>', 'Field Theory place, relative path, title, or filename')
+    .option('--json', 'JSON output')
+    .action(safe(async (targetPath: string, options) => {
+      const state = cdNavigation(targetPath);
+      if (options.json) printJson(state);
+      else process.stdout.write(formatNavigationState(state));
+    }));
+
+  program
+    .command('back')
+    .description('Move back through the CLI Field Theory location state')
+    .option('--json', 'JSON output')
+    .action(safe(async (options) => {
+      const state = backNavigation();
+      if (options.json) printJson(state);
+      else process.stdout.write(formatNavigationState(state));
+    }));
+
+  program
+    .command('current')
+    .description('Show the active Field Theory document attached to the Mac app terminal')
+    .option('--manifest <path>', 'Read a specific context manifest')
+    .option('--content-only', 'Print only the active document markdown/content')
+    .option('--include-content', 'Include active document content in --json output')
+    .option('--json', 'JSON output')
+    .action(safe(async (options) => {
+      if (options.contentOnly) {
+        process.stdout.write(readCurrentDocumentContext(options.manifest).content);
+        return;
+      }
+      const context = options.includeContent
+        ? readCurrentDocumentContext(options.manifest)
+        : readCurrentDocumentSummary(options.manifest);
+      if (options.json) {
+        printJson(context);
+        return;
+      }
+      process.stdout.write(formatCurrentDocumentSummary(context));
     }));
 
   registerCompanionCommands(program, safe);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -39,6 +39,7 @@ import { skillWithFrontmatter, installSkill, uninstallSkill } from './skill.js';
 import { registerCompanionCommands } from './companion-cli.js';
 import { getPathReport } from './field-status.js';
 import { formatAgentContext, getAgentContext } from './agent-context.js';
+import { formatCurrentDocumentContext, readCurrentDocumentContext } from './current.js';
 import {
   formatIdeasIntro,
   formatRunList,
@@ -440,7 +441,7 @@ function isInternalWorkerCommand(command: Command): boolean {
 function shouldSkipCommandChrome(command: Command): boolean {
   if (isInternalWorkerCommand(command)) return true;
   if (command.opts().json) return true;
-  if (command.name() === 'path' || command.name() === 'paths' || command.name() === 'recent') return true;
+  if (command.name() === 'path' || command.name() === 'paths' || command.name() === 'current' || command.name() === 'recent') return true;
   if (command.name() === 'show' && command.parent?.name() === 'skill') return true;
   return false;
 }
@@ -1527,6 +1528,25 @@ export function buildCli() {
         return;
       }
       process.stdout.write(formatAgentContext(context));
+    }));
+
+  program
+    .command('current')
+    .description('Show the active Field Theory document attached to the Mac app terminal')
+    .option('--manifest <path>', 'Read a specific context manifest')
+    .option('--content-only', 'Print only the active document markdown/content')
+    .option('--json', 'JSON output')
+    .action(safe(async (options) => {
+      const context = readCurrentDocumentContext(options.manifest);
+      if (options.json) {
+        printJson(context);
+        return;
+      }
+      if (options.contentOnly) {
+        process.stdout.write(context.content.endsWith('\n') ? context.content : `${context.content}\n`);
+        return;
+      }
+      process.stdout.write(formatCurrentDocumentContext(context));
     }));
 
   registerCompanionCommands(program, safe);

--- a/src/current.ts
+++ b/src/current.ts
@@ -1,0 +1,116 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { codexContextSessionsDir } from './paths.js';
+
+export interface CurrentDocumentContext {
+  manifestPath: string;
+  updatedAt: string | null;
+  activeDocument: {
+    title: string | null;
+    path: string | null;
+    kind: string | null;
+    contentMode: string | null;
+    contentPath: string;
+  };
+  content: string;
+}
+
+type ManifestRecord = Record<string, unknown>;
+
+function readJsonObject(filePath: string): ManifestRecord {
+  const parsed = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error(`Context manifest is not an object: ${filePath}`);
+  }
+  return parsed as ManifestRecord;
+}
+
+function stringField(value: unknown): string | null {
+  return typeof value === 'string' && value.length > 0 ? value : null;
+}
+
+function statMtimeMs(filePath: string): number {
+  try {
+    return fs.statSync(filePath).mtimeMs;
+  } catch {
+    return 0;
+  }
+}
+
+function assertInsideDirectory(filePath: string, dirPath: string): void {
+  const resolvedFilePath = path.resolve(filePath);
+  const resolvedDirPath = path.resolve(dirPath);
+  const relativePath = path.relative(resolvedDirPath, resolvedFilePath);
+  if (relativePath.startsWith('..') || path.isAbsolute(relativePath)) {
+    throw new Error(`Context content path must stay inside its session directory: ${filePath}`);
+  }
+}
+
+export function findCurrentContextManifest(sessionsDir = codexContextSessionsDir()): string | null {
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(sessionsDir, { withFileTypes: true });
+  } catch {
+    return null;
+  }
+
+  const manifests = entries
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => path.join(sessionsDir, entry.name, 'context.json'))
+    .filter((manifestPath) => fs.existsSync(manifestPath))
+    .sort((a, b) => statMtimeMs(b) - statMtimeMs(a));
+
+  return manifests[0] ?? null;
+}
+
+export function readCurrentDocumentContext(manifestPath = findCurrentContextManifest()): CurrentDocumentContext {
+  if (!manifestPath) {
+    throw new Error('No active Field Theory context found. Open a Field Theory document and attach a Codex terminal first.');
+  }
+
+  const manifest = readJsonObject(manifestPath);
+  const activeDocument = manifest.activeDocument;
+  if (!activeDocument || typeof activeDocument !== 'object' || Array.isArray(activeDocument)) {
+    throw new Error(`Context manifest has no activeDocument object: ${manifestPath}`);
+  }
+
+  const documentRecord = activeDocument as ManifestRecord;
+  const contentPath = stringField(documentRecord.contentPath);
+  if (!contentPath) {
+    throw new Error(`Context manifest has no activeDocument.contentPath: ${manifestPath}`);
+  }
+  assertInsideDirectory(contentPath, path.dirname(manifestPath));
+
+  return {
+    manifestPath,
+    updatedAt: stringField(manifest.updatedAt),
+    activeDocument: {
+      title: stringField(documentRecord.title),
+      path: stringField(documentRecord.path),
+      kind: stringField(documentRecord.kind),
+      contentMode: stringField(documentRecord.contentMode),
+      contentPath,
+    },
+    content: fs.readFileSync(contentPath, 'utf-8'),
+  };
+}
+
+export function formatCurrentDocumentContext(context: CurrentDocumentContext): string {
+  const lines = [
+    '# Field Theory Current Document',
+    '',
+    `title: ${context.activeDocument.title ?? '(untitled)'}`,
+    `source: ${context.activeDocument.path ?? '(unknown)'}`,
+    `kind: ${context.activeDocument.kind ?? '(unknown)'}`,
+    `contentMode: ${context.activeDocument.contentMode ?? '(unknown)'}`,
+    `updatedAt: ${context.updatedAt ?? '(unknown)'}`,
+    `manifest: ${context.manifestPath}`,
+    `content: ${context.activeDocument.contentPath}`,
+    '',
+    '---',
+    '',
+    context.content,
+  ];
+
+  return `${lines.join('\n')}${context.content.endsWith('\n') ? '' : '\n'}`;
+}

--- a/src/current.ts
+++ b/src/current.ts
@@ -1,0 +1,139 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { codexContextSessionsDir } from './paths.js';
+
+export interface CurrentDocumentSummary {
+  manifestPath: string;
+  updatedAt: string | null;
+  activeDocument: {
+    title: string | null;
+    path: string | null;
+    kind: string | null;
+    contentMode: string | null;
+    contentPath: string;
+  };
+}
+
+export interface CurrentDocumentContext extends CurrentDocumentSummary {
+  content: string;
+}
+
+type ManifestRecord = Record<string, unknown>;
+
+function readJsonObject(filePath: string): ManifestRecord {
+  const parsed = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error(`Context manifest is not an object: ${filePath}`);
+  }
+  return parsed as ManifestRecord;
+}
+
+function stringField(value: unknown): string | null {
+  return typeof value === 'string' && value.length > 0 ? value : null;
+}
+
+function statMtimeMs(filePath: string): number {
+  try {
+    return fs.statSync(filePath).mtimeMs;
+  } catch {
+    return 0;
+  }
+}
+
+function assertInsideDirectory(filePath: string, dirPath: string): void {
+  const resolvedFilePath = path.resolve(filePath);
+  const resolvedDirPath = path.resolve(dirPath);
+  const relativePath = path.relative(resolvedDirPath, resolvedFilePath);
+  if (relativePath.startsWith('..') || path.isAbsolute(relativePath)) {
+    throw new Error(`Context content path must stay inside its session directory: ${filePath}`);
+  }
+}
+
+export function findCurrentContextManifest(sessionsDir = codexContextSessionsDir()): string | null {
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(sessionsDir, { withFileTypes: true });
+  } catch {
+    return null;
+  }
+
+  const manifests = entries
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => path.join(sessionsDir, entry.name, 'context.json'))
+    .filter((manifestPath) => fs.existsSync(manifestPath))
+    .sort((a, b) => statMtimeMs(b) - statMtimeMs(a));
+
+  return manifests[0] ?? null;
+}
+
+export function readCurrentDocumentSummary(manifestPath = findCurrentContextManifest()): CurrentDocumentSummary {
+  if (!manifestPath) {
+    throw new Error('No active Field Theory context found. Open a Field Theory document and attach a Codex terminal first.');
+  }
+
+  const manifest = readJsonObject(manifestPath);
+  const activeDocument = manifest.activeDocument;
+  if (!activeDocument || typeof activeDocument !== 'object' || Array.isArray(activeDocument)) {
+    throw new Error(`Context manifest has no activeDocument object: ${manifestPath}`);
+  }
+
+  const documentRecord = activeDocument as ManifestRecord;
+  const contentPath = stringField(documentRecord.contentPath);
+  if (!contentPath) {
+    throw new Error(`Context manifest has no activeDocument.contentPath: ${manifestPath}`);
+  }
+  assertInsideDirectory(contentPath, path.dirname(manifestPath));
+
+  return {
+    manifestPath,
+    updatedAt: stringField(manifest.updatedAt),
+    activeDocument: {
+      title: stringField(documentRecord.title),
+      path: stringField(documentRecord.path),
+      kind: stringField(documentRecord.kind),
+      contentMode: stringField(documentRecord.contentMode),
+      contentPath,
+    },
+  };
+}
+
+export function readCurrentDocumentContext(manifestPath = findCurrentContextManifest()): CurrentDocumentContext {
+  const summary = readCurrentDocumentSummary(manifestPath);
+  return {
+    ...summary,
+    content: fs.readFileSync(summary.activeDocument.contentPath, 'utf-8'),
+  };
+}
+
+export function formatCurrentDocumentContext(context: CurrentDocumentContext): string {
+  const lines = [
+    '# Field Theory Current Document',
+    '',
+    `title: ${context.activeDocument.title ?? '(untitled)'}`,
+    `source: ${context.activeDocument.path ?? '(unknown)'}`,
+    `kind: ${context.activeDocument.kind ?? '(unknown)'}`,
+    `contentMode: ${context.activeDocument.contentMode ?? '(unknown)'}`,
+    `updatedAt: ${context.updatedAt ?? '(unknown)'}`,
+    `manifest: ${context.manifestPath}`,
+    `content: ${context.activeDocument.contentPath}`,
+    '',
+    '---',
+    '',
+    context.content,
+  ];
+
+  return `${lines.join('\n')}${context.content.endsWith('\n') ? '' : '\n'}`;
+}
+
+export function formatCurrentDocumentSummary(context: CurrentDocumentSummary): string {
+  return [
+    `title: ${context.activeDocument.title ?? '(untitled)'}`,
+    `source: ${context.activeDocument.path ?? '(unknown)'}`,
+    `kind: ${context.activeDocument.kind ?? '(unknown)'}`,
+    `contentMode: ${context.activeDocument.contentMode ?? '(unknown)'}`,
+    `updatedAt: ${context.updatedAt ?? '(unknown)'}`,
+    `manifest: ${context.manifestPath}`,
+    `content: ${context.activeDocument.contentPath}`,
+    '',
+  ].join('\n');
+}

--- a/src/document-ops.ts
+++ b/src/document-ops.ts
@@ -31,7 +31,7 @@ export function sha256(value: string): string {
 
 export function isPathInside(parentPath: string, childPath: string): boolean {
   const relPath = path.relative(parentPath, childPath);
-  return relPath === '' || (!!relPath && !relPath.startsWith(`..${path.sep}`) && !path.isAbsolute(relPath));
+  return relPath === '' || (!!relPath && relPath !== '..' && !relPath.startsWith(`..${path.sep}`) && !path.isAbsolute(relPath));
 }
 
 export function normalizeMarkdownFileName(name: string, options: { rejectLeadingUnderscore?: boolean } = {}): string | null {

--- a/src/library.ts
+++ b/src/library.ts
@@ -1,9 +1,10 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { canonicalLibraryDir } from './paths.js';
+import { canonicalLibraryDir, codexContextSessionsDir } from './paths.js';
 import {
   createMarkdownFile,
   DocumentVersion,
+  isPathInside,
   moveToTrash,
   readContentInput,
   readMarkdownDocument,
@@ -43,6 +44,13 @@ export interface LibraryUpdateInput extends LibraryWriteInput {
   force?: boolean;
 }
 
+export interface LibraryListOptions {
+  limit?: number;
+  includeRelPathPrefixes?: string[];
+  excludeDirs?: string[];
+  includeInternal?: boolean;
+}
+
 function libraryRoot(): string {
   return canonicalLibraryDir();
 }
@@ -53,35 +61,77 @@ function titleFromContent(filePath: string, content: string): string {
   return path.basename(filePath, path.extname(filePath));
 }
 
-function summaryForFile(filePath: string): LibraryDocumentSummary {
-  const content = fs.readFileSync(filePath, 'utf-8');
+function summaryForFile(filePath: string, content?: string): LibraryDocumentSummary {
+  const fileContent = content ?? fs.readFileSync(filePath, 'utf-8');
   const stats = fs.statSync(filePath);
   return {
     path: filePath,
     relPath: relativeMarkdownPath(libraryRoot(), filePath),
-    title: titleFromContent(filePath, content),
+    title: titleFromContent(filePath, fileContent),
     updatedAt: new Date(stats.mtimeMs).toISOString(),
     size: stats.size,
   };
 }
 
-function walkMarkdownFiles(dirPath: string): string[] {
+function defaultExcludedDirs(): string[] {
+  return [codexContextSessionsDir()];
+}
+
+function normalizedRelPathPrefix(prefix: string): string {
+  return prefix.replace(/\\/g, '/').replace(/^\/+/, '');
+}
+
+function excludedDirsFor(options: LibraryListOptions): string[] {
+  const explicit = options.excludeDirs ?? [];
+  return options.includeInternal ? explicit : [...defaultExcludedDirs(), ...explicit];
+}
+
+function shouldSkipDir(dirPath: string, excludedDirs: string[]): boolean {
+  const resolved = path.resolve(dirPath);
+  return excludedDirs.some((excludedDir) => {
+    const excluded = path.resolve(excludedDir);
+    return resolved === excluded || isPathInside(excluded, resolved);
+  });
+}
+
+function matchesRelPathPrefix(filePath: string, root: string, prefixes: string[] | undefined): boolean {
+  if (!prefixes || prefixes.length === 0) return true;
+  const relPath = relativeMarkdownPath(root, filePath);
+  return prefixes.some((prefix) => relPath.startsWith(prefix));
+}
+
+function walkMarkdownFiles(dirPath: string, options: LibraryListOptions = {}): string[] {
   const files: string[] = [];
   if (!fs.existsSync(dirPath)) return files;
+  const root = path.resolve(dirPath);
+  const includePrefixes = options.includeRelPathPrefixes?.map(normalizedRelPathPrefix);
+  const excludedDirs = excludedDirsFor(options);
+  const limit = options.limit && options.limit > 0 ? options.limit : undefined;
 
   function walk(current: string): void {
-    for (const entry of fs.readdirSync(current, { withFileTypes: true })) {
+    if (limit !== undefined && files.length >= limit) return;
+    const entries = fs.readdirSync(current, { withFileTypes: true })
+      .sort((a, b) => a.name.localeCompare(b.name));
+
+    for (const entry of entries) {
+      if (limit !== undefined && files.length >= limit) break;
       const absPath = path.join(current, entry.name);
       if (entry.isDirectory()) {
+        if (entry.name.startsWith('.') || shouldSkipDir(absPath, excludedDirs)) continue;
         walk(absPath);
-      } else if (entry.isFile() && /\.(md|markdown)$/i.test(entry.name)) {
+      } else if (
+        entry.isFile()
+        && !entry.name.startsWith('.')
+        && /\.(md|markdown)$/i.test(entry.name)
+        && matchesRelPathPrefix(absPath, root, includePrefixes)
+      ) {
         files.push(absPath);
       }
     }
   }
 
   walk(dirPath);
-  return files.sort();
+  return files;
 }
 
 function snippetFor(content: string, query: string): string {
@@ -105,21 +155,20 @@ function defaultContent(targetPath: string, input: LibraryWriteInput): string {
   return `# ${input.title.trim() || path.basename(targetPath, path.extname(targetPath))}\n`;
 }
 
-export function listLibraryDocuments(options: { limit?: number } = {}): LibraryDocumentSummary[] {
-  const docs = walkMarkdownFiles(libraryRoot()).map((filePath) => summaryForFile(filePath));
-  return docs.slice(0, options.limit ?? docs.length);
+export function listLibraryDocuments(options: LibraryListOptions = {}): LibraryDocumentSummary[] {
+  return walkMarkdownFiles(libraryRoot(), options).map((filePath) => summaryForFile(filePath));
 }
 
-export function searchLibraryDocuments(query: string, options: { limit?: number } = {}): LibrarySearchResult[] {
+export function searchLibraryDocuments(query: string, options: LibraryListOptions = {}): LibrarySearchResult[] {
   const needle = query.trim();
   if (!needle) return [];
 
   const results: LibrarySearchResult[] = [];
-  for (const filePath of walkMarkdownFiles(libraryRoot())) {
+  for (const filePath of walkMarkdownFiles(libraryRoot(), { ...options, limit: undefined })) {
     const content = fs.readFileSync(filePath, 'utf-8');
     if (!content.toLowerCase().includes(needle.toLowerCase())) continue;
     results.push({
-      ...summaryForFile(filePath),
+      ...summaryForFile(filePath, content),
       snippet: snippetFor(content, needle),
     });
     if (results.length >= (options.limit ?? 20)) break;

--- a/src/navigation.ts
+++ b/src/navigation.ts
@@ -1,0 +1,578 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { buildFieldTheoryOpenTarget, inferOpenKind, openFieldTheoryTarget } from './app-open.js';
+import {
+  createCommandDocument,
+  listCommandDocuments,
+  renameCommandDocument,
+  showCommandDocument,
+  type CommandDocumentSummary,
+} from './commands-files.js';
+import { formatAgentContext, getAgentContext } from './agent-context.js';
+import { readCurrentDocumentSummary } from './current.js';
+import {
+  canonicalCommandsDir,
+  canonicalLibraryDir,
+} from './paths.js';
+import {
+  createLibraryDocument,
+  listLibraryDocuments,
+  renameLibraryDocument,
+  searchLibraryDocuments,
+  showLibraryDocument,
+  type LibraryDocumentSummary,
+} from './library.js';
+import { isPathInside, readContentInput, readDocumentVersion, resolveMarkdownPath } from './document-ops.js';
+
+export type NavigationPlace = 'library' | 'commands' | 'briefs' | 'scratchpad' | 'wikis' | 'debates' | 'recent' | 'current';
+
+export interface NavigationEntry {
+  place: NavigationPlace | 'command';
+  path: string;
+  relPath: string;
+  title: string;
+  updatedAt: string;
+  size: number;
+}
+
+export interface NavigationSearchResult extends NavigationEntry {
+  snippet?: string;
+}
+
+export interface NavigationLink {
+  target: string;
+  count: number;
+}
+
+export interface NavigationWikiLink {
+  target: string;
+  link: string;
+  label: string;
+  entry: NavigationEntry;
+}
+
+export interface NavigationTag {
+  tag: string;
+  count: number;
+}
+
+export interface NavigationWriteInput {
+  stdin?: boolean;
+  file?: string;
+  content?: string;
+}
+
+export interface NavigationOpenOptions {
+  launch?: boolean;
+  query?: string;
+  action?: 'open' | 'tab' | 'reveal';
+}
+
+export interface NavigationOpenResult {
+  path: string;
+  url: string | null;
+  launched: boolean;
+}
+
+export interface NavigationState {
+  current: string;
+  backStack: string[];
+}
+
+export type NavigationPlaceSummary = { name: NavigationPlace; description: string };
+
+function navigationPlaces(): NavigationPlaceSummary[] {
+  return [
+    { name: 'library', description: canonicalLibraryDir() },
+    { name: 'commands', description: canonicalCommandsDir() },
+    { name: 'briefs', description: 'Library/briefs' },
+    { name: 'scratchpad', description: 'Library/Scratchpad' },
+    { name: 'wikis', description: 'Library wiki documents' },
+    { name: 'debates', description: 'Library debate documents' },
+    { name: 'recent', description: 'recent repo files for agent context' },
+    { name: 'current', description: 'active Field Theory document context' },
+  ];
+}
+
+const PLACE_PREFIXES: Partial<Record<NavigationPlace, string[]>> = {
+  briefs: ['briefs/', 'Briefs/'],
+  scratchpad: ['scratchpad/', 'Scratchpad/'],
+  wikis: ['wikis/', 'Wikis/', 'wiki/', 'Wiki/'],
+  debates: ['debates/', 'Debates/'],
+};
+
+function titleFromLibrary(doc: LibraryDocumentSummary): string {
+  return doc.title || path.basename(doc.relPath, path.extname(doc.relPath));
+}
+
+function libraryEntry(doc: LibraryDocumentSummary, place: NavigationPlace = 'library'): NavigationEntry {
+  return {
+    place,
+    path: doc.path,
+    relPath: doc.relPath,
+    title: titleFromLibrary(doc),
+    updatedAt: doc.updatedAt,
+    size: doc.size,
+  };
+}
+
+function commandEntry(doc: CommandDocumentSummary): NavigationEntry {
+  return {
+    place: 'commands',
+    path: doc.path,
+    relPath: doc.relPath,
+    title: doc.name,
+    updatedAt: doc.updatedAt,
+    size: doc.size,
+  };
+}
+
+function normalizeNeedle(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+function matchesTitleOrPath(entry: NavigationEntry, query: string): boolean {
+  const needle = normalizeNeedle(query);
+  return entry.title.toLowerCase().includes(needle) || entry.relPath.toLowerCase().includes(needle);
+}
+
+function allNavigationEntries(): NavigationEntry[] {
+  return [
+    ...listLibraryNavigationDocuments().map((doc) => libraryEntry(doc)),
+    ...listCommandDocuments().map(commandEntry),
+  ];
+}
+
+function navigationLibraryExcludeDirs(): string[] {
+  const libraryRoot = path.resolve(canonicalLibraryDir());
+  const commandsRoot = path.resolve(canonicalCommandsDir());
+  if (commandsRoot !== libraryRoot && isPathInside(libraryRoot, commandsRoot)) {
+    return [commandsRoot];
+  }
+  return [];
+}
+
+function listLibraryNavigationDocuments(options: {
+  limit?: number;
+  includeRelPathPrefixes?: string[];
+} = {}): LibraryDocumentSummary[] {
+  return listLibraryDocuments({
+    ...options,
+    excludeDirs: navigationLibraryExcludeDirs(),
+  });
+}
+
+function slugTitle(title: string): string {
+  return title
+    .trim()
+    .toLowerCase()
+    .replace(/['"]/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '') || 'untitled';
+}
+
+function todayIsoDate(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function navStatePath(): string {
+  return path.join(canonicalLibraryDir(), '.ft-navigation-state.json');
+}
+
+function readNavState(): NavigationState {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(navStatePath(), 'utf-8')) as Partial<NavigationState>;
+    return {
+      current: typeof parsed.current === 'string' ? parsed.current : 'library',
+      backStack: Array.isArray(parsed.backStack) ? parsed.backStack.filter((item): item is string => typeof item === 'string') : [],
+    };
+  } catch {
+    return { current: 'library', backStack: [] };
+  }
+}
+
+function writeNavState(state: NavigationState): void {
+  fs.mkdirSync(path.dirname(navStatePath()), { recursive: true });
+  fs.writeFileSync(navStatePath(), JSON.stringify(state, null, 2));
+}
+
+function parseFrontmatterTags(content: string): string[] {
+  const match = /^---\n([\s\S]*?)\n---\n/.exec(content);
+  if (!match) return [];
+  const yaml = match[1];
+  const tags: string[] = [];
+  const inline = /^tags:\s*(.+)$/im.exec(yaml);
+  if (inline) {
+    const raw = inline[1].trim();
+    if (raw.startsWith('[') && raw.endsWith(']')) {
+      tags.push(...raw.slice(1, -1).split(',').map((tag) => tag.trim().replace(/^["']|["']$/g, '')));
+    } else if (!raw.startsWith('|')) {
+      tags.push(...raw.split(/[,\s]+/).map((tag) => tag.trim()));
+    }
+  }
+  const block = /^tags:\s*\n((?:\s*-\s*.+\n?)+)/im.exec(yaml);
+  if (block) {
+    tags.push(...block[1].split('\n').map((line) => line.replace(/^\s*-\s*/, '').trim()));
+  }
+  return tags.map((tag) => tag.replace(/^#/, '')).filter(Boolean);
+}
+
+function extractInlineTags(content: string): string[] {
+  const tags = new Set<string>();
+  for (const match of content.matchAll(/(?:^|[\s(])#([A-Za-z][A-Za-z0-9_-]*)\b/gm)) {
+    tags.add(match[1]);
+  }
+  return [...tags];
+}
+
+function extractWikiLinks(content: string): string[] {
+  const counts = new Map<string, number>();
+  for (const match of content.matchAll(/\[\[([^\]\n|]+)(?:\|[^\]\n]+)?\]\]/g)) {
+    const target = match[1].trim();
+    counts.set(target, (counts.get(target) ?? 0) + 1);
+  }
+  return [...counts.entries()]
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+    .map(([target]) => target);
+}
+
+function escapeWikiLinkPart(value: string): string {
+  return value.replace(/\]\]/g, ']]\\]');
+}
+
+function bestWikiLinkLabel(entry: NavigationEntry): string {
+  if (entry.place === 'commands') return entry.title;
+  if (entry.title) return entry.title;
+  return entry.relPath.replace(/\.(md|markdown)$/i, '');
+}
+
+function countValues(values: string[]): { value: string; count: number }[] {
+  const counts = new Map<string, number>();
+  for (const value of values) counts.set(value, (counts.get(value) ?? 0) + 1);
+  return [...counts.entries()]
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+    .map(([value, count]) => ({ value, count }));
+}
+
+function retitleMarkdownFile(filePath: string, title: string): void {
+  const content = fs.readFileSync(filePath, 'utf-8');
+  const next = /^#\s+.+$/m.test(content)
+    ? content.replace(/^#\s+.+$/m, `# ${title}`)
+    : `# ${title}\n\n${content}`;
+  fs.writeFileSync(filePath, next, 'utf-8');
+}
+
+export function resolveNavigationEntry(target: string): NavigationEntry {
+  const raw = target.trim();
+  const exact = allNavigationEntries().find((entry) => {
+    return entry.relPath === raw
+      || entry.path === raw
+      || entry.title.toLowerCase() === raw.toLowerCase()
+      || entry.relPath.toLowerCase() === `${raw.toLowerCase()}.md`;
+  });
+  if (exact) return exact;
+
+  const matches = findNavigationEntries(raw, 2);
+  if (matches.length === 1) return matches[0];
+  if (matches.length > 1) throw new Error(`Ambiguous Field Theory document: ${target}`);
+  throw new Error(`Field Theory document not found: ${target}`);
+}
+
+export function listNavigationPlaces(): NavigationPlaceSummary[] {
+  return navigationPlaces();
+}
+
+export function listNavigationEntries(place: NavigationPlace, limit?: number): NavigationEntry[] {
+  if (place === 'commands') {
+    return listCommandDocuments().map(commandEntry).slice(0, limit);
+  }
+
+  if (place === 'recent' || place === 'current') return [];
+
+  const prefixes = PLACE_PREFIXES[place];
+  return listLibraryNavigationDocuments({
+    limit,
+    includeRelPathPrefixes: prefixes,
+  }).map((doc) => libraryEntry(doc, place));
+}
+
+export function findNavigationEntries(query: string, limit = 20): NavigationEntry[] {
+  return allNavigationEntries().filter((entry) => matchesTitleOrPath(entry, query)).slice(0, limit);
+}
+
+export function grepNavigationContent(query: string, limit = 20): NavigationSearchResult[] {
+  const results: NavigationSearchResult[] = [];
+  for (const result of searchLibraryDocuments(query, { limit, excludeDirs: navigationLibraryExcludeDirs() })) {
+    results.push({ ...libraryEntry(result), snippet: result.snippet });
+  }
+
+  if (results.length >= limit) return results.slice(0, limit);
+
+  const needle = normalizeNeedle(query);
+  for (const doc of listCommandDocuments()) {
+    if (results.length >= limit) break;
+    const content = fs.readFileSync(doc.path, 'utf-8');
+    const compact = content.replace(/\s+/g, ' ').trim();
+    const index = compact.toLowerCase().indexOf(needle);
+    if (index < 0) continue;
+    const start = Math.max(0, index - 70);
+    const end = Math.min(compact.length, index + needle.length + 110);
+    results.push({
+      ...commandEntry(doc),
+      snippet: `${start > 0 ? '...' : ''}${compact.slice(start, end)}${end < compact.length ? '...' : ''}`,
+    });
+  }
+
+  return results;
+}
+
+export async function readNavigationDocument(target: string): Promise<NavigationEntry & { content: string }> {
+  const resolved = resolveMarkdownPath(canonicalLibraryDir(), target) ?? resolveMarkdownPath(canonicalCommandsDir(), target);
+  const input = resolved && fs.existsSync(resolved) ? resolved : resolveNavigationEntry(target).path;
+  const kind = inferOpenKind(input);
+  if (kind === 'command') {
+    const doc = await showCommandDocument(input);
+    return { ...commandEntry(doc), content: doc.content };
+  }
+
+  if (kind === 'library' || kind === null) {
+    try {
+      const doc = await showLibraryDocument(input);
+      return { ...libraryEntry(doc), content: doc.content };
+    } catch (error) {
+      if (kind === 'library') throw error;
+      const doc = await showCommandDocument(input);
+      return { ...commandEntry(doc), content: doc.content };
+    }
+  }
+
+  throw new Error(`Unsupported document target: ${target}`);
+}
+
+export async function openNavigationDocument(target: string, options: NavigationOpenOptions = {}): Promise<NavigationOpenResult> {
+  const entry = options.query ? findNavigationEntries(options.query, 1)[0] : resolveNavigationEntry(target);
+  if (!entry) throw new Error(`No Field Theory document found for query: ${options.query}`);
+  const kind = inferOpenKind(entry.path) ?? 'library';
+  const openTarget = buildFieldTheoryOpenTarget(entry.path, kind);
+  if (openTarget.url && options.action && options.action !== 'open') {
+    const url = new URL(openTarget.url);
+    url.searchParams.set('action', options.action);
+    openTarget.url = url.toString();
+  }
+  const launch = options.launch !== false ? openFieldTheoryTarget(openTarget) : undefined;
+  return {
+    path: openTarget.path,
+    url: openTarget.url,
+    launched: Boolean(launch?.launched),
+  };
+}
+
+export function formatNavigationEntries(entries: NavigationEntry[]): string {
+  if (entries.length === 0) return '(none)\n';
+  return `${entries.map((entry) => `${entry.relPath}  ${entry.title}`).join('\n')}\n`;
+}
+
+export function formatNavigationSearchResults(entries: NavigationSearchResult[]): string {
+  if (entries.length === 0) return '(none)\n';
+  return `${entries.map((entry) => {
+    const firstLine = `${entry.relPath}  ${entry.title}`;
+    return entry.snippet ? `${firstLine}\n  ${entry.snippet}` : firstLine;
+  }).join('\n')}\n`;
+}
+
+export function formatNavigationPlaces(): string {
+  return `${listNavigationPlaces().map((place) => `${place.name}  ${place.description}`).join('\n')}\n`;
+}
+
+export function formatNavigationTree(limit = 80): string {
+  const entries = listLibraryNavigationDocuments({ limit }).map((doc) => doc.relPath);
+  if (entries.length === 0) return '(none)\n';
+  return `${entries.join('\n')}\n`;
+}
+
+export function formatNavigationHead(content: string, lines = 40): string {
+  return `${content.split('\n').slice(0, lines).join('\n')}\n`;
+}
+
+export function formatNavigationMeta(entry: NavigationEntry): string {
+  const content = fs.readFileSync(entry.path, 'utf-8');
+  const tags = [...new Set([...parseFrontmatterTags(content), ...extractInlineTags(content)])].sort();
+  const links = extractWikiLinks(content);
+  return [
+    `title: ${entry.title}`,
+    `place: ${entry.place}`,
+    `path: ${entry.path}`,
+    `relPath: ${entry.relPath}`,
+    `updatedAt: ${entry.updatedAt}`,
+    `size: ${entry.size}`,
+    `tags: ${tags.length ? tags.join(', ') : '(none)'}`,
+    `links: ${links.length ? links.join(', ') : '(none)'}`,
+    '',
+  ].join('\n');
+}
+
+export function formatNavigationPwd(): string {
+  try {
+    const context = readCurrentDocumentSummary();
+    const source = context.activeDocument.path ?? context.activeDocument.contentPath;
+    return `${context.activeDocument.title ?? '(untitled)'}\n${source}\n`;
+  } catch {
+    return `Library\n${canonicalLibraryDir()}\n`;
+  }
+}
+
+export function formatNavigationContext(repoPath = process.cwd(), limit = 8): string {
+  const lines = ['# Field Theory Context', ''];
+  try {
+    const context = readCurrentDocumentSummary();
+    lines.push(`current: ${context.activeDocument.title ?? '(untitled)'}`);
+    lines.push(`source: ${context.activeDocument.path ?? '(unknown)'}`);
+    lines.push(`manifest: ${context.manifestPath}`);
+  } catch (error) {
+    lines.push(`current: ${(error as Error).message}`);
+  }
+  lines.push('');
+  lines.push(formatAgentContext(getAgentContext(repoPath, limit)).trimEnd());
+  lines.push('');
+  return lines.join('\n');
+}
+
+export async function createNavigationDocument(type: string, title: string, input: NavigationWriteInput = {}): Promise<NavigationEntry> {
+  const normalizedType = type.trim().toLowerCase();
+  const cleanTitle = title.trim();
+  if (!cleanTitle) throw new Error('Title is required.');
+  if (normalizedType === 'command') {
+    const doc = await createCommandDocument(slugTitle(cleanTitle), input);
+    return commandEntry(doc);
+  }
+  const folderByType: Record<string, string> = {
+    brief: 'briefs',
+    scratchpad: 'Scratchpad',
+    wiki: 'wikis',
+    debate: 'debates',
+  };
+  const placeByType: Record<string, NavigationPlace> = {
+    brief: 'briefs',
+    scratchpad: 'scratchpad',
+    wiki: 'wikis',
+    debate: 'debates',
+  };
+  const folder = folderByType[normalizedType];
+  if (!folder) throw new Error(`Unknown Field Theory document type: ${type}`);
+  const target = path.posix.join(folder, slugTitle(cleanTitle));
+  const content = input.content ?? `# ${cleanTitle}\n`;
+  const doc = await createLibraryDocument(target, { ...input, content, title: cleanTitle });
+  return libraryEntry(doc, placeByType[normalizedType]);
+}
+
+export async function appendNavigationDocument(target: string, input: NavigationWriteInput): Promise<NavigationEntry & { version: ReturnType<typeof readDocumentVersion> }> {
+  const entry = resolveNavigationEntry(target);
+  const content = await readContentInput({ stdin: input.stdin, file: input.file, fallback: input.content });
+  if (!content) throw new Error('Append content is required. Pass text, --stdin, or --file.');
+  fs.appendFileSync(entry.path, content.endsWith('\n') ? content : `${content}\n`, 'utf-8');
+  return { ...entry, version: readDocumentVersion(entry.path) };
+}
+
+export async function createNavigationNote(text: string, title?: string): Promise<NavigationEntry & { version: ReturnType<typeof readDocumentVersion> }> {
+  const target = path.posix.join('Scratchpad', `${todayIsoDate()}.md`);
+  const filePath = resolveMarkdownPath(canonicalLibraryDir(), target);
+  if (!filePath) throw new Error(`Invalid scratchpad note path: ${target}`);
+  const heading = title?.trim() || `Scratchpad ${todayIsoDate()}`;
+  if (!fs.existsSync(filePath)) {
+    await createLibraryDocument(target, { content: `# ${heading}\n\n` });
+  }
+  const entry = resolveNavigationEntry(target);
+  fs.appendFileSync(filePath, `${text.trim()}\n`, 'utf-8');
+  return { ...entry, version: readDocumentVersion(filePath) };
+}
+
+export async function renameNavigationDocument(target: string, nextTitle: string): Promise<NavigationEntry> {
+  const entry = resolveNavigationEntry(target);
+  const cleanTitle = nextTitle.trim();
+  if (!cleanTitle) throw new Error('New title is required.');
+  if (entry.place === 'commands') {
+    const doc = await renameCommandDocument(entry.path, slugTitle(cleanTitle));
+    retitleMarkdownFile(doc.path, cleanTitle);
+    return commandEntry(doc);
+  }
+  const folder = path.posix.dirname(entry.relPath);
+  const nextPath = path.posix.join(folder === '.' ? '' : folder, slugTitle(cleanTitle));
+  const doc = await renameLibraryDocument(entry.path, nextPath);
+  retitleMarkdownFile(doc.path, cleanTitle);
+  return libraryEntry(doc, entry.place as NavigationPlace);
+}
+
+export function listNavigationLinks(target: string): NavigationLink[] {
+  const entry = resolveNavigationEntry(target);
+  const content = fs.readFileSync(entry.path, 'utf-8');
+  return countValues(extractWikiLinks(content)).map(({ value, count }) => ({ target: value, count }));
+}
+
+export function buildNavigationWikiLink(target: string, alias?: string): NavigationWikiLink {
+  const entry = resolveNavigationEntry(target);
+  const label = bestWikiLinkLabel(entry);
+  const link = alias?.trim()
+    ? `[[${escapeWikiLinkPart(label)}|${escapeWikiLinkPart(alias.trim())}]]`
+    : `[[${escapeWikiLinkPart(label)}]]`;
+  return { target: label, link, label, entry };
+}
+
+export function listNavigationBacklinks(target: string): NavigationSearchResult[] {
+  const entry = resolveNavigationEntry(target);
+  const needles = new Set([entry.title, entry.relPath, entry.relPath.replace(/\.(md|markdown)$/i, '')]);
+  return allNavigationEntries()
+    .filter((candidate) => candidate.path !== entry.path)
+    .filter((candidate) => {
+      const links = extractWikiLinks(fs.readFileSync(candidate.path, 'utf-8'));
+      return links.some((link) => needles.has(link));
+    });
+}
+
+export function listNavigationTags(): NavigationTag[] {
+  const tags: string[] = [];
+  for (const entry of allNavigationEntries()) {
+    const content = fs.readFileSync(entry.path, 'utf-8');
+    tags.push(...parseFrontmatterTags(content), ...extractInlineTags(content));
+  }
+  return countValues(tags).map(({ value, count }) => ({ tag: value, count }));
+}
+
+export function listNavigationTagged(tag: string): NavigationEntry[] {
+  const needle = tag.trim().replace(/^#/, '').toLowerCase();
+  return allNavigationEntries().filter((entry) => {
+    const content = fs.readFileSync(entry.path, 'utf-8');
+    const tags = [...parseFrontmatterTags(content), ...extractInlineTags(content)];
+    return tags.some((candidate) => candidate.toLowerCase() === needle);
+  });
+}
+
+export function cdNavigation(target: string): NavigationState {
+  const state = readNavState();
+  const destination = listNavigationPlaces().some((place) => place.name === target)
+    ? target
+    : resolveNavigationEntry(target).relPath;
+  writeNavState({ current: destination, backStack: [state.current, ...state.backStack].slice(0, 25) });
+  return readNavState();
+}
+
+export function backNavigation(): NavigationState {
+  const state = readNavState();
+  const [previous, ...rest] = state.backStack;
+  if (!previous) return state;
+  writeNavState({ current: previous, backStack: rest });
+  return readNavState();
+}
+
+export function formatNavigationState(state: NavigationState): string {
+  return `current: ${state.current}\nback: ${state.backStack[0] ?? '(none)'}\n`;
+}
+
+export function formatNavigationLinks(links: NavigationLink[]): string {
+  if (links.length === 0) return '(none)\n';
+  return `${links.map((link) => `${link.target}  ${link.count}`).join('\n')}\n`;
+}
+
+export function formatNavigationTags(tags: NavigationTag[]): string {
+  if (tags.length === 0) return '(none)\n';
+  return `${tags.map((tag) => `${tag.tag}  ${tag.count}`).join('\n')}\n`;
+}

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -28,7 +28,11 @@ export function canonicalLibraryDir(): string {
 }
 
 export function canonicalCommandsDir(): string {
-  return process.env.FT_COMMANDS_DIR ?? path.join(fieldTheoryDir(), 'commands');
+  return process.env.FT_COMMANDS_DIR ?? path.join(canonicalLibraryDir(), 'Commands');
+}
+
+export function codexContextSessionsDir(): string {
+  return path.join(canonicalLibraryDir(), 'Codex Context', 'sessions');
 }
 
 export function libraryDir(): string {

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -31,6 +31,10 @@ export function canonicalCommandsDir(): string {
   return process.env.FT_COMMANDS_DIR ?? path.join(fieldTheoryDir(), 'commands');
 }
 
+export function codexContextSessionsDir(): string {
+  return path.join(canonicalLibraryDir(), 'Codex Context', 'sessions');
+}
+
 export function libraryDir(): string {
   const override = process.env.FT_LIBRARY_DIR;
   if (override) return override;

--- a/src/skill.ts
+++ b/src/skill.ts
@@ -35,12 +35,13 @@ Field Theory has three main local surfaces:
 ## Search Workflow
 
 1. Check paths and status when setup matters: \`ft paths --json\`, \`ft status --json\`
-2. When the user says "that file" or "the recent file", inspect current repo recency with \`ft recent --json\`
-3. Search durable notes first when prior project knowledge matters: \`ft library search <query> --json\`
-4. Search bookmarks when reading history or saved X/Twitter posts matter: \`ft search <query> --json\`
-5. Inspect exact files or bookmarks with \`ft library show <path> --json\`, \`ft show <id> --json\`, or \`ft commands show <name> --json\`
-6. Create or update durable Library notes and portable commands only when the user asks for a saved artifact
-7. Open useful Library pages in the Mac app with \`ft library open <path>\`
+2. When the user asks what Field Theory document they are looking at, run \`ft current --json\`; only use \`ft current --content-only\` when the document body is needed
+3. When the user says "that file" or "the recent file", inspect current repo recency with \`ft recent --json\`
+4. Search durable notes first when prior project knowledge matters: \`ft library search <query> --json\`
+5. Search bookmarks when reading history or saved X/Twitter posts matter: \`ft search <query> --json\`
+6. Inspect exact files or bookmarks with \`ft library show <path> --json\`, \`ft show <id> --json\`, or \`ft commands show <name> --json\`
+7. Create or update durable Library notes and portable commands only when the user asks for a saved artifact
+8. Open useful Library pages in the Mac app with \`ft library open <path>\`
 
 ## Possible Roadmap Workflow
 
@@ -58,7 +59,8 @@ Use this shape:
 \`\`\`bash
 ft seeds search "<bookmark topic>" --days 180 --limit 8 --frame impact-effort --create
 ft possible run --seed <seed-id> --repos <repo-a> <repo-b> <repo-c> --frame impact-effort --nodes 7 --model opus --effort medium
-ft possible grid latest
+ft possible grid latest          # latest run or batch
+ft possible grid latest-batch    # latest multi-repo batch
 ft possible dots latest
 ft possible prompt <node-id>
 \`\`\`
@@ -70,6 +72,8 @@ ft possible run --seed <seed-id> --repos <repo-a> <repo-b> --nodes 7 --model opu
 ft possible jobs
 ft possible job <job-id> --log
 \`\`\`
+
+LLM-backed commands default to the user's logged-in Claude Code/Codex CLI account. Only use API/provider billing env vars when the user explicitly sets \`FT_ENGINE_AUTH_MODE=api\`.
 
 For nightly roadmap generation on macOS:
 
@@ -87,6 +91,8 @@ If the user says "debate", use the existing \`ft possible\` pipeline as generate
 \`\`\`bash
 ft paths --json                # Canonical bookmarks, library, commands paths
 ft status --json               # Bookmark/classification status plus paths
+ft current --json              # Active Field Theory document metadata without the full body
+ft current --content-only      # Active document body when the user/model actually needs it
 ft recent --json               # Current repo last-modified file and recent files for agent references
 
 ft search <query>              # Full-text BM25 search ("exact phrase", AND, OR, NOT)
@@ -100,7 +106,8 @@ ft show <id>                   # Full detail for one bookmark
 ft seeds search <query> --create
 ft repos add <path>
 ft possible run --seed <id> --repos <paths...>
-ft possible grid latest
+ft possible grid latest          # latest run or batch
+ft possible grid latest-batch    # latest multi-repo batch
 ft possible dots latest
 ft possible prompt <node-id>
 ft possible nightly install --time 02:00 --defaults

--- a/src/skill.ts
+++ b/src/skill.ts
@@ -35,12 +35,13 @@ Field Theory has three main local surfaces:
 ## Search Workflow
 
 1. Check paths and status when setup matters: \`ft paths --json\`, \`ft status --json\`
-2. When the user says "that file" or "the recent file", inspect current repo recency with \`ft recent --json\`
-3. Search durable notes first when prior project knowledge matters: \`ft library search <query> --json\`
-4. Search bookmarks when reading history or saved X/Twitter posts matter: \`ft search <query> --json\`
-5. Inspect exact files or bookmarks with \`ft library show <path> --json\`, \`ft show <id> --json\`, or \`ft commands show <name> --json\`
-6. Create or update durable Library notes and portable commands only when the user asks for a saved artifact
-7. Open useful Library pages in the Mac app with \`ft library open <path>\`
+2. When the user asks what Field Theory document they are looking at, run \`ft current --json\`
+3. When the user says "that file" or "the recent file", inspect current repo recency with \`ft recent --json\`
+4. Search durable notes first when prior project knowledge matters: \`ft library search <query> --json\`
+5. Search bookmarks when reading history or saved X/Twitter posts matter: \`ft search <query> --json\`
+6. Inspect exact files or bookmarks with \`ft library show <path> --json\`, \`ft show <id> --json\`, or \`ft commands show <name> --json\`
+7. Create or update durable Library notes and portable commands only when the user asks for a saved artifact
+8. Open useful Library pages in the Mac app with \`ft library open <path>\`
 
 ## Possible Roadmap Workflow
 
@@ -87,6 +88,7 @@ If the user says "debate", use the existing \`ft possible\` pipeline as generate
 \`\`\`bash
 ft paths --json                # Canonical bookmarks, library, commands paths
 ft status --json               # Bookmark/classification status plus paths
+ft current --json              # Active Field Theory document attached to the Mac app terminal
 ft recent --json               # Current repo last-modified file and recent files for agent references
 
 ft search <query>              # Full-text BM25 search ("exact phrase", AND, OR, NOT)

--- a/tests/agent-context.test.ts
+++ b/tests/agent-context.test.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -28,23 +29,22 @@ test('getAgentContext returns last modified file and recent files', () => {
   }
 });
 
-test('getAgentContext rejects a missing repo path', () => {
-  const missing = path.join(os.tmpdir(), `ft-agent-context-missing-${Date.now()}`);
-  assert.throws(
-    () => getAgentContext(missing, 2),
-    /Repo path not found/,
-  );
-});
-
-test('getAgentContext rejects a file repo path', () => {
-  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ft-agent-context-file-'));
+test('getAgentContext prefers dirty git files before scanning every tracked file', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ft-agent-context-git-'));
   try {
-    const filePath = path.join(tmpDir, 'not-a-directory.md');
-    fs.writeFileSync(filePath, 'hello');
-    assert.throws(
-      () => getAgentContext(filePath, 2),
-      /Repo path is not a directory/,
-    );
+    execFileSync('git', ['init'], { cwd: tmpDir, stdio: 'ignore' });
+    fs.writeFileSync(path.join(tmpDir, 'clean.md'), 'clean');
+    fs.writeFileSync(path.join(tmpDir, 'dirty.md'), 'dirty');
+    execFileSync('git', ['add', 'clean.md', 'dirty.md'], { cwd: tmpDir, stdio: 'ignore' });
+    execFileSync('git', ['-c', 'user.name=Test', '-c', 'user.email=test@example.com', 'commit', '-m', 'init'], { cwd: tmpDir, stdio: 'ignore' });
+
+    fs.writeFileSync(path.join(tmpDir, 'dirty.md'), 'dirty changed');
+    fs.utimesSync(path.join(tmpDir, 'clean.md'), new Date('2026-01-03T00:00:00.000Z'), new Date('2026-01-03T00:00:00.000Z'));
+    fs.utimesSync(path.join(tmpDir, 'dirty.md'), new Date('2026-01-02T00:00:00.000Z'), new Date('2026-01-02T00:00:00.000Z'));
+
+    const context = getAgentContext(tmpDir, 5);
+    assert.deepEqual(context.recentFiles.map((file) => file.path), ['dirty.md']);
+    assert.equal(context.lastModifiedFile?.path, 'dirty.md');
   } finally {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   }

--- a/tests/app-open.test.ts
+++ b/tests/app-open.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import path from 'node:path';
-import { buildFieldTheoryOpenTarget, openFieldTheoryTarget } from '../src/app-open.js';
+import { buildFieldTheoryOpenTarget, inferOpenKind, openFieldTheoryTarget } from '../src/app-open.js';
 
 test('app-open builds Field Theory wiki URL for library paths', () => {
   const previous = process.env.FT_LIBRARY_DIR;
@@ -31,6 +31,21 @@ test('app-open reports command paths as unsupported deep links', () => {
   } finally {
     if (previous === undefined) delete process.env.FT_COMMANDS_DIR;
     else process.env.FT_COMMANDS_DIR = previous;
+  }
+});
+
+test('app-open infers nested Library/Commands paths as commands', () => {
+  const previousLibrary = process.env.FT_LIBRARY_DIR;
+  const previousCommands = process.env.FT_COMMANDS_DIR;
+  process.env.FT_LIBRARY_DIR = '/tmp/ft-library';
+  delete process.env.FT_COMMANDS_DIR;
+  try {
+    assert.equal(inferOpenKind(path.join('/tmp/ft-library', 'Commands', 'review.md')), 'command');
+  } finally {
+    if (previousLibrary === undefined) delete process.env.FT_LIBRARY_DIR;
+    else process.env.FT_LIBRARY_DIR = previousLibrary;
+    if (previousCommands === undefined) delete process.env.FT_COMMANDS_DIR;
+    else process.env.FT_COMMANDS_DIR = previousCommands;
   }
 });
 

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -26,6 +26,25 @@ async function captureStdout(fn: () => Promise<void>): Promise<string> {
   return chunks.join('');
 }
 
+async function captureStderr(fn: () => Promise<void>): Promise<string> {
+  const chunks: string[] = [];
+  const origWrite = process.stderr.write;
+  process.stderr.write = ((chunk: any, encodingOrCb?: any, cb?: any) => {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk.toString('utf-8') : String(chunk));
+    if (typeof encodingOrCb === 'function') encodingOrCb();
+    if (typeof cb === 'function') cb();
+    return true;
+  }) as typeof process.stderr.write;
+
+  try {
+    await fn();
+  } finally {
+    process.stderr.write = origWrite;
+  }
+
+  return chunks.join('');
+}
+
 test('showDashboard: prints update notice when cache is newer than local', async () => {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ft-dashboard-'));
   const origEnv = process.env.FT_DATA_DIR;
@@ -73,10 +92,265 @@ test('ft search, stats, and status expose --json', () => {
   }
 });
 
-test('ft paths, recent, library, commands, app, and install command groups are registered', () => {
+test('ft paths, current, recent, navigation aliases, library, commands, app, and install command groups are registered', () => {
   const program = buildCli();
-  for (const name of ['paths', 'recent', 'library', 'commands', 'app', 'install']) {
+  for (const name of [
+    'paths', 'current', 'recent', 'ls', 'tree', 'find', 'grep', 'cat', 'head',
+    'meta', 'open', 'tab', 'reveal', 'pwd', 'context', 'link', 'links', 'backlinks',
+    'tags', 'tagged', 'new', 'append', 'note', 'rename', 'cd', 'back',
+    'library', 'commands', 'app', 'install',
+  ]) {
     assert.ok(program.commands.find((c: any) => c.name() === name), `${name} command should be registered`);
+  }
+});
+
+test('ft navigation aliases inspect Field Theory library markdown', async () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ft-nav-'));
+  const origEnv = {
+    FT_LIBRARY_DIR: process.env.FT_LIBRARY_DIR,
+    FT_COMMANDS_DIR: process.env.FT_COMMANDS_DIR,
+  };
+  process.env.FT_LIBRARY_DIR = path.join(tmpDir, 'library');
+  process.env.FT_COMMANDS_DIR = path.join(process.env.FT_LIBRARY_DIR, 'Commands');
+  fs.mkdirSync(path.join(process.env.FT_LIBRARY_DIR, 'briefs'), { recursive: true });
+  fs.mkdirSync(process.env.FT_COMMANDS_DIR, { recursive: true });
+  fs.writeFileSync(path.join(process.env.FT_LIBRARY_DIR, 'briefs', 'Navigation Brief.md'), '# Navigation Brief\n\nFind this routing phrase.\n');
+  fs.writeFileSync(path.join(process.env.FT_COMMANDS_DIR, 'review.md'), '# review\n\nUse this when reviewing work.\n\n## Steps\n\n1. Review.\n\n## Guardrails\n\n- Verify.\n');
+
+  try {
+    const lsOutput = await captureStdout(async () => {
+      await buildCli().parseAsync(['node', 'ft', 'ls', 'briefs']);
+    });
+    assert.match(lsOutput, /briefs\/Navigation Brief\.md/);
+
+    const findOutput = await captureStdout(async () => {
+      await buildCli().parseAsync(['node', 'ft', 'find', 'Navigation']);
+    });
+    assert.match(findOutput, /Navigation Brief/);
+
+    const commandFindOutput = await captureStdout(async () => {
+      await buildCli().parseAsync(['node', 'ft', 'find', 'review', '--limit', '10']);
+    });
+    assert.match(commandFindOutput, /^review\.md\s+review/m);
+    assert.doesNotMatch(commandFindOutput, /Commands\/review\.md/);
+
+    const grepOutput = await captureStdout(async () => {
+      await buildCli().parseAsync(['node', 'ft', 'grep', 'routing phrase']);
+    });
+    assert.match(grepOutput, /routing phrase/);
+
+    const headOutput = await captureStdout(async () => {
+      await buildCli().parseAsync(['node', 'ft', 'head', 'briefs/Navigation Brief', '--lines', '1']);
+    });
+    assert.match(headOutput, /# Navigation Brief\n$/);
+
+    const commandOutput = await captureStdout(async () => {
+      await buildCli().parseAsync(['node', 'ft', 'cat', 'review']);
+    });
+    assert.match(commandOutput, /Use this when reviewing work/);
+  } finally {
+    for (const [key, value] of Object.entries(origEnv)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test('ft link prints canonical wiki links for commands and library docs', async () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ft-link-'));
+  const origEnv = {
+    FT_LIBRARY_DIR: process.env.FT_LIBRARY_DIR,
+    FT_COMMANDS_DIR: process.env.FT_COMMANDS_DIR,
+  };
+  process.env.FT_LIBRARY_DIR = path.join(tmpDir, 'library');
+  process.env.FT_COMMANDS_DIR = path.join(process.env.FT_LIBRARY_DIR, 'Commands');
+  fs.mkdirSync(path.join(process.env.FT_LIBRARY_DIR, 'briefs'), { recursive: true });
+  fs.mkdirSync(process.env.FT_COMMANDS_DIR, { recursive: true });
+  fs.writeFileSync(path.join(process.env.FT_LIBRARY_DIR, 'briefs', 'Workflow Brief.md'), '# Workflow Brief\n\nbody\n');
+  fs.writeFileSync(path.join(process.env.FT_COMMANDS_DIR, 'save.md'), '# save\n\nUse this when saving work.\n');
+
+  try {
+    const commandOutput = await captureStdout(async () => {
+      await buildCli().parseAsync(['node', 'ft', 'link', 'save']);
+    });
+    assert.equal(commandOutput.trim(), '[[save]]');
+
+    const libraryOutput = await captureStdout(async () => {
+      await buildCli().parseAsync(['node', 'ft', 'link', 'Workflow Brief']);
+    });
+    assert.equal(libraryOutput.trim(), '[[Workflow Brief]]');
+
+    const aliasOutput = await captureStdout(async () => {
+      await buildCli().parseAsync(['node', 'ft', 'link', 'Workflow Brief', '--alias', 'the workflow brief']);
+    });
+    assert.equal(aliasOutput.trim(), '[[Workflow Brief|the workflow brief]]');
+
+    const jsonOutput = await captureStdout(async () => {
+      await buildCli().parseAsync(['node', 'ft', 'link', 'save', '--json']);
+    });
+    const parsed = JSON.parse(jsonOutput);
+    assert.equal(parsed.link, '[[save]]');
+    assert.equal(parsed.entry.place, 'commands');
+  } finally {
+    for (const [key, value] of Object.entries(origEnv)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test('ft navigation commands cover links tags writes app targets and location state', async () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ft-nav-full-'));
+  const origEnv = {
+    FT_LIBRARY_DIR: process.env.FT_LIBRARY_DIR,
+    FT_COMMANDS_DIR: process.env.FT_COMMANDS_DIR,
+  };
+  process.env.FT_LIBRARY_DIR = path.join(tmpDir, 'library');
+  process.env.FT_COMMANDS_DIR = path.join(process.env.FT_LIBRARY_DIR, 'Commands');
+  fs.mkdirSync(path.join(process.env.FT_LIBRARY_DIR, 'wikis'), { recursive: true });
+  fs.mkdirSync(process.env.FT_COMMANDS_DIR, { recursive: true });
+  fs.writeFileSync(path.join(process.env.FT_LIBRARY_DIR, 'wikis', 'Alpha.md'), [
+    '---',
+    'tags: [systems, nav]',
+    '---',
+    '# Alpha',
+    '',
+    'See [[Beta]] and #fieldnote.',
+    '',
+  ].join('\n'));
+  fs.writeFileSync(path.join(process.env.FT_LIBRARY_DIR, 'wikis', 'Beta.md'), '# Beta\n\nBack to [[Alpha]].\n');
+
+  try {
+    const linksOutput = await captureStdout(async () => {
+      await buildCli().parseAsync(['node', 'ft', 'links', 'Alpha']);
+    });
+    assert.match(linksOutput, /Beta\s+1/);
+
+    const backlinksOutput = await captureStdout(async () => {
+      await buildCli().parseAsync(['node', 'ft', 'backlinks', 'Alpha']);
+    });
+    assert.match(backlinksOutput, /wikis\/Beta\.md/);
+
+    const tagsOutput = await captureStdout(async () => {
+      await buildCli().parseAsync(['node', 'ft', 'tags']);
+    });
+    assert.match(tagsOutput, /systems\s+1/);
+    assert.match(tagsOutput, /fieldnote\s+1/);
+
+    const taggedOutput = await captureStdout(async () => {
+      await buildCli().parseAsync(['node', 'ft', 'tagged', 'nav']);
+    });
+    assert.match(taggedOutput, /wikis\/Alpha\.md/);
+
+    const openOutput = await captureStdout(async () => {
+      await buildCli().parseAsync(['node', 'ft', 'open', '--query', 'Alpha', '--no-launch']);
+    });
+    assert.match(openOutput, /fieldtheory:\/\/wiki\/open/);
+    assert.match(openOutput, /Alpha\.md/);
+
+    const tabOutput = await captureStdout(async () => {
+      await buildCli().parseAsync(['node', 'ft', 'tab', 'Alpha', '--no-launch']);
+    });
+    assert.match(tabOutput, /action=tab/);
+
+    const revealOutput = await captureStdout(async () => {
+      await buildCli().parseAsync(['node', 'ft', 'reveal', 'Alpha', '--no-launch']);
+    });
+    assert.match(revealOutput, /action=reveal/);
+
+    await buildCli().parseAsync(['node', 'ft', 'new', 'brief', 'Fast Lookup Plan']);
+    assert.equal(fs.existsSync(path.join(process.env.FT_LIBRARY_DIR, 'briefs', 'fast-lookup-plan.md')), true);
+
+    await buildCli().parseAsync(['node', 'ft', 'append', 'Fast Lookup Plan', '--content', 'next step']);
+    assert.match(fs.readFileSync(path.join(process.env.FT_LIBRARY_DIR, 'briefs', 'fast-lookup-plan.md'), 'utf-8'), /next step/);
+
+    await buildCli().parseAsync(['node', 'ft', 'note', 'quick model note']);
+    const scratchpadFiles = fs.readdirSync(path.join(process.env.FT_LIBRARY_DIR, 'Scratchpad'));
+    assert.equal(scratchpadFiles.length, 1);
+    assert.match(fs.readFileSync(path.join(process.env.FT_LIBRARY_DIR, 'Scratchpad', scratchpadFiles[0]), 'utf-8'), /quick model note/);
+
+    await buildCli().parseAsync(['node', 'ft', 'rename', 'Fast Lookup Plan', 'Faster Lookup Plan']);
+    assert.equal(fs.existsSync(path.join(process.env.FT_LIBRARY_DIR, 'briefs', 'faster-lookup-plan.md')), true);
+
+    const cdOutput = await captureStdout(async () => {
+      await buildCli().parseAsync(['node', 'ft', 'cd', 'Faster Lookup Plan']);
+    });
+    assert.match(cdOutput, /current: briefs\/faster-lookup-plan\.md/);
+
+    const backOutput = await captureStdout(async () => {
+      await buildCli().parseAsync(['node', 'ft', 'back']);
+    });
+    assert.match(backOutput, /current: library/);
+  } finally {
+    for (const [key, value] of Object.entries(origEnv)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test('ft current keeps document content opt-in for model-facing JSON', async () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ft-current-cli-'));
+  const previousExitCode = process.exitCode;
+  try {
+    const sessionDir = path.join(tmpDir, 'session');
+    fs.mkdirSync(sessionDir, { recursive: true });
+    const contentPath = path.join(sessionDir, 'active.md');
+    const manifestPath = path.join(sessionDir, 'context.json');
+    fs.writeFileSync(contentPath, '# Current Body\n\nprivate working text\n');
+    fs.writeFileSync(manifestPath, JSON.stringify({
+      updatedAt: '2026-01-02T00:00:00.000Z',
+      activeDocument: {
+        title: 'Current Body',
+        path: '/library/current-body.md',
+        kind: 'wiki',
+        contentMode: 'rendered',
+        contentPath,
+      },
+    }));
+
+    const summaryOutput = await captureStdout(async () => {
+      await buildCli().parseAsync(['node', 'ft', 'current', '--manifest', manifestPath, '--json']);
+    });
+    const summary = JSON.parse(summaryOutput);
+    assert.equal(summary.activeDocument.title, 'Current Body');
+    assert.equal(summary.content, undefined);
+
+    const contentOutput = await captureStdout(async () => {
+      await buildCli().parseAsync(['node', 'ft', 'current', '--manifest', manifestPath, '--content-only']);
+    });
+    assert.equal(contentOutput, '# Current Body\n\nprivate working text\n');
+
+    const fullOutput = await captureStdout(async () => {
+      await buildCli().parseAsync(['node', 'ft', 'current', '--manifest', manifestPath, '--include-content', '--json']);
+    });
+    assert.match(JSON.parse(fullOutput).content, /private working text/);
+  } finally {
+    process.exitCode = previousExitCode;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test('ft current reports missing context without a stack trace', async () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ft-current-missing-'));
+  const previous = process.env.FT_LIBRARY_DIR;
+  const previousExitCode = process.exitCode;
+  process.env.FT_LIBRARY_DIR = path.join(tmpDir, 'library');
+  try {
+    const stderr = await captureStderr(async () => {
+      await buildCli().parseAsync(['node', 'ft', 'current']);
+    });
+    assert.match(stderr, /No active Field Theory context found/);
+    assert.doesNotMatch(stderr, /at readCurrentDocument/);
+    assert.equal(process.exitCode, 1);
+  } finally {
+    if (previous === undefined) delete process.env.FT_LIBRARY_DIR;
+    else process.env.FT_LIBRARY_DIR = previous;
+    process.exitCode = previousExitCode;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
   }
 });
 

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -73,9 +73,9 @@ test('ft search, stats, and status expose --json', () => {
   }
 });
 
-test('ft paths, recent, library, commands, app, and install command groups are registered', () => {
+test('ft paths, current, recent, library, commands, app, and install command groups are registered', () => {
   const program = buildCli();
-  for (const name of ['paths', 'recent', 'library', 'commands', 'app', 'install']) {
+  for (const name of ['paths', 'current', 'recent', 'library', 'commands', 'app', 'install']) {
     assert.ok(program.commands.find((c: any) => c.name() === name), `${name} command should be registered`);
   }
 });

--- a/tests/current.test.ts
+++ b/tests/current.test.ts
@@ -1,0 +1,82 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import {
+  findCurrentContextManifest,
+  formatCurrentDocumentContext,
+  formatCurrentDocumentSummary,
+  readCurrentDocumentContext,
+  readCurrentDocumentSummary,
+} from '../src/current.js';
+
+function writeContext(root: string, id: string, title: string, content: string, updatedAt: string): string {
+  const sessionDir = path.join(root, id);
+  fs.mkdirSync(sessionDir, { recursive: true });
+  const contentPath = path.join(sessionDir, 'active.md');
+  const manifestPath = path.join(sessionDir, 'context.json');
+  fs.writeFileSync(contentPath, content);
+  fs.writeFileSync(manifestPath, JSON.stringify({
+    version: 1,
+    updatedAt,
+    activeDocument: {
+      title,
+      path: `/library/${title}.md`,
+      kind: 'wiki',
+      contentMode: 'rendered',
+      contentPath,
+    },
+  }));
+  return manifestPath;
+}
+
+test('readCurrentDocumentContext reads newest Field Theory context manifest', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ft-current-'));
+  try {
+    const sessionsDir = path.join(tmpDir, 'sessions');
+    const olderManifest = writeContext(sessionsDir, 'older', 'Older Page', 'old body', '2026-01-01T00:00:00.000Z');
+    const newerManifest = writeContext(sessionsDir, 'newer', 'Newer Page', '# Newer\n', '2026-01-02T00:00:00.000Z');
+    const olderTime = new Date('2026-01-01T00:00:00.000Z');
+    const newerTime = new Date('2026-01-02T00:00:00.000Z');
+    fs.utimesSync(olderManifest, olderTime, olderTime);
+    fs.utimesSync(newerManifest, newerTime, newerTime);
+
+    assert.equal(findCurrentContextManifest(sessionsDir), newerManifest);
+
+    const summary = readCurrentDocumentSummary(newerManifest);
+    assert.equal(summary.activeDocument.title, 'Newer Page');
+    assert.equal('content' in summary, false);
+
+    const context = readCurrentDocumentContext(newerManifest);
+    assert.equal(context.activeDocument.title, 'Newer Page');
+    assert.equal(context.content, '# Newer\n');
+    assert.match(formatCurrentDocumentContext(context), /title: Newer Page/);
+    assert.match(formatCurrentDocumentContext(context), /# Newer/);
+    assert.match(formatCurrentDocumentSummary(context), /title: Newer Page/);
+    assert.doesNotMatch(formatCurrentDocumentSummary(context), /# Newer/);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test('readCurrentDocumentContext rejects content paths outside the session directory', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ft-current-'));
+  try {
+    const sessionsDir = path.join(tmpDir, 'sessions');
+    const manifestPath = writeContext(sessionsDir, 'session', 'Page', 'body', '2026-01-01T00:00:00.000Z');
+    const secretPath = path.join(tmpDir, 'secret.md');
+    fs.writeFileSync(secretPath, 'do not read');
+    const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf-8'));
+    manifest.activeDocument.contentPath = secretPath;
+    fs.writeFileSync(manifestPath, JSON.stringify(manifest));
+
+    assert.throws(
+      () => readCurrentDocumentContext(manifestPath),
+      /must stay inside its session directory/,
+    );
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});

--- a/tests/current.test.ts
+++ b/tests/current.test.ts
@@ -1,0 +1,74 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import {
+  findCurrentContextManifest,
+  formatCurrentDocumentContext,
+  readCurrentDocumentContext,
+} from '../src/current.js';
+
+function writeContext(root: string, id: string, title: string, content: string, updatedAt: string): string {
+  const sessionDir = path.join(root, id);
+  fs.mkdirSync(sessionDir, { recursive: true });
+  const contentPath = path.join(sessionDir, 'active.md');
+  const manifestPath = path.join(sessionDir, 'context.json');
+  fs.writeFileSync(contentPath, content);
+  fs.writeFileSync(manifestPath, JSON.stringify({
+    version: 1,
+    updatedAt,
+    activeDocument: {
+      title,
+      path: `/library/${title}.md`,
+      kind: 'wiki',
+      contentMode: 'rendered',
+      contentPath,
+    },
+  }));
+  return manifestPath;
+}
+
+test('readCurrentDocumentContext reads newest Field Theory context manifest', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ft-current-'));
+  try {
+    const sessionsDir = path.join(tmpDir, 'sessions');
+    const olderManifest = writeContext(sessionsDir, 'older', 'Older Page', 'old body', '2026-01-01T00:00:00.000Z');
+    const newerManifest = writeContext(sessionsDir, 'newer', 'Newer Page', '# Newer\n', '2026-01-02T00:00:00.000Z');
+    const olderTime = new Date('2026-01-01T00:00:00.000Z');
+    const newerTime = new Date('2026-01-02T00:00:00.000Z');
+    fs.utimesSync(olderManifest, olderTime, olderTime);
+    fs.utimesSync(newerManifest, newerTime, newerTime);
+
+    assert.equal(findCurrentContextManifest(sessionsDir), newerManifest);
+
+    const context = readCurrentDocumentContext(newerManifest);
+    assert.equal(context.activeDocument.title, 'Newer Page');
+    assert.equal(context.content, '# Newer\n');
+    assert.match(formatCurrentDocumentContext(context), /title: Newer Page/);
+    assert.match(formatCurrentDocumentContext(context), /# Newer/);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test('readCurrentDocumentContext rejects content paths outside the session directory', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ft-current-'));
+  try {
+    const sessionsDir = path.join(tmpDir, 'sessions');
+    const manifestPath = writeContext(sessionsDir, 'session', 'Page', 'body', '2026-01-01T00:00:00.000Z');
+    const secretPath = path.join(tmpDir, 'secret.md');
+    fs.writeFileSync(secretPath, 'do not read');
+    const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf-8'));
+    manifest.activeDocument.contentPath = secretPath;
+    fs.writeFileSync(manifestPath, JSON.stringify(manifest));
+
+    assert.throws(
+      () => readCurrentDocumentContext(manifestPath),
+      /must stay inside its session directory/,
+    );
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});

--- a/tests/document-ops.test.ts
+++ b/tests/document-ops.test.ts
@@ -1,0 +1,14 @@
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import test from 'node:test';
+
+import { isPathInside } from '../src/document-ops.js';
+
+test('isPathInside rejects sibling and parent paths', () => {
+  const root = path.join(path.sep, 'tmp', 'fieldtheory-root', 'child');
+
+  assert.equal(isPathInside(root, root), true);
+  assert.equal(isPathInside(root, path.join(root, 'note.md')), true);
+  assert.equal(isPathInside(root, path.join(root, '..')), false);
+  assert.equal(isPathInside(root, path.join(path.sep, 'tmp', 'fieldtheory-root-other')), false);
+});

--- a/tests/library.test.ts
+++ b/tests/library.test.ts
@@ -79,3 +79,21 @@ test('library rejects traversal paths', async () => {
     );
   });
 });
+
+test('library list and search skip hidden and internal context files by default', async () => {
+  await withLibraryRoot(async (root) => {
+    await createLibraryDocument('notes/visible', { content: '# Visible\n\nordinary phrase\n' });
+    fs.mkdirSync(path.join(root, '.backup'), { recursive: true });
+    fs.writeFileSync(path.join(root, '.backup', 'hidden.md'), '# Hidden\n\nhidden phrase\n');
+    fs.mkdirSync(path.join(root, 'Codex Context', 'sessions', 'abc'), { recursive: true });
+    fs.writeFileSync(path.join(root, 'Codex Context', 'sessions', 'abc', 'active.md'), '# Active\n\nsession phrase\n');
+    fs.writeFileSync(path.join(root, 'Codex Context', 'Durable Note.md'), '# Durable\n\ndurable phrase\n');
+
+    const listed = listLibraryDocuments().map((doc) => doc.relPath);
+    assert.deepEqual(listed, ['Codex Context/Durable Note.md', 'notes/visible.md']);
+    assert.equal(searchLibraryDocuments('hidden phrase').length, 0);
+    assert.equal(searchLibraryDocuments('session phrase').length, 0);
+    assert.equal(searchLibraryDocuments('durable phrase').length, 1);
+    assert.equal(searchLibraryDocuments('session phrase', { includeInternal: true }).length, 1);
+  });
+});

--- a/tests/paths.test.ts
+++ b/tests/paths.test.ts
@@ -52,8 +52,18 @@ test('paths: FT_DATA_DIR keeps the legacy md child unless FT_LIBRARY_DIR is set'
 
 test('paths: default command root is under ~/.fieldtheory', () => {
   withEnv({
+    FT_LIBRARY_DIR: undefined,
     FT_COMMANDS_DIR: undefined,
   }, () => {
-    assert.equal(commandsDir(), path.join(os.homedir(), '.fieldtheory', 'commands'));
+    assert.equal(commandsDir(), path.join(os.homedir(), '.fieldtheory', 'library', 'Commands'));
+  });
+});
+
+test('paths: default command root follows FT_LIBRARY_DIR', () => {
+  withEnv({
+    FT_LIBRARY_DIR: '/tmp/ft-library',
+    FT_COMMANDS_DIR: undefined,
+  }, () => {
+    assert.equal(commandsDir(), path.join('/tmp/ft-library', 'Commands'));
   });
 });


### PR DESCRIPTION
## Summary
- Add Field Theory navigation commands for ls/find/grep/cat/head/meta/open/link/links/backlinks/tags/write/location workflows
- Add current-document context reading with content opt-in for model-facing calls
- Point default commands to ~/.fieldtheory/library/Commands and exclude internal context files from Library navigation

## Verification
- npm run build
- npm test
- npx tsx src/cli.ts link workflow
- npx tsx src/cli.ts link "Field Theory Start Save Ship Workflow Brief" --alias "workflow brief"
- npx tsx src/cli.ts ls commands --limit 3