### PR TITLE
fix: emit browser panel links from ft panel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fieldtheory",
-  "version": "1.3.21",
+  "version": "1.3.22",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fieldtheory",
-      "version": "1.3.21",
+      "version": "1.3.22",
       "license": "MIT",
       "dependencies": {
         "commander": "^14.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fieldtheory",
-  "version": "1.3.21",
+  "version": "1.3.22",
   "description": "Field Theory CLI. Self-custody for your X/Twitter bookmarks. Local sync, full-text search, classification, and terminal dashboards.",
   "type": "module",
   "bin": {

--- a/src/browser-helper-state.ts
+++ b/src/browser-helper-state.ts
@@ -1,0 +1,60 @@
+import { readJson } from './fs.js';
+import { browserHelperStatePath } from './paths.js';
+
+export type BrowserPanelTarget = Record<string, unknown> & {
+  kind?: unknown;
+  path?: unknown;
+};
+
+type BrowserHelperState = {
+  host: string;
+  port: number;
+  token: string;
+  browserUrl?: string;
+};
+
+function normalizeState(value: unknown): BrowserHelperState | null {
+  if (!value || typeof value !== 'object') return null;
+  const record = value as Record<string, unknown>;
+  if (typeof record.host !== 'string' || record.host.trim() === '') return null;
+  if (typeof record.port !== 'number' || !Number.isInteger(record.port) || record.port <= 0) return null;
+  if (typeof record.token !== 'string' || record.token.trim() === '') return null;
+  return {
+    host: record.host,
+    port: record.port,
+    token: record.token,
+    browserUrl: typeof record.browserUrl === 'string' && record.browserUrl.trim() ? record.browserUrl : undefined,
+  };
+}
+
+async function assertHelperAvailable(state: BrowserHelperState): Promise<void> {
+  const healthUrl = `http://${state.host}:${state.port}/health?token=${encodeURIComponent(state.token)}`;
+  const response = await fetch(healthUrl, { signal: AbortSignal.timeout(1000) });
+  if (!response.ok) throw new Error(`Field Theory browser helper returned HTTP ${response.status}.`);
+}
+
+export async function buildBrowserPanelUrl(target: BrowserPanelTarget): Promise<string> {
+  let state: BrowserHelperState | null = null;
+  try {
+    state = normalizeState(await readJson<unknown>(browserHelperStatePath()));
+  } catch {
+    state = null;
+  }
+  if (!state) {
+    throw new Error('Field Theory browser helper is not available. Start Field Theory with FIELD_THEORY_BROWSER_HELPER=1, then run ft panel again.');
+  }
+
+  try {
+    await assertHelperAvailable(state);
+  } catch (error) {
+    throw new Error('Field Theory browser helper is not responding. Restart Field Theory with FIELD_THEORY_BROWSER_HELPER=1, then run ft panel again.', { cause: error });
+  }
+
+  const baseUrl = state.browserUrl || `http://${state.host}:${state.port}/browser-library.html`;
+  const url = new URL(baseUrl);
+  url.pathname = '/browser-library.html';
+  url.searchParams.set('api', `http://${state.host}:${state.port}`);
+  url.searchParams.set('token', state.token);
+  url.searchParams.set('target', JSON.stringify(target));
+  return url.toString();
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -313,6 +313,12 @@ function printJson(value: unknown): void {
   console.log(JSON.stringify(value, null, 2));
 }
 
+function formatMarkdownLink(label: string, href: string): string {
+  const safeLabel = label.replace(/]/g, '\\]');
+  const safeHref = href.replace(/\)/g, '%29');
+  return `[${safeLabel}](${safeHref})`;
+}
+
 function parseNavigationPlace(value: string): NavigationPlace {
   const place = value.toLowerCase();
   if (listNavigationPlaces().some((candidate) => candidate.name === place)) {
@@ -1706,9 +1712,9 @@ export function buildCli() {
     .argument('[file]', 'Relative or absolute markdown path, title, or filename')
     .option('--query <query>', 'Find one matching document and link it')
     .option('--open', 'Open the panel link in the Field Theory app')
+    .option('--url', 'Print the raw URL instead of a Markdown hyperlink')
     .option('--json', 'JSON output')
     .action(safe(async (targetPath: string | undefined, options) => {
-      if (!targetPath && !options.query) throw new Error('Pass a file/title or --query.');
       const result = await panelNavigationDocument(targetPath ?? '', {
         launch: options.open === true,
         query: options.query ? String(options.query) : undefined,
@@ -1717,7 +1723,8 @@ export function buildCli() {
         printJson(result);
         return;
       }
-      console.log(result.url ?? result.path);
+      const href = result.url ?? result.path;
+      console.log(options.url ? href : formatMarkdownLink('Open in Field Theory panel', href));
     }));
 
   const codexCommand = program
@@ -1729,9 +1736,9 @@ export function buildCli() {
     .description('Print a Field Theory panel link for Codex')
     .argument('[file]', 'Relative or absolute markdown path, title, or filename')
     .option('--query <query>', 'Find one matching document and link it')
+    .option('--url', 'Print the raw URL instead of a Markdown hyperlink')
     .option('--json', 'JSON output')
     .action(safe(async (targetPath: string | undefined, options) => {
-      if (!targetPath && !options.query) throw new Error('Pass a file/title or --query.');
       const result = await panelNavigationDocument(targetPath ?? '', {
         launch: false,
         query: options.query ? String(options.query) : undefined,
@@ -1740,7 +1747,8 @@ export function buildCli() {
         printJson(result);
         return;
       }
-      console.log(result.url ?? result.path);
+      const href = result.url ?? result.path;
+      console.log(options.url ? href : formatMarkdownLink('Open in Field Theory panel', href));
     }));
 
   program

--- a/src/companion-cli.ts
+++ b/src/companion-cli.ts
@@ -20,7 +20,7 @@ import {
   showLibraryDocument,
   updateLibraryDocument,
 } from './library.js';
-import { panelNavigationDocument } from './navigation.js';
+import { appPanelNavigationDocument } from './navigation.js';
 
 type SafeAction = (fn: (...args: any[]) => Promise<void>) => (...args: any[]) => Promise<void>;
 
@@ -364,8 +364,7 @@ export function registerCompanionCommands(program: Command, safe: SafeAction): v
     .option('--query <query>', 'Find one matching document and link it')
     .option('--json', 'JSON output')
     .action(safe(async (targetPath: string | undefined, options) => {
-      if (!targetPath && !options.query) throw new Error('Pass a file/title or --query.');
-      const result = await panelNavigationDocument(targetPath ?? '', {
+      const result = await appPanelNavigationDocument(targetPath ?? '', {
         launch: false,
         query: options.query ? String(options.query) : undefined,
       });

--- a/src/navigation.ts
+++ b/src/navigation.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { buildFieldTheoryOpenTarget, buildFieldTheoryPanelOpenTarget, inferOpenKind, openFieldTheoryTarget } from './app-open.js';
+import { buildBrowserPanelUrl } from './browser-helper-state.js';
 import {
   createCommandDocument,
   listCommandDocuments,
@@ -368,15 +369,46 @@ export async function openNavigationDocument(target: string, options: Navigation
 }
 
 export async function panelNavigationDocument(target: string, options: NavigationOpenOptions = {}): Promise<NavigationOpenResult> {
+  if (!target && !options.query) {
+    const url = await buildBrowserPanelUrl({ kind: 'library' });
+    return {
+      path: 'library',
+      url,
+      launched: false,
+    };
+  }
+
   const entry = options.query ? findNavigationEntries(options.query, 1)[0] : resolveNavigationEntry(target);
   if (!entry) throw new Error(`No Field Theory document found for query: ${options.query}`);
   const kind = inferOpenKind(entry.path) ?? 'library';
   const openTarget = buildFieldTheoryPanelOpenTarget(entry.path, kind);
-  const launch = options.launch === true ? openFieldTheoryTarget(openTarget) : undefined;
+  const url = kind === 'command'
+    ? await buildBrowserPanelUrl({ kind: 'command', path: openTarget.path })
+    : await buildBrowserPanelUrl({ kind: 'wiki', path: path.relative(canonicalLibraryDir(), openTarget.path).split(path.sep).join('/') });
+  return {
+    path: openTarget.path,
+    url,
+    launched: false,
+  };
+}
+
+export async function appPanelNavigationDocument(target: string, options: NavigationOpenOptions = {}): Promise<NavigationOpenResult> {
+  if (!target && !options.query) {
+    return {
+      path: 'library',
+      url: 'fieldtheory://browser-library/open?kind=library',
+      launched: false,
+    };
+  }
+
+  const entry = options.query ? findNavigationEntries(options.query, 1)[0] : resolveNavigationEntry(target);
+  if (!entry) throw new Error(`No Field Theory document found for query: ${options.query}`);
+  const kind = inferOpenKind(entry.path) ?? 'library';
+  const openTarget = buildFieldTheoryPanelOpenTarget(entry.path, kind);
   return {
     path: openTarget.path,
     url: openTarget.url,
-    launched: Boolean(launch?.launched),
+    launched: false,
   };
 }
 

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -15,6 +15,10 @@ export function fieldTheoryDir(): string {
   return path.join(os.homedir(), '.fieldtheory');
 }
 
+export function browserHelperStatePath(): string {
+  return process.env.FT_BROWSER_HELPER_STATE_PATH ?? path.join(fieldTheoryDir(), 'browser-helper.json');
+}
+
 export function legacyDataDir(): string {
   return path.join(os.homedir(), '.ft-bookmarks');
 }

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -206,11 +206,19 @@ test('ft navigation commands cover links tags writes app targets and location st
   const origEnv = {
     FT_LIBRARY_DIR: process.env.FT_LIBRARY_DIR,
     FT_COMMANDS_DIR: process.env.FT_COMMANDS_DIR,
+    FT_BROWSER_HELPER_STATE_PATH: process.env.FT_BROWSER_HELPER_STATE_PATH,
   };
   process.env.FT_LIBRARY_DIR = path.join(tmpDir, 'library');
   process.env.FT_COMMANDS_DIR = path.join(process.env.FT_LIBRARY_DIR, 'Commands');
+  process.env.FT_BROWSER_HELPER_STATE_PATH = path.join(tmpDir, 'browser-helper.json');
   fs.mkdirSync(path.join(process.env.FT_LIBRARY_DIR, 'wikis'), { recursive: true });
   fs.mkdirSync(process.env.FT_COMMANDS_DIR, { recursive: true });
+  fs.writeFileSync(process.env.FT_BROWSER_HELPER_STATE_PATH, JSON.stringify({
+    host: '127.0.0.1',
+    port: 59971,
+    token: 'test-token',
+    browserUrl: 'http://127.0.0.1:59971/browser-library.html',
+  }));
   fs.writeFileSync(path.join(process.env.FT_LIBRARY_DIR, 'wikis', 'Alpha.md'), [
     '---',
     'tags: [systems, nav]',
@@ -221,6 +229,8 @@ test('ft navigation commands cover links tags writes app targets and location st
     '',
   ].join('\n'));
   fs.writeFileSync(path.join(process.env.FT_LIBRARY_DIR, 'wikis', 'Beta.md'), '# Beta\n\nBack to [[Alpha]].\n');
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (async () => new Response(JSON.stringify({ ok: true }), { status: 200 })) as typeof fetch;
 
   try {
     const linksOutput = await captureStdout(async () => {
@@ -253,19 +263,45 @@ test('ft navigation commands cover links tags writes app targets and location st
     const panelOutput = await captureStdout(async () => {
       await buildCli().parseAsync(['node', 'ft', 'panel', 'Alpha']);
     });
-    assert.match(panelOutput, /fieldtheory:\/\/browser-library\/open/);
-    assert.match(panelOutput, /kind=wiki/);
-    assert.match(panelOutput, /path=wikis%2FAlpha\.md/);
+    const panelLine = panelOutput.trim().split('\n').at(-1) ?? '';
+    assert.match(panelLine, /http:\/\/127\.0\.0\.1:59971\/browser-library\.html/);
+    assert.match(panelLine, /api=http%3A%2F%2F127\.0\.0\.1%3A59971/);
+    assert.match(panelLine, /token=test-token/);
+    assert.match(panelLine, /target=%7B%22kind%22%3A%22wiki%22%2C%22path%22%3A%22wikis%2FAlpha\.md%22%7D/);
+
+    const panelUrlOutput = await captureStdout(async () => {
+      await buildCli().parseAsync(['node', 'ft', 'panel', 'Alpha', '--url']);
+    });
+    const panelUrlLine = panelUrlOutput.trim().split('\n').at(-1) ?? '';
+    assert.match(panelUrlLine, /^http:\/\/127\.0\.0\.1:59971\/browser-library\.html/);
+    assert.match(panelUrlLine, /target=%7B%22kind%22%3A%22wiki%22%2C%22path%22%3A%22wikis%2FAlpha\.md%22%7D/);
+
+    const libraryPanelOutput = await captureStdout(async () => {
+      await buildCli().parseAsync(['node', 'ft', 'panel']);
+    });
+    const libraryPanelLine = libraryPanelOutput.trim().split('\n').at(-1) ?? '';
+    assert.match(libraryPanelLine, /http:\/\/127\.0\.0\.1:59971\/browser-library\.html/);
+    assert.match(libraryPanelLine, /target=%7B%22kind%22%3A%22library%22%7D/);
 
     const codexPanelOutput = await captureStdout(async () => {
       await buildCli().parseAsync(['node', 'ft', 'codex', 'panel', 'Alpha']);
     });
-    assert.equal(codexPanelOutput, panelOutput);
+    const codexPanelLine = codexPanelOutput.trim().split('\n').at(-1) ?? '';
+    assert.match(codexPanelLine, /http:\/\/127\.0\.0\.1:59971\/browser-library\.html/);
+    assert.match(codexPanelLine, /target=%7B%22kind%22%3A%22wiki%22%2C%22path%22%3A%22wikis%2FAlpha\.md%22%7D/);
 
     const appUrlOutput = await captureStdout(async () => {
       await buildCli().parseAsync(['node', 'ft', 'app', 'url', 'Alpha']);
     });
-    assert.equal(appUrlOutput, panelOutput);
+    const appUrlLine = appUrlOutput.trim().split('\n').at(-1) ?? '';
+    assert.match(appUrlLine, /^fieldtheory:\/\/browser-library\/open/);
+    assert.match(appUrlLine, /path=wikis%2FAlpha\.md/);
+
+    const appLibraryUrlOutput = await captureStdout(async () => {
+      await buildCli().parseAsync(['node', 'ft', 'app', 'url']);
+    });
+    const appLibraryUrlLine = appLibraryUrlOutput.trim().split('\n').at(-1) ?? '';
+    assert.equal(appLibraryUrlLine, 'fieldtheory://browser-library/open?kind=library');
 
     const tabOutput = await captureStdout(async () => {
       await buildCli().parseAsync(['node', 'ft', 'tab', 'Alpha', '--no-launch']);
@@ -301,6 +337,7 @@ test('ft navigation commands cover links tags writes app targets and location st
     });
     assert.match(backOutput, /current: library/);
   } finally {
+    globalThis.fetch = originalFetch;
     for (const [key, value] of Object.entries(origEnv)) {
       if (value === undefined) delete process.env[key];
       else process.env[key] = value;


### PR DESCRIPTION
## Summary
- make ft panel / ft codex panel emit Codex-browser HTTP links from the live Browser Helper state instead of fieldtheory:// native-app links
- make no-argument ft panel target the Library surface
- keep ft app url as the native app URL command
- bump CLI to 1.3.22

## Verification
- npm run build
- npm test -- tests/cli.test.ts tests/app-open.test.ts
- installed CLI smoke test with a mock Browser Helper state