### PR TITLE
Fix ft current runtime context lookup

### DIFF
--- a/src/current.ts
+++ b/src/current.ts
@@ -1,6 +1,18 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { codexContextSessionsDir } from './paths.js';
+import { legacyCodexContextSessionsDir, runtimeContextSessionsDir } from './paths.js';
+
+export interface CurrentDocumentSelection {
+  textPath: string;
+  preview: string | null;
+}
+
+export interface CurrentDocumentRelatedPage {
+  title: string | null;
+  path: string | null;
+  kind: string | null;
+  contentPath: string | null;
+}
 
 export interface CurrentDocumentSummary {
   manifestPath: string;
@@ -12,6 +24,9 @@ export interface CurrentDocumentSummary {
     contentMode: string | null;
     contentPath: string;
   };
+  selection: CurrentDocumentSelection | null;
+  recent: CurrentDocumentRelatedPage[];
+  includedPages: CurrentDocumentRelatedPage[];
 }
 
 export interface CurrentDocumentContext extends CurrentDocumentSummary {
@@ -40,6 +55,10 @@ function statMtimeMs(filePath: string): number {
   }
 }
 
+function arrayField(value: unknown): unknown[] {
+  return Array.isArray(value) ? value : [];
+}
+
 function assertInsideDirectory(filePath: string, dirPath: string): void {
   const resolvedFilePath = path.resolve(filePath);
   const resolvedDirPath = path.resolve(dirPath);
@@ -49,21 +68,61 @@ function assertInsideDirectory(filePath: string, dirPath: string): void {
   }
 }
 
