### PR TITLE
Expose current document line mapping

### DIFF
--- a/src/current.ts
+++ b/src/current.ts
@@ -23,6 +23,7 @@ export interface CurrentDocumentSummary {
     kind: string | null;
     contentMode: string | null;
     contentPath: string;
+    lineMapping: unknown;
   };
   selection: CurrentDocumentSelection | null;
   recent: CurrentDocumentRelatedPage[];
@@ -215,6 +216,7 @@ export function readCurrentDocumentSummary(manifestPath = findCurrentContextMani
       kind: stringField(documentRecord.kind),
       contentMode: stringField(documentRecord.contentMode),
       contentPath,
+      lineMapping: documentRecord.lineMapping ?? null,
     },
     selection: readSelection(manifest.selection, sessionDir),
     recent: readRelatedPages(manifest.recent, sessionDir),
@@ -241,6 +243,7 @@ export function formatCurrentDocumentContext(context: CurrentDocumentContext): s
     `updatedAt: ${context.updatedAt ?? '(unknown)'}`,
     `manifest: ${context.manifestPath}`,
     `content: ${context.activeDocument.contentPath}`,
+    `lineMapping: ${context.activeDocument.lineMapping ? 'available' : '(none)'}`,
     '',
     '---',
     '',
@@ -259,6 +262,7 @@ export function formatCurrentDocumentSummary(context: CurrentDocumentSummary): s
     `updatedAt: ${context.updatedAt ?? '(unknown)'}`,
     `manifest: ${context.manifestPath}`,
     `content: ${context.activeDocument.contentPath}`,
+    `lineMapping: ${context.activeDocument.lineMapping ? 'available' : '(none)'}`,
     '',
   ].join('\n');
 }

--- a/tests/current.test.ts
+++ b/tests/current.test.ts
@@ -170,6 +170,35 @@ test('readCurrentDocumentSummary exposes selection, recent, and included page me
   }
 });
 
+test('readCurrentDocumentSummary exposes active document line mapping', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ft-current-line-map-'));
+  try {
+    const sessionsDir = path.join(tmpDir, 'sessions');
+    const manifestPath = writeContext(sessionsDir, 'session', 'Page', 'body', '2026-01-01T00:00:00.000Z');
+    const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf-8'));
+    const lineMapping = {
+      activeLineKind: 'renderedVisual',
+      contentMode: 'rendered',
+      visibleRowsOnly: true,
+      lines: [{
+        visibleLine: 20,
+        sourceLine: 15,
+        rowInSourceLine: 1,
+        rowsInSourceLine: 3,
+        text: 'The phrase "Ego sum" is Latin for "I am."',
+      }],
+    };
+    manifest.activeDocument.lineMapping = lineMapping;
+    fs.writeFileSync(manifestPath, JSON.stringify(manifest));
+
+    const summary = readCurrentDocumentSummary(manifestPath);
+    assert.deepEqual(summary.activeDocument.lineMapping, lineMapping);
+    assert.match(formatCurrentDocumentSummary(summary), /lineMapping: available/);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
 test('readCurrentDocumentContext rejects content paths outside the session directory', () => {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ft-current-'));
   try {


### PR DESCRIPTION
## Summary
- preserve activeDocument.lineMapping from Field Theory terminal context manifests
- show lineMapping availability in human-readable ft current output
- add regression coverage for rendered visible-line to source-line mappings

## Tests
- npm test -- tests/current.test.ts
- npm run build