### PR TITLE
feat(auth): refresh OAuth2 access token instead of failing on expiry

### DIFF
--- a/src/bookmarks.ts
+++ b/src/bookmarks.ts
@@ -2,7 +2,7 @@ import { ensureDir, pathExists, readJson, readJsonLines, writeJson, writeJsonLin
 import { ensureDataDir, twitterBackfillStatePath, twitterBookmarksCachePath, twitterBookmarksMetaPath } from './paths.js';
 import type { BookmarkBackfillState, BookmarkCacheMeta, BookmarkRecord } from './types.js';
 import { loadXApiConfig } from './config.js';
-import { loadTwitterOAuthToken } from './xauth.js';
+import { ensureValidTwitterToken, refreshTwitterTokenNow } from './xauth.js';
 
 export interface BookmarkSyncResult {
   mode: 'full' | 'incremental';
@@ -171,12 +171,21 @@ export async function syncTwitterBookmarks(
   mode: 'full' | 'incremental',
   options: { targetAdds?: number } = {}
 ): Promise<BookmarkSyncResult> {
-  const token = await loadTwitterOAuthToken();
+  const token = await ensureValidTwitterToken();
   if (!token?.access_token) {
     throw new Error('Missing user-context OAuth token. Run: ft auth');
   }
 
-  const me = await fetchCurrentUserId(token.access_token);
+  let accessToken = token.access_token;
+  let me = await fetchCurrentUserId(accessToken);
+  if (!me.ok && me.status === 401) {
+    // Access token may have been revoked or expired ahead of its stated lifetime; refresh once and retry.
+    const refreshed = await refreshTwitterTokenNow();
+    if (refreshed?.access_token) {
+      accessToken = refreshed.access_token;
+      me = await fetchCurrentUserId(accessToken);
+    }
+  }
   if (!me.ok || !me.id) {
     throw new Error(`Could not resolve current user id: ${me.detail}`);
   }
@@ -194,7 +203,7 @@ export async function syncTwitterBookmarks(
   const maxPages = mode === 'full' ? 200 : 2;
 
   while (pages < maxPages) {
-    const pageResult = await fetchBookmarksPage(token.access_token, me.id, nextToken);
+    const pageResult = await fetchBookmarksPage(accessToken, me.id, nextToken);
     if (!pageResult.ok || !pageResult.page) {
       throw new Error(`Bookmark fetch failed (${pageResult.status}): ${pageResult.detail}`);
     }

--- a/src/xauth.ts
+++ b/src/xauth.ts
@@ -76,6 +76,74 @@ async function exchangeCodeForToken(code: string, verifier: string): Promise<XOA
   };
 }
 
+async function requestTokenRefresh(refreshToken: string): Promise<XOAuthTokenSet> {
+  const cfg = loadXApiConfig();
+  const basic = Buffer.from(`${cfg.clientId}:${cfg.clientSecret}`).toString('base64');
+  const body = new URLSearchParams({
+    grant_type: 'refresh_token',
+    refresh_token: refreshToken,
+    client_id: cfg.clientId,
+  });
+
+  const response = await fetch('https://api.x.com/2/oauth2/token', {
+    method: 'POST',
+    headers: {
+      Authorization: `Basic ${basic}`,
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    body,
+  });
+
+  const text = await response.text();
+  if (!response.ok) {
+    throw new Error(`Token refresh failed (HTTP ${response.status}). Run: ft auth`);
+  }
+  let parsed: any;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    throw new Error(`Token refresh returned a non-JSON response (HTTP ${response.status}). Run: ft auth`);
+  }
+
+  return {
+    access_token: parsed.access_token,
+    // X rotates the refresh token on each refresh; keep the prior one only if the response omits it.
+    refresh_token: parsed.refresh_token ?? refreshToken,
+    expires_in: parsed.expires_in,
+    scope: parsed.scope,
+    token_type: parsed.token_type,
+    obtained_at: new Date().toISOString(),
+  };
+}
+
+function isAccessTokenExpired(token: XOAuthTokenSet, bufferSeconds = 300): boolean {
+  if (!token.expires_in) return false;
+  const obtainedMs = Date.parse(token.obtained_at);
+  if (Number.isNaN(obtainedMs)) return true;
+  const expiresAtMs = obtainedMs + token.expires_in * 1000;
+  return Date.now() >= expiresAtMs - bufferSeconds * 1000;
+}
+
+export async function ensureValidTwitterToken(): Promise<XOAuthTokenSet | null> {
+  const token = await loadTwitterOAuthToken();
+  if (!token?.access_token) return token;
+  if (!isAccessTokenExpired(token)) return token;
+  if (!token.refresh_token) return token;
+  const refreshed = await requestTokenRefresh(token.refresh_token);
+  // Persist the rotated token set before using it; writeJson is atomic (tmp + rename),
+  // so an interrupted write cannot strand us with the now-invalidated old refresh token.
+  await saveTwitterOAuthToken(refreshed);
+  return refreshed;
+}
+
+export async function refreshTwitterTokenNow(): Promise<XOAuthTokenSet | null> {
+  const token = await loadTwitterOAuthToken();
+  if (!token?.refresh_token) return null;
+  const refreshed = await requestTokenRefresh(token.refresh_token);
+  await saveTwitterOAuthToken(refreshed);
+  return refreshed;
+}
+
 export async function saveTwitterOAuthToken(token: XOAuthTokenSet): Promise<string> {
   ensureDataDir();
   const tokenPath = twitterOauthTokenPath();


### PR DESCRIPTION
## Problem

`ft` only ever performs the `authorization_code` grant. The OAuth2 access token it stores has a short lifetime (`expires_in`, ~2h for X), and nothing ever refreshes it. The `refresh_token` returned by X is saved to the token file but never used.

As a result, any `ft sync --api` run more than ~2 hours after `ft auth` fails:

```
Could not resolve current user id: {"title":"Unauthorized","type":"about:blank","status":401,"detail":"Unauthorized"}
```

This makes unattended or scheduled bookmark syncs (cron / launchd) impossible — the interactive `ft auth` browser flow would have to be re-run every couple of hours.

## Fix

Implement the `refresh_token` grant flow:

- **`requestTokenRefresh()`** — exchanges the stored refresh token for a new access token at `https://api.x.com/2/oauth2/token`. It checks the HTTP status before parsing and reports non-JSON error bodies without masking the status. X **rotates** the refresh token on each refresh, so the new refresh token is persisted (falling back to the prior one only if the response omits it).
- **`ensureValidTwitterToken()`** — proactively refreshes when the access token is within 5 minutes of expiry, then persists the rotated token set **before** using it. `writeJson` is atomic (tmp + `rename`), so an interrupted write cannot strand the now-invalidated old refresh token.
- **`refreshTwitterTokenNow()` + a 401 retry in `syncTwitterBookmarks()`** — if the first authenticated request still returns 401 (token revoked server-side, or local clock skew), refresh once and retry within the same run.

No new dependencies. The token file schema is unchanged (`refresh_token` / `expires_in` / `obtained_at` were already stored).

## Testing

With an access token already past its `expires_in`, `ft sync --api` previously failed every time with 401. After this change the same run refreshes the token (the token file's `obtained_at` updates) and the sync completes; subsequent runs reuse the still-valid token until it nears expiry.
