### PR TITLE
Add repo workflow state command

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -39,6 +39,7 @@ import { skillWithFrontmatter, installSkill, uninstallSkill } from './skill.js';
 import { registerCompanionCommands } from './companion-cli.js';
 import { getPathReport } from './field-status.js';
 import { formatAgentContext, getAgentContext } from './agent-context.js';
+import { formatWorkflowState, getWorkflowState } from './workflow-state.js';
 import {
   formatIdeasIntro,
   formatRunList,
@@ -440,7 +441,7 @@ function isInternalWorkerCommand(command: Command): boolean {
 function shouldSkipCommandChrome(command: Command): boolean {
   if (isInternalWorkerCommand(command)) return true;
   if (command.opts().json) return true;
-  if (command.name() === 'path' || command.name() === 'paths' || command.name() === 'recent') return true;
+  if (command.name() === 'path' || command.name() === 'paths' || command.name() === 'recent' || command.name() === 'state') return true;
   if (command.name() === 'show' && command.parent?.name() === 'skill') return true;
   return false;
 }
@@ -1527,6 +1528,24 @@ export function buildCli() {
         return;
       }
       process.stdout.write(formatAgentContext(context));
+    }));
+
+  program
+    .command('state')
+    .description('Show repo workflow state in one read-only table')
+    .option('--repo <path>', 'Repo path to inspect (default: cwd)')
+    .option('--no-fetch', 'Skip fetching remote refs before reading state')
+    .option('--json', 'JSON output')
+    .action(safe(async (options) => {
+      const state = getWorkflowState({
+        repo: options.repo,
+        fetch: options.fetch !== false,
+      });
+      if (options.json) {
+        printJson(state);
+        return;
+      }
+      process.stdout.write(formatWorkflowState(state));
     }));
 
   registerCompanionCommands(program, safe);

