### PR TITLE
feat: add panel link commands

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fieldtheory",
-  "version": "1.3.20",
+  "version": "1.3.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fieldtheory",
-      "version": "1.3.20",
+      "version": "1.3.21",
       "license": "MIT",
       "dependencies": {
         "commander": "^14.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fieldtheory",
-  "version": "1.3.20",
+  "version": "1.3.21",
   "description": "Field Theory CLI. Self-custody for your X/Twitter bookmarks. Local sync, full-text search, classification, and terminal dashboards.",
   "type": "module",
   "bin": {

--- a/src/app-open.ts
+++ b/src/app-open.ts
@@ -29,6 +29,10 @@ export interface FieldTheoryLaunchOptions {
   spawn?: SpawnRunner;
 }
 
+function posixRelativePath(from: string, to: string): string {
+  return path.relative(from, to).split(path.sep).join('/');
+}
+
 export function inferOpenKind(filePath: string): FieldTheoryOpenKind | null {
   const resolved = path.resolve(filePath);
   if (isPathInside(path.resolve(commandsDir()), resolved)) return 'command';
@@ -66,6 +70,31 @@ export function buildFieldTheoryOpenTarget(inputPath: string, kind?: FieldTheory
     supported: false,
     note: 'Field Theory does not expose a command-file deep link yet; open this path in the Commands view.',
   };
+}
+
+export function buildFieldTheoryPanelOpenTarget(inputPath: string, kind?: FieldTheoryOpenKind): FieldTheoryOpenTarget {
+  const target = buildFieldTheoryOpenTarget(inputPath, kind);
+  if (target.kind === 'library') {
+    const relPath = posixRelativePath(path.resolve(canonicalLibraryDir()), target.path);
+    const params = new URLSearchParams({ kind: 'wiki', path: relPath });
+    return {
+      ...target,
+      url: `fieldtheory://browser-library/open?${params.toString()}`,
+      supported: true,
+    };
+  }
+
+  if (target.kind === 'command') {
+    const params = new URLSearchParams({ kind: 'command', path: target.path });
+    return {
+      ...target,
+      url: `fieldtheory://browser-library/open?${params.toString()}`,
+      supported: true,
+      note: undefined,
+    };
+  }
+
+  return target;
 }
 
 function runLauncher(spawn: SpawnRunner, command: string, args: string[], method: FieldTheoryLaunchResult['method'], cwd?: string): FieldTheoryLaunchResult {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -67,6 +67,7 @@ import {
   listNavigationTagged,
   listNavigationTags,
   openNavigationDocument,
+  panelNavigationDocument,
   readNavigationDocument,
   renameNavigationDocument,
   type NavigationPlace,
@@ -1690,6 +1691,49 @@ export function buildCli() {
       if (!targetPath && !options.query) throw new Error('Pass a file/title or --query.');
       const result = await openNavigationDocument(targetPath ?? '', {
         launch: options.launch !== false,
+        query: options.query ? String(options.query) : undefined,
+      });
+      if (options.json) {
+        printJson(result);
+        return;
+      }
+      console.log(result.url ?? result.path);
+    }));
+
+  program
+    .command('panel')
+    .description('Print a Field Theory panel link for a Library or command document')
+    .argument('[file]', 'Relative or absolute markdown path, title, or filename')
+    .option('--query <query>', 'Find one matching document and link it')
+    .option('--open', 'Open the panel link in the Field Theory app')
+    .option('--json', 'JSON output')
+    .action(safe(async (targetPath: string | undefined, options) => {
+      if (!targetPath && !options.query) throw new Error('Pass a file/title or --query.');
+      const result = await panelNavigationDocument(targetPath ?? '', {
+        launch: options.open === true,
+        query: options.query ? String(options.query) : undefined,
+      });
+      if (options.json) {
+        printJson(result);
+        return;
+      }
+      console.log(result.url ?? result.path);
+    }));
+
+  const codexCommand = program
+    .command('codex')
+    .description('Codex-facing Field Theory helpers');
+
+  codexCommand
+    .command('panel')
+    .description('Print a Field Theory panel link for Codex')
+    .argument('[file]', 'Relative or absolute markdown path, title, or filename')
+    .option('--query <query>', 'Find one matching document and link it')
+    .option('--json', 'JSON output')
+    .action(safe(async (targetPath: string | undefined, options) => {
+      if (!targetPath && !options.query) throw new Error('Pass a file/title or --query.');
+      const result = await panelNavigationDocument(targetPath ?? '', {
+        launch: false,
         query: options.query ? String(options.query) : undefined,
       });
       if (options.json) {

--- a/src/companion-cli.ts
+++ b/src/companion-cli.ts
@@ -20,6 +20,7 @@ import {
   showLibraryDocument,
   updateLibraryDocument,
 } from './library.js';
+import { panelNavigationDocument } from './navigation.js';
 
 type SafeAction = (fn: (...args: any[]) => Promise<void>) => (...args: any[]) => Promise<void>;
 
@@ -354,6 +355,25 @@ export function registerCompanionCommands(program: Command, safe: SafeAction): v
         console.log(target.note ?? 'No app deep link available for this target.');
         console.log(target.path);
       }
+    }));
+
+  appCommand
+    .command('url')
+    .description('Print a Field Theory panel URL for a Library or command document')
+    .argument('[path]', 'Relative or absolute markdown path, title, or filename')
+    .option('--query <query>', 'Find one matching document and link it')
+    .option('--json', 'JSON output')
+    .action(safe(async (targetPath: string | undefined, options) => {
+      if (!targetPath && !options.query) throw new Error('Pass a file/title or --query.');
+      const result = await panelNavigationDocument(targetPath ?? '', {
+        launch: false,
+        query: options.query ? String(options.query) : undefined,
+      });
+      if (options.json) {
+        printJson(result);
+        return;
+      }
+      console.log(result.url ?? result.path);
     }));
 
   const install = program

--- a/src/navigation.ts
+++ b/src/navigation.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { buildFieldTheoryOpenTarget, inferOpenKind, openFieldTheoryTarget } from './app-open.js';
+import { buildFieldTheoryOpenTarget, buildFieldTheoryPanelOpenTarget, inferOpenKind, openFieldTheoryTarget } from './app-open.js';
 import {
   createCommandDocument,
   listCommandDocuments,
@@ -360,6 +360,19 @@ export async function openNavigationDocument(target: string, options: Navigation
     openTarget.url = url.toString();
   }
   const launch = options.launch !== false ? openFieldTheoryTarget(openTarget) : undefined;
+  return {
+    path: openTarget.path,
+    url: openTarget.url,
+    launched: Boolean(launch?.launched),
+  };
+}
+
+export async function panelNavigationDocument(target: string, options: NavigationOpenOptions = {}): Promise<NavigationOpenResult> {
+  const entry = options.query ? findNavigationEntries(options.query, 1)[0] : resolveNavigationEntry(target);
+  if (!entry) throw new Error(`No Field Theory document found for query: ${options.query}`);
+  const kind = inferOpenKind(entry.path) ?? 'library';
+  const openTarget = buildFieldTheoryPanelOpenTarget(entry.path, kind);
+  const launch = options.launch === true ? openFieldTheoryTarget(openTarget) : undefined;
   return {
     path: openTarget.path,
     url: openTarget.url,

--- a/tests/app-open.test.ts
+++ b/tests/app-open.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import path from 'node:path';
-import { buildFieldTheoryOpenTarget, inferOpenKind, openFieldTheoryTarget } from '../src/app-open.js';
+import { buildFieldTheoryOpenTarget, buildFieldTheoryPanelOpenTarget, inferOpenKind, openFieldTheoryTarget } from '../src/app-open.js';
 
 test('app-open builds Field Theory wiki URL for library paths', () => {
   const previous = process.env.FT_LIBRARY_DIR;
@@ -13,6 +13,23 @@ test('app-open builds Field Theory wiki URL for library paths', () => {
     assert.equal(target.path, path.join('/tmp/ft-library', 'entries', 'hello.md'));
     assert.ok(target.url?.startsWith('fieldtheory://wiki/open?'));
     assert.ok(target.url?.includes('immersive=true'));
+  } finally {
+    if (previous === undefined) delete process.env.FT_LIBRARY_DIR;
+    else process.env.FT_LIBRARY_DIR = previous;
+  }
+});
+
+test('app-open builds Browser Library panel URL for library paths', () => {
+  const previous = process.env.FT_LIBRARY_DIR;
+  process.env.FT_LIBRARY_DIR = '/tmp/ft-library';
+  try {
+    const target = buildFieldTheoryPanelOpenTarget('entries/hello', 'library');
+    assert.equal(target.kind, 'library');
+    assert.equal(target.supported, true);
+    assert.equal(target.path, path.join('/tmp/ft-library', 'entries', 'hello.md'));
+    assert.ok(target.url?.startsWith('fieldtheory://browser-library/open?'));
+    assert.ok(target.url?.includes('kind=wiki'));
+    assert.ok(target.url?.includes('path=entries%2Fhello.md'));
   } finally {
     if (previous === undefined) delete process.env.FT_LIBRARY_DIR;
     else process.env.FT_LIBRARY_DIR = previous;

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -250,6 +250,23 @@ test('ft navigation commands cover links tags writes app targets and location st
     assert.match(openOutput, /fieldtheory:\/\/wiki\/open/);
     assert.match(openOutput, /Alpha\.md/);
 
+    const panelOutput = await captureStdout(async () => {
+      await buildCli().parseAsync(['node', 'ft', 'panel', 'Alpha']);
+    });
+    assert.match(panelOutput, /fieldtheory:\/\/browser-library\/open/);
+    assert.match(panelOutput, /kind=wiki/);
+    assert.match(panelOutput, /path=wikis%2FAlpha\.md/);
+
+    const codexPanelOutput = await captureStdout(async () => {
+      await buildCli().parseAsync(['node', 'ft', 'codex', 'panel', 'Alpha']);
+    });
+    assert.equal(codexPanelOutput, panelOutput);
+
+    const appUrlOutput = await captureStdout(async () => {
+      await buildCli().parseAsync(['node', 'ft', 'app', 'url', 'Alpha']);
+    });
+    assert.equal(appUrlOutput, panelOutput);
+
     const tabOutput = await captureStdout(async () => {
       await buildCli().parseAsync(['node', 'ft', 'tab', 'Alpha', '--no-launch']);
     });


### PR DESCRIPTION
## Summary
- add Browser Library panel deep-link generation for Library and command documents
- add `ft panel`, `ft app url`, and `ft codex panel` commands
- bump CLI version to `1.3.21`

## Verification
- `npm run build`
- `npm test -- tests/app-open.test.ts tests/cli.test.ts`
- `git diff --check`