### PR TITLE
fix(auth): use x.com OAuth2 authorize endpoint instead of twitter.com

### DIFF
--- a/src/xauth.ts
+++ b/src/xauth.ts
@@ -24,7 +24,7 @@ export function buildTwitterOAuthUrl(): { url: string; state: string; verifier: 
   }
 
   const { verifier, challenge, state } = createPkce();
-  const url = new URL('https://twitter.com/i/oauth2/authorize');
+  const url = new URL('https://x.com/i/oauth2/authorize');
   url.searchParams.set('response_type', 'code');
   url.searchParams.set('client_id', cfg.clientId);
   url.searchParams.set('redirect_uri', cfg.callbackUrl);


### PR DESCRIPTION
## Problem

The OAuth2 authorize URL points at `twitter.com`:

```ts
const url = new URL('https://twitter.com/i/oauth2/authorize');
```

After the X rebrand, an authenticated user's session cookies live on the `x.com` domain. The `twitter.com` authorize page can't read those cookies, so a user who is *already signed in* is treated as logged out — triggering repeated login prompts and 2FA failures during `ft auth`.

## Fix

Point the authorize endpoint at `x.com`. An existing `x.com` session can then approve the app directly, without re-login. The token endpoint (`api.x.com/2/oauth2/token`) is already on `x.com` and is unchanged.

## Testing

With an already-logged-in `x.com` session, `ft auth` against `x.com/i/oauth2/authorize` completes the authorization cleanly; the original `twitter.com` URL reproduces the repeated-login loop.