-export function findCurrentContextManifest(sessionsDir = codexContextSessionsDir()): string | null {
+function readSessionManifests(sessionsDir: string): string[] {
   let entries: fs.Dirent[];
   try {
     entries = fs.readdirSync(sessionsDir, { withFileTypes: true });
   } catch {
-    return null;
+    return [];
   }
 
-  const manifests = entries
+  return entries
     .filter((entry) => entry.isDirectory())
     .map((entry) => path.join(sessionsDir, entry.name, 'context.json'))
-    .filter((manifestPath) => fs.existsSync(manifestPath))
+    .filter((manifestPath) => fs.existsSync(manifestPath));
+}
+
+function contextSessionDirs(): string[] {
+  return Array.from(new Set([
+    runtimeContextSessionsDir(),
+    legacyCodexContextSessionsDir(),
+  ]));
+}
+
+export function findCurrentContextManifest(sessionsDir?: string): string | null {
+  const manifests = (sessionsDir ? readSessionManifests(sessionsDir) : contextSessionDirs().flatMap(readSessionManifests))
     .sort((a, b) => statMtimeMs(b) - statMtimeMs(a));
 
   return manifests[0] ?? null;
+}
+
+function readSelection(value: unknown, sessionDir: string): CurrentDocumentSelection | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+  const record = value as ManifestRecord;
+  const textPath = stringField(record.textPath);
+  if (!textPath) return null;
+  assertInsideDirectory(textPath, sessionDir);
+  return {
+    textPath,
+    preview: stringField(record.preview),
+  };
+}
+
+function readRelatedPages(value: unknown, sessionDir: string): CurrentDocumentRelatedPage[] {
+  return arrayField(value)
+    .map((item) => {
+      if (!item || typeof item !== 'object' || Array.isArray(item)) return null;
+      const record = item as ManifestRecord;
+      const contentPath = stringField(record.contentPath);
+      if (contentPath) assertInsideDirectory(contentPath, sessionDir);
+      return {
+        title: stringField(record.title),
+        path: stringField(record.path),
+        kind: stringField(record.kind),
+        contentPath,
+      };
+    })
+    .filter((item): item is CurrentDocumentRelatedPage => item !== null);
 }
 
 export function readCurrentDocumentSummary(manifestPath = findCurrentContextManifest()): CurrentDocumentSummary {
@@ -82,7 +141,8 @@ export function readCurrentDocumentSummary(manifestPath = findCurrentContextMani
   if (!contentPath) {
     throw new Error(`Context manifest has no activeDocument.contentPath: ${manifestPath}`);
   }
-  assertInsideDirectory(contentPath, path.dirname(manifestPath));
+  const sessionDir = path.dirname(manifestPath);
+  assertInsideDirectory(contentPath, sessionDir);
 
   return {
     manifestPath,
@@ -94,6 +154,9 @@ export function readCurrentDocumentSummary(manifestPath = findCurrentContextMani
       contentMode: stringField(documentRecord.contentMode),
       contentPath,
     },
+    selection: readSelection(manifest.selection, sessionDir),
+    recent: readRelatedPages(manifest.recent, sessionDir),
+    includedPages: readRelatedPages(manifest.includedPages, sessionDir),
   };
 }
 

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -35,8 +35,16 @@ export function canonicalCommandsDir(): string {
   return process.env.FT_COMMANDS_DIR ?? path.join(canonicalLibraryDir(), 'Commands');
 }
 
-export function codexContextSessionsDir(): string {
+export function runtimeContextSessionsDir(): string {
+  return path.join(fieldTheoryDir(), '.codex-context', 'sessions');
+}
+
+export function legacyCodexContextSessionsDir(): string {
   return path.join(canonicalLibraryDir(), 'Codex Context', 'sessions');
+}
+
+export function codexContextSessionsDir(): string {
+  return legacyCodexContextSessionsDir();
 }
 
 export function libraryDir(): string {

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -390,8 +390,10 @@ test('ft current keeps document content opt-in for model-facing JSON', async () 
 
 test('ft current reports missing context without a stack trace', async () => {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ft-current-missing-'));
-  const previous = process.env.FT_LIBRARY_DIR;
+  const previousHome = process.env.HOME;
+  const previousLibraryDir = process.env.FT_LIBRARY_DIR;
   const previousExitCode = process.exitCode;
+  process.env.HOME = tmpDir;
   process.env.FT_LIBRARY_DIR = path.join(tmpDir, 'library');
   try {
     const stderr = await captureStderr(async () => {
@@ -401,8 +403,10 @@ test('ft current reports missing context without a stack trace', async () => {
     assert.doesNotMatch(stderr, /at readCurrentDocument/);
     assert.equal(process.exitCode, 1);
   } finally {
-    if (previous === undefined) delete process.env.FT_LIBRARY_DIR;
-    else process.env.FT_LIBRARY_DIR = previous;
+    if (previousHome === undefined) delete process.env.HOME;
+    else process.env.HOME = previousHome;
+    if (previousLibraryDir === undefined) delete process.env.FT_LIBRARY_DIR;
+    else process.env.FT_LIBRARY_DIR = previousLibraryDir;
     process.exitCode = previousExitCode;
     fs.rmSync(tmpDir, { recursive: true, force: true });
   }

--- a/tests/current.test.ts
+++ b/tests/current.test.ts
@@ -12,7 +12,7 @@ import {
   readCurrentDocumentSummary,
 } from '../src/current.js';
 
-function writeContext(root: string, id: string, title: string, content: string, updatedAt: string): string {
+function writeContext(root: string, id: string, title: string, content: string, updatedAt: string, extra: Record<string, unknown> = {}): string {
   const sessionDir = path.join(root, id);
   fs.mkdirSync(sessionDir, { recursive: true });
   const contentPath = path.join(sessionDir, 'active.md');
@@ -28,6 +28,7 @@ function writeContext(root: string, id: string, title: string, content: string, 
       contentMode: 'rendered',
       contentPath,
     },
+    ...extra,
   }));
   return manifestPath;
 }
@@ -56,6 +57,77 @@ test('readCurrentDocumentContext reads newest Field Theory context manifest', ()
     assert.match(formatCurrentDocumentContext(context), /# Newer/);
     assert.match(formatCurrentDocumentSummary(context), /title: Newer Page/);
     assert.doesNotMatch(formatCurrentDocumentSummary(context), /# Newer/);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test('findCurrentContextManifest reads the app runtime context before legacy Library context', () => {
+  const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ft-current-home-'));
+  const originalHome = process.env.HOME;
+  const originalLibraryDir = process.env.FT_LIBRARY_DIR;
+  delete process.env.FT_LIBRARY_DIR;
+  process.env.HOME = homeDir;
+
+  try {
+    const runtimeSessionsDir = path.join(homeDir, '.fieldtheory', '.codex-context', 'sessions');
+    const legacySessionsDir = path.join(homeDir, '.fieldtheory', 'library', 'Codex Context', 'sessions');
+    const runtimeManifest = writeContext(runtimeSessionsDir, 'runtime', 'Runtime Page', 'runtime body', '2026-01-03T00:00:00.000Z');
+    const legacyManifest = writeContext(legacySessionsDir, 'legacy', 'Legacy Page', 'legacy body', '2026-01-02T00:00:00.000Z');
+    const runtimeTime = new Date('2026-01-03T00:00:00.000Z');
+    const legacyTime = new Date('2026-01-02T00:00:00.000Z');
+    fs.utimesSync(runtimeManifest, runtimeTime, runtimeTime);
+    fs.utimesSync(legacyManifest, legacyTime, legacyTime);
+
+    assert.equal(findCurrentContextManifest(), runtimeManifest);
+    assert.equal(readCurrentDocumentSummary().activeDocument.title, 'Runtime Page');
+  } finally {
+    if (originalHome === undefined) delete process.env.HOME;
+    else process.env.HOME = originalHome;
+    if (originalLibraryDir === undefined) delete process.env.FT_LIBRARY_DIR;
+    else process.env.FT_LIBRARY_DIR = originalLibraryDir;
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  }
+});
+
+test('readCurrentDocumentSummary exposes selection, recent, and included page metadata', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ft-current-context-fields-'));
+  try {
+    const sessionsDir = path.join(tmpDir, 'sessions');
+    const sessionDir = path.join(sessionsDir, 'session');
+    const selectionPath = path.join(sessionDir, 'selection.md');
+    const recentPath = path.join(sessionDir, 'recent.md');
+    const includedPath = path.join(sessionDir, 'included.md');
+    fs.mkdirSync(sessionDir, { recursive: true });
+    fs.writeFileSync(selectionPath, 'selected text');
+    fs.writeFileSync(recentPath, 'recent text');
+    fs.writeFileSync(includedPath, 'included text');
+    const manifestPath = writeContext(sessionsDir, 'session', 'Page', 'body', '2026-01-01T00:00:00.000Z', {
+      selection: {
+        textPath: selectionPath,
+        preview: 'selected text',
+      },
+      recent: [{
+        title: 'Recent Page',
+        path: '/library/recent.md',
+        kind: 'wiki',
+        contentPath: recentPath,
+      }],
+      includedPages: [{
+        title: 'Included Page',
+        path: '/library/included.md',
+        kind: 'wiki',
+        contentPath: includedPath,
+      }],
+    });
+
+    const summary = readCurrentDocumentSummary(manifestPath);
+    assert.equal(summary.selection?.textPath, selectionPath);
+    assert.equal(summary.selection?.preview, 'selected text');
+    assert.equal(summary.recent[0]?.path, '/library/recent.md');
+    assert.equal(summary.recent[0]?.contentPath, recentPath);
+    assert.equal(summary.includedPages[0]?.path, '/library/included.md');
+    assert.equal(summary.includedPages[0]?.contentPath, includedPath);
   } finally {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary
- Teach `ft current` to read the app runtime context under `~/.fieldtheory/.codex-context/sessions`
- Keep legacy `Library/Codex Context` sessions as a fallback and preserve Library hiding behavior
- Include selection, recent, and included page metadata in `ft current --json` when present

## Verification
- `npx tsx --test tests/current.test.ts tests/cli.test.ts tests/library.test.ts`
- `npm run build`
- Live smoke: `node /tmp/fieldtheory-cli-current-context-pr/bin/ft.mjs current --json` returned `/Users/afar/.fieldtheory/library/scratchpad/Friday Jun 5th at 7:27pm.md`