### PR TITLE
Use Library Commands as command root

### DIFF
--- a/src/app-open.ts
+++ b/src/app-open.ts
@@ -1,6 +1,6 @@
 import { spawnSync } from 'node:child_process';
 import path from 'node:path';
-import { canonicalCommandsDir, canonicalLibraryDir } from './paths.js';
+import { canonicalLibraryDir, commandsDir } from './paths.js';
 import { isPathInside, resolveMarkdownPath } from './document-ops.js';
 
 const DEFAULT_FIELD_THEORY_BUNDLE_ID = 'com.fieldtheory.app';
@@ -32,7 +32,7 @@ export interface FieldTheoryLaunchOptions {
 export function inferOpenKind(filePath: string): FieldTheoryOpenKind | null {
   const resolved = path.resolve(filePath);
   if (isPathInside(path.resolve(canonicalLibraryDir()), resolved)) return 'library';
-  if (isPathInside(path.resolve(canonicalCommandsDir()), resolved)) return 'command';
+  if (isPathInside(path.resolve(commandsDir()), resolved)) return 'command';
   return null;
 }
 
@@ -45,7 +45,7 @@ export function buildFieldTheoryOpenTarget(inputPath: string, kind?: FieldTheory
     throw new Error(`Unknown target kind: ${String(resolvedKind)}`);
   }
 
-  const root = resolvedKind === 'library' ? canonicalLibraryDir() : canonicalCommandsDir();
+  const root = resolvedKind === 'library' ? canonicalLibraryDir() : commandsDir();
   const resolvedPath = resolveMarkdownPath(root, inputPath);
   if (!resolvedPath) throw new Error(`Path is outside the ${resolvedKind} root or is not markdown.`);
 

--- a/src/commands-files.ts
+++ b/src/commands-files.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { canonicalCommandsDir } from './paths.js';
+import { commandsDir } from './paths.js';
 import {
   createMarkdownFile,
   DocumentVersion,
@@ -47,7 +47,7 @@ export interface CommandUpdateInput extends CommandWriteInput {
 }
 
 function commandsRoot(): string {
-  return canonicalCommandsDir();
+  return commandsDir();
 }
 
 function resolveCommandPath(target: string): string {

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -28,7 +28,7 @@ export function canonicalLibraryDir(): string {
 }
 
 export function canonicalCommandsDir(): string {
-  return process.env.FT_COMMANDS_DIR ?? path.join(fieldTheoryDir(), 'commands');
+  return process.env.FT_COMMANDS_DIR ?? path.join(canonicalLibraryDir(), 'Commands');
 }
 
 export function codexContextSessionsDir(): string {
@@ -46,7 +46,12 @@ export function libraryDir(): string {
 }
 
 export function commandsDir(): string {
-  return canonicalCommandsDir();
+  const override = process.env.FT_COMMANDS_DIR;
+  if (override) return override;
+  const canonical = path.join(canonicalLibraryDir(), 'Commands');
+  const legacy = path.join(fieldTheoryDir(), 'commands');
+  if (fs.existsSync(canonical) || !fs.existsSync(legacy)) return canonical;
+  return legacy;
 }
 
 /**

--- a/tests/commands-files.test.ts
+++ b/tests/commands-files.test.ts
@@ -106,3 +106,30 @@ test('commands reject unsafe names and flag weak command content', async () => {
     ]);
   });
 });
+
+test('commands default to the Library Commands folder', async () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'ft-library-commands-'));
+  const home = path.join(tmp, 'home');
+  const root = path.join(home, '.fieldtheory', 'library', 'Commands');
+  fs.mkdirSync(root, { recursive: true });
+  fs.writeFileSync(path.join(root, 'state.md'), goodCommand);
+
+  const previous = {
+    FT_COMMANDS_DIR: process.env.FT_COMMANDS_DIR,
+    HOME: process.env.HOME,
+  };
+  delete process.env.FT_COMMANDS_DIR;
+  process.env.HOME = home;
+
+  try {
+    const shown = await showCommandDocument('state');
+    assert.equal(shown.path, path.join(root, 'state.md'));
+    assert.equal(shown.name, 'state');
+  } finally {
+    if (previous.FT_COMMANDS_DIR === undefined) delete process.env.FT_COMMANDS_DIR;
+    else process.env.FT_COMMANDS_DIR = previous.FT_COMMANDS_DIR;
+    if (previous.HOME === undefined) delete process.env.HOME;
+    else process.env.HOME = previous.HOME;
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});

--- a/tests/paths.test.ts
+++ b/tests/paths.test.ts
@@ -1,5 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
 import { canonicalCommandsDir, canonicalDataDir, canonicalLibraryDir, dataDir, libraryDir, mdDir, commandsDir, mdSchemaPath } from '../src/paths.js';
@@ -50,10 +51,29 @@ test('paths: FT_DATA_DIR keeps the legacy md child unless FT_LIBRARY_DIR is set'
   });
 });
 
-test('paths: default command root is under ~/.fieldtheory', () => {
+test('paths: default command root is under the Field Theory Library', () => {
   withEnv({
     FT_COMMANDS_DIR: undefined,
   }, () => {
-    assert.equal(commandsDir(), path.join(os.homedir(), '.fieldtheory', 'commands'));
+    assert.equal(commandsDir(), path.join(os.homedir(), '.fieldtheory', 'library', 'Commands'));
+    assert.equal(canonicalCommandsDir(), path.join(os.homedir(), '.fieldtheory', 'library', 'Commands'));
   });
+});
+
+test('paths: command root falls back to old commands dir for old installs', () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'ft-paths-home-'));
+  const home = path.join(tmp, 'home');
+  const legacyCommands = path.join(home, '.fieldtheory', 'commands');
+  fs.mkdirSync(legacyCommands, { recursive: true });
+
+  withEnv({
+    HOME: home,
+    FT_LIBRARY_DIR: undefined,
+    FT_COMMANDS_DIR: undefined,
+  }, () => {
+    assert.equal(commandsDir(), legacyCommands);
+    assert.equal(canonicalCommandsDir(), path.join(home, '.fieldtheory', 'library', 'Commands'));
+  });
+
+  fs.rmSync(tmp, { recursive: true, force: true });
 });


### PR DESCRIPTION
## Summary
- Make the Field Theory Library Commands folder the canonical command root
- Keep a code fallback to the old ~/.fieldtheory/commands directory for old installs
- Route command file reads and command open targets through the active command root

## Verification
- tsx --test tests/paths.test.ts tests/commands-files.test.ts tests/app-open.test.ts tests/cli.test.ts
- npm test
- npm run build
- HOME=<temp with only library/Commands> node dist/cli.js commands show state --json