### PR TITLE
Fix ft current attached terminal context lookup

### DIFF
--- a/src/current.ts
+++ b/src/current.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { legacyCodexContextSessionsDir, runtimeContextSessionsDir } from './paths.js';
+import { legacyCodexContextSessionsDir, runtimeContextSessionStatePath, runtimeContextSessionsDir } from './paths.js';
 
 export interface CurrentDocumentSelection {
   textPath: string;
@@ -35,6 +35,14 @@ export interface CurrentDocumentContext extends CurrentDocumentSummary {
 
 type ManifestRecord = Record<string, unknown>;
 
+interface SessionStateManifestCandidate {
+  manifestPath: string;
+  cwdMatches: boolean;
+  active: boolean;
+  attachedAtMs: number;
+  mtimeMs: number;
+}
+
 function readJsonObject(filePath: string): ManifestRecord {
   const parsed = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
   if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
@@ -57,6 +65,17 @@ function statMtimeMs(filePath: string): number {
 
 function arrayField(value: unknown): unknown[] {
   return Array.isArray(value) ? value : [];
+}
+
+function timestampMs(value: unknown): number {
+  if (typeof value !== 'string') return 0;
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function cwdMatchesSession(value: unknown, cwd = process.cwd()): boolean {
+  if (typeof value !== 'string' || value.length === 0) return false;
+  return path.resolve(value) === path.resolve(cwd);
 }
 
 function assertInsideDirectory(filePath: string, dirPath: string): void {
@@ -89,7 +108,50 @@ function contextSessionDirs(): string[] {
   ]));
 }
 
+function readSessionStateManifestCandidates(sessionStatePath: string): SessionStateManifestCandidate[] {
+  let sessions: unknown[];
+  try {
+    sessions = arrayField(JSON.parse(fs.readFileSync(sessionStatePath, 'utf-8')));
+  } catch {
+    return [];
+  }
+
+  return sessions.flatMap((item) => {
+    if (!item || typeof item !== 'object' || Array.isArray(item)) return [];
+    const session = item as ManifestRecord;
+    const attachedContexts = arrayField(session.attachedContexts);
+    return attachedContexts.flatMap((context) => {
+      if (!context || typeof context !== 'object' || Array.isArray(context)) return [];
+      const manifestPath = stringField((context as ManifestRecord).filePath);
+      if (!manifestPath || !fs.existsSync(manifestPath)) return [];
+      return [{
+        manifestPath,
+        cwdMatches: cwdMatchesSession(session.cwd) || cwdMatchesSession(session.sessionCwd) || cwdMatchesSession((context as ManifestRecord).sessionCwd),
+        active: !stringField(session.exitedAt),
+        attachedAtMs: timestampMs((context as ManifestRecord).attachedAt),
+        mtimeMs: statMtimeMs(manifestPath),
+      }];
+    });
+  });
+}
+
+function findAttachedContextManifest(sessionStatePath = runtimeContextSessionStatePath()): string | null {
+  const candidates = readSessionStateManifestCandidates(sessionStatePath)
+    .sort((a, b) => {
+      if (a.cwdMatches !== b.cwdMatches) return a.cwdMatches ? -1 : 1;
+      if (a.active !== b.active) return a.active ? -1 : 1;
+      return (b.attachedAtMs - a.attachedAtMs) || (b.mtimeMs - a.mtimeMs);
+    });
+
+  return candidates[0]?.manifestPath ?? null;
+}
+
 export function findCurrentContextManifest(sessionsDir?: string): string | null {
+  if (!sessionsDir) {
+    const attachedManifest = findAttachedContextManifest();
+    if (attachedManifest) return attachedManifest;
+  }
+
   const manifests = (sessionsDir ? readSessionManifests(sessionsDir) : contextSessionDirs().flatMap(readSessionManifests))
     .sort((a, b) => statMtimeMs(b) - statMtimeMs(a));
 

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -39,6 +39,10 @@ export function runtimeContextSessionsDir(): string {
   return path.join(fieldTheoryDir(), '.codex-context', 'sessions');
 }
 
+export function runtimeContextSessionStatePath(): string {
+  return path.join(fieldTheoryDir(), '.codex-context', 'session-state.json');
+}
+
 export function legacyCodexContextSessionsDir(): string {
   return path.join(canonicalLibraryDir(), 'Codex Context', 'sessions');
 }

--- a/tests/current.test.ts
+++ b/tests/current.test.ts
@@ -90,6 +90,43 @@ test('findCurrentContextManifest reads the app runtime context before legacy Lib
   }
 });
 
+test('findCurrentContextManifest prefers the terminal attached context from session state', () => {
+  const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ft-current-attached-home-'));
+  const originalHome = process.env.HOME;
+  const originalLibraryDir = process.env.FT_LIBRARY_DIR;
+  delete process.env.FT_LIBRARY_DIR;
+  process.env.HOME = homeDir;
+
+  try {
+    const runtimeSessionsDir = path.join(homeDir, '.fieldtheory', '.codex-context', 'sessions');
+    const attachedManifest = writeContext(runtimeSessionsDir, 'attached', 'Attached Artifact', 'attached body', '2026-01-02T00:00:00.000Z');
+    const newerUnattachedManifest = writeContext(runtimeSessionsDir, 'unattached', 'Workflow', 'workflow body', '2026-01-03T00:00:00.000Z');
+    fs.utimesSync(attachedManifest, new Date('2026-01-02T00:00:00.000Z'), new Date('2026-01-02T00:00:00.000Z'));
+    fs.utimesSync(newerUnattachedManifest, new Date('2026-01-03T00:00:00.000Z'), new Date('2026-01-03T00:00:00.000Z'));
+
+    const sessionStatePath = path.join(homeDir, '.fieldtheory', '.codex-context', 'session-state.json');
+    fs.writeFileSync(sessionStatePath, JSON.stringify([{
+      id: 'terminal-1',
+      cwd: process.cwd(),
+      exitedAt: null,
+      attachedContexts: [{
+        filePath: attachedManifest,
+        attachedAt: '2026-01-04T00:00:00.000Z',
+        sourcePath: '/Users/afar/.fieldtheory/librarian/artifacts/fieldtheory-2026-05-08-093112-artifact.md',
+      }],
+    }]));
+
+    assert.equal(findCurrentContextManifest(), attachedManifest);
+    assert.equal(readCurrentDocumentSummary().activeDocument.title, 'Attached Artifact');
+  } finally {
+    if (originalHome === undefined) delete process.env.HOME;
+    else process.env.HOME = originalHome;
+    if (originalLibraryDir === undefined) delete process.env.FT_LIBRARY_DIR;
+    else process.env.FT_LIBRARY_DIR = originalLibraryDir;
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  }
+});
+
 test('readCurrentDocumentSummary exposes selection, recent, and included page metadata', () => {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ft-current-context-fields-'));
   try {


### PR DESCRIPTION
## Summary
- prefer the active terminal attached context from `.fieldtheory/.codex-context/session-state.json` before falling back to newest context manifests
- keep cwd-matching active sessions ahead of stale or unattached manifests
- add a regression test where a newer unattached workflow manifest loses to the attached artifact context

## Verification
- `npm test -- tests/current.test.ts` (runs full suite: 554 passed)
- `npm run build`
- `npm install -g .`
- `ft current --json` returns The Carcass on Disk artifact