--- a/src/skill.ts
+++ b/src/skill.ts
@@ -35,12 +35,13 @@ Field Theory has three main local surfaces:
 ## Search Workflow
 
 1. Check paths and status when setup matters: \`ft paths --json\`, \`ft status --json\`
-2. When the user says "that file" or "the recent file", inspect current repo recency with \`ft recent --json\`
-3. Search durable notes first when prior project knowledge matters: \`ft library search <query> --json\`
-4. Search bookmarks when reading history or saved X/Twitter posts matter: \`ft search <query> --json\`
-5. Inspect exact files or bookmarks with \`ft library show <path> --json\`, \`ft show <id> --json\`, or \`ft commands show <name> --json\`
-6. Create or update durable Library notes and portable commands only when the user asks for a saved artifact
-7. Open useful Library pages in the Mac app with \`ft library open <path>\`
+2. Check repo workflow state when branch/worktree/PR shape matters: \`ft state --json\`
+3. When the user says "that file" or "the recent file", inspect current repo recency with \`ft recent --json\`
+4. Search durable notes first when prior project knowledge matters: \`ft library search <query> --json\`
+5. Search bookmarks when reading history or saved X/Twitter posts matter: \`ft search <query> --json\`
+6. Inspect exact files or bookmarks with \`ft library show <path> --json\`, \`ft show <id> --json\`, or \`ft commands show <name> --json\`
+7. Create or update durable Library notes and portable commands only when the user asks for a saved artifact
+8. Open useful Library pages in the Mac app with \`ft library open <path>\`
 
 ## Possible Roadmap Workflow
 
@@ -87,6 +88,7 @@ If the user says "debate", use the existing \`ft possible\` pipeline as generate
 \`\`\`bash
 ft paths --json                # Canonical bookmarks, library, commands paths
 ft status --json               # Bookmark/classification status plus paths
+ft state --json                # Repo workflow state: root, workers, PRs, cleanup, next step
 ft recent --json               # Current repo last-modified file and recent files for agent references
 
 ft search <query>              # Full-text BM25 search ("exact phrase", AND, OR, NOT)

--- a/src/workflow-state.ts
+++ b/src/workflow-state.ts
@@ -1,0 +1,321 @@
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+
+export interface WorkflowStateOptions {
+  repo?: string;
+  fetch?: boolean;
+}
+
+export interface WorkflowStateRow {
+  category: string;
+  state: string;
+  plainEnglish: string;
+  next: string;
+}
+
+export interface WorkflowStatePullRequest {
+  number: number;
+  title: string;
+  url: string;
+  isDraft: boolean;
+  mergeStateStatus?: string;
+}
+
+export interface WorkflowState {
+  repo: string;
+  root: string | null;
+  rows: WorkflowStateRow[];
+  openPullRequests: WorkflowStatePullRequest[];
+  verdict: string;
+  summary: string;
+}
+
+interface GitRunOptions {
+  cwd: string;
+  timeout?: number;
+}
+
+function runGit(args: string[], options: GitRunOptions): string | null {
+  try {
+    return execFileSync('git', args, {
+      cwd: options.cwd,
+      encoding: 'utf-8',
+      timeout: options.timeout ?? 10_000,
+      stdio: ['pipe', 'pipe', 'ignore'],
+    }).trim();
+  } catch {
+    return null;
+  }
+}
+
+function runCommand(command: string, args: string[], options: GitRunOptions): string | null {
+  try {
+    return execFileSync(command, args, {
+      cwd: options.cwd,
+      encoding: 'utf-8',
+      timeout: options.timeout ?? 10_000,
+      stdio: ['pipe', 'pipe', 'ignore'],
+    }).trim();
+  } catch {
+    return null;
+  }
+}
+
+function parseAheadBehind(statusLine: string): { ahead: number; behind: number } {
+  const ahead = Number(statusLine.match(/ahead (\d+)/)?.[1] ?? 0);
+  const behind = Number(statusLine.match(/behind (\d+)/)?.[1] ?? 0);
+  return { ahead, behind };
+}
+
+function branchSummary(root: string): { branch: string; upstream: string | null; ahead: number; behind: number } {
+  const branch = runGit(['branch', '--show-current'], { cwd: root }) || 'detached';
+  const upstream = runGit(['rev-parse', '--abbrev-ref', '--symbolic-full-name', '@{u}'], { cwd: root });
+  const statusLine = runGit(['status', '--short', '--branch'], { cwd: root })?.split('\n')[0] ?? '';
+  const { ahead, behind } = parseAheadBehind(statusLine);
+  return { branch, upstream, ahead, behind };
+}
+
+function changedFiles(root: string): string[] {
+  const output = runGit(['status', '--porcelain=v1', '--untracked-files=all'], { cwd: root });
+  return output ? output.split('\n').filter(Boolean) : [];
+}
+
+function parseWorktrees(root: string): { path: string; branch: string | null; prunable: boolean }[] {
+  const output = runGit(['worktree', 'list', '--porcelain'], { cwd: root });
+  if (!output) return [];
+
+  const blocks = output.split('\n\n').filter(Boolean);
+  return blocks.map((block) => {
+    const lines = block.split('\n');
+    const worktreePath = lines.find((line) => line.startsWith('worktree '))?.slice('worktree '.length) ?? '';
+    const branch = lines.find((line) => line.startsWith('branch '))?.replace(/^branch refs\/heads\//, '') ?? null;
+    return {
+      path: worktreePath,
+      branch,
+      prunable: lines.some((line) => line.startsWith('prunable')),
+    };
+  }).filter((worktree) => worktree.path);
+}
+
+function countAbandonedRefs(root: string): number {
+  const output = runGit(['for-each-ref', '--format=%(refname:short)', 'refs/remotes/origin/abandoned'], { cwd: root });
+  return output ? output.split('\n').filter(Boolean).length : 0;
+}
+
+function readOpenPullRequests(root: string): WorkflowStatePullRequest[] {
+  const output = runCommand('gh', [
+    'pr',
+    'list',
+    '--state',
+    'open',
+    '--json',
+    'number,title,url,isDraft,mergeStateStatus',
+    '--limit',
+    '50',
+  ], { cwd: root, timeout: 15_000 });
+  if (!output) return [];
+
+  try {
+    const parsed = JSON.parse(output) as WorkflowStatePullRequest[];
+    return parsed.map((pr) => ({
+      number: pr.number,
+      title: pr.title,
+      url: pr.url,
+      isDraft: Boolean(pr.isDraft),
+      mergeStateStatus: pr.mergeStateStatus,
+    }));
+  } catch {
+    return [];
+  }
+}
+
+function formatCount(count: number, noun: string): string {
+  return `${count} ${noun}${count === 1 ? '' : 's'}`;
+}
+
+export function getWorkflowState(options: WorkflowStateOptions = {}): WorkflowState {
+  const repo = path.resolve(options.repo ?? process.cwd());
+  const root = runGit(['rev-parse', '--show-toplevel'], { cwd: repo });
+
+  if (!root) {
+    const rows = [
+      {
+        category: 'Root',
+        state: 'not a git repo',
+        plainEnglish: 'This directory is not inside a Git checkout.',
+        next: 'choose a repo',
+      },
+    ];
+    return {
+      repo,
+      root: null,
+      rows,
+      openPullRequests: [],
+      verdict: 'not a repo',
+      summary: 'Run `ft state --repo <path>` from inside a Git repo.',
+    };
+  }
+
+  if (options.fetch !== false) {
+    runGit(['fetch', '--quiet', '--all', '--prune'], { cwd: root, timeout: 30_000 });
+  }
+
+  const { branch, upstream, ahead, behind } = branchSummary(root);
+  const changes = changedFiles(root);
+  const worktrees = parseWorktrees(root);
+  const activeWorkers = worktrees.filter((worktree) => path.resolve(worktree.path) !== path.resolve(root) && !worktree.prunable);
+  const prunableWorktrees = worktrees.filter((worktree) => worktree.prunable);
+  const abandonedCount = countAbandonedRefs(root);
+  const openPullRequests = readOpenPullRequests(root);
+
+  const rootBits = [
+    changes.length === 0 ? 'clean' : `${formatCount(changes.length, 'changed file')}`,
+    upstream ? `tracking ${upstream}` : 'no upstream',
+  ];
+  if (ahead > 0) rootBits.push(`ahead ${ahead}`);
+  if (behind > 0) rootBits.push(`behind ${behind}`);
+
+  const rows: WorkflowStateRow[] = [
+    {
+      category: 'Root',
+      state: `${branch}: ${rootBits.join(', ')}`,
+      plainEnglish: changes.length === 0
+        ? 'The main checkout has no local file changes.'
+        : 'The main checkout has local work that is not clean yet.',
+      next: changes.length === 0 ? 'no action' : 'save, ship, or abandon',
+    },
+    {
+      category: 'Active workers',
+      state: activeWorkers.length === 0 ? 'none' : formatCount(activeWorkers.length, 'worktree'),
+      plainEnglish: activeWorkers.length === 0
+        ? 'There are no separate local task worktrees.'
+        : 'Separate local work exists outside this checkout.',
+      next: activeWorkers.length === 0 ? 'no action' : 'inspect each worker',
+    },
+    {
+      category: 'Included work',
+      state: changes.length === 0 && ahead === 0 ? 'none' : `${formatCount(changes.length, 'changed file')}, ahead ${ahead}`,
+      plainEnglish: changes.length === 0 && ahead === 0
+        ? 'Root does not contain obvious unsaved local work.'
+        : 'Root contains local changes or commits that may need to be saved or shipped.',
+      next: changes.length === 0 && ahead === 0 ? 'no action' : 'ship or clean up',
+    },
+    {
+      category: 'Excluded work',
+      state: activeWorkers.length === 0 ? 'none' : formatCount(activeWorkers.length, 'worker'),
+      plainEnglish: activeWorkers.length === 0
+        ? 'There is no separate local work waiting outside root.'
+        : 'Work in task worktrees is outside root until it is saved or shipped.',
+      next: activeWorkers.length === 0 ? 'no action' : 'save, ship, or abandon',
+    },
+    {
+      category: 'Shipped work',
+      state: openPullRequests.length === 0 ? 'none' : formatCount(openPullRequests.length, 'open PR'),
+      plainEnglish: openPullRequests.length === 0
+        ? 'No GitHub PRs are currently open for this repo.'
+        : 'GitHub has active review surfaces for this repo.',
+      next: openPullRequests.length === 0 ? 'no action' : 'review, merge, or abandon',
+    },
+    {
+      category: 'Landed work',
+      state: behind > 0 ? `behind ${behind}` : 'up to date or unknown',
+      plainEnglish: behind > 0
+        ? 'Remote has commits that are not in this checkout yet.'
+        : 'This checkout is not obviously missing remote base commits.',
+      next: behind > 0 ? 'update root' : 'no action',
+    },
+    {
+      category: 'Abandoned work',
+      state: abandonedCount === 0 ? 'none' : formatCount(abandonedCount, 'remote abandoned ref'),
+      plainEnglish: abandonedCount === 0
+        ? 'No abandoned remote refs were found under origin/abandoned.'
+        : 'Old work is preserved remotely and is not active locally.',
+      next: 'no action',
+    },
+    {
+      category: 'Open PRs',
+      state: openPullRequests.length === 0 ? 'none' : formatCount(openPullRequests.length, 'open PR'),
+      plainEnglish: openPullRequests.length === 0
+        ? 'There are no open PR decisions visible from GitHub.'
+        : 'These PRs still need review, merge, or abandon decisions.',
+      next: openPullRequests.length === 0 ? 'no action' : 'review, merge, or abandon',
+    },
+    {
+      category: 'Local cleanup',
+      state: prunableWorktrees.length === 0 ? 'none' : formatCount(prunableWorktrees.length, 'prunable worktree'),
+      plainEnglish: prunableWorktrees.length === 0
+        ? 'There are no stale worktree registrations.'
+        : 'Git has stale worktree records that can be pruned after inspection.',
+      next: prunableWorktrees.length === 0 ? 'no action' : 'clean-slate',
+    },
+  ];
+
+  let verdict = 'clean working state';
+  let summary = `Root is on ${branch}`;
+  if (changes.length > 0 || activeWorkers.length > 0 || prunableWorktrees.length > 0 || ahead > 0 || behind > 0) {
+    verdict = 'not clean yet';
+    summary = [
+      changes.length > 0 ? formatCount(changes.length, 'changed file') : null,
+      activeWorkers.length > 0 ? formatCount(activeWorkers.length, 'active worker') : null,
+      prunableWorktrees.length > 0 ? formatCount(prunableWorktrees.length, 'prunable worktree') : null,
+      ahead > 0 ? `ahead ${ahead}` : null,
+      behind > 0 ? `behind ${behind}` : null,
+    ].filter(Boolean).join(', ');
+  } else if (openPullRequests.length > 0) {
+    summary = `Root is clean and ${formatCount(openPullRequests.length, 'PR')} remains open.`;
+  } else {
+    summary = `Root is clean on ${branch}, with no active local workers or open PRs.`;
+  }
+
+  rows.push({
+    category: 'Recommended next',
+    state: verdict,
+    plainEnglish: summary,
+    next: verdict === 'clean working state' ? 'start' : 'clean-slate',
+  });
+
+  return { repo, root, rows, openPullRequests, verdict, summary };
+}
+
+function pad(value: string, width: number): string {
+  return value + ' '.repeat(Math.max(0, width - value.length));
+}
+
+export function formatWorkflowState(state: WorkflowState): string {
+  const headers = ['Category', 'State', 'Plain English', 'Next'];
+  const widths = headers.map((header, index) => Math.max(
+    header.length,
+    ...state.rows.map((row) => [row.category, row.state, row.plainEnglish, row.next][index].length),
+  ));
+
+  const lines = ['FT state', ''];
+  lines.push(`| ${headers.map((header, index) => pad(header, widths[index])).join(' | ')} |`);
+  lines.push(`| ${widths.map((width) => '-'.repeat(width)).join(' | ')} |`);
+  for (const row of state.rows) {
+    lines.push(`| ${[
+      row.category,
+      row.state,
+      row.plainEnglish,
+      row.next,
+    ].map((value, index) => pad(value, widths[index])).join(' | ')} |`);
+  }
+
+  lines.push('');
+  if (state.openPullRequests.length === 0) {
+    lines.push('Open PRs: none');
+  } else {
+    lines.push('Open PRs (merge sequentially):', '');
+    state.openPullRequests.forEach((pr, index) => {
+      const conflict = pr.mergeStateStatus === 'DIRTY' ? 'conflicts' : 'no conflicts';
+      const draft = pr.isDraft ? 'draft, ' : '';
+      lines.push(`${index + 1}. ${pr.title} - ${pr.url} - ${draft}${conflict}`);
+    });
+  }
+
+  lines.push('', `Verdict: ${state.verdict}.`, state.summary);
+  if (state.root && !fs.existsSync(path.join(state.root, '.git'))) {
+    lines.push(`Repo root: ${state.root}`);
+  }
+  return `${lines.join('\n')}\n`;
+}

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -73,10 +73,26 @@ test('ft search, stats, and status expose --json', () => {
   }
 });
 
-test('ft paths, recent, library, commands, app, and install command groups are registered', () => {
+test('ft paths, state, recent, library, commands, app, and install command groups are registered', () => {
   const program = buildCli();
-  for (const name of ['paths', 'recent', 'library', 'commands', 'app', 'install']) {
+  for (const name of ['paths', 'state', 'recent', 'library', 'commands', 'app', 'install']) {
     assert.ok(program.commands.find((c: any) => c.name() === name), `${name} command should be registered`);
+  }
+});
+
+test('ft state prints a read-only repo workflow table', async () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ft-state-'));
+  try {
+    const output = await captureStdout(async () => {
+      await buildCli().parseAsync(['node', 'ft', 'state', '--repo', tmpDir, '--no-fetch']);
+    });
+    assert.match(output, /^FT state/);
+    assert.match(output, /FT state/);
+    assert.match(output, /Root/);
+    assert.match(output, /not a git repo/);
+    assert.match(output, /Verdict: not a repo\./);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
   }
 });
 


### PR DESCRIPTION
## Summary
- add `ft state` for a read-only repo workflow table covering root, workers, PRs, abandoned refs, cleanup, and recommended next step
- expose `--json`, `--repo`, and `--no-fetch` for agent-friendly use
- teach the generated Field Theory agent skill to use `ft state --json` when branch/worktree/PR shape matters

## Verification
- `npm run build`
- `npx tsx --test tests/cli.test.ts tests/skill.test.ts`
- `npm test -- --test-name-pattern "ft state|skill|paths, state"` (ran the full suite; 544 passing)
- `node bin/ft.mjs state --repo /Users/afar/dev/fieldtheory-cli-state --no-fetch`