### PR TITLE
Prefer stable Field Theory panel URLs

### DIFF
--- a/src/browser-helper-state.ts
+++ b/src/browser-helper-state.ts
@@ -11,6 +11,7 @@ type BrowserHelperState = {
   port: number;
   token: string;
   browserUrl?: string;
+  panelUrl?: string;
 };
 
 function normalizeState(value: unknown): BrowserHelperState | null {
@@ -24,6 +25,7 @@ function normalizeState(value: unknown): BrowserHelperState | null {
     port: record.port,
     token: record.token,
     browserUrl: typeof record.browserUrl === 'string' && record.browserUrl.trim() ? record.browserUrl : undefined,
+    panelUrl: typeof record.panelUrl === 'string' && record.panelUrl.trim() ? record.panelUrl : undefined,
   };
 }
 
@@ -50,11 +52,13 @@ export async function buildBrowserPanelUrl(target: BrowserPanelTarget): Promise<
     throw new Error('Field Theory browser helper is not responding. Restart Field Theory with FIELD_THEORY_BROWSER_HELPER=1, then run ft panel again.', { cause: error });
   }
 
-  const baseUrl = state.browserUrl || `http://${state.host}:${state.port}/browser-library.html`;
+  const baseUrl = state.panelUrl || state.browserUrl || `http://${state.host}:${state.port}/browser-library.html`;
   const url = new URL(baseUrl);
-  url.pathname = '/browser-library.html';
-  url.searchParams.set('api', `http://${state.host}:${state.port}`);
-  url.searchParams.set('token', state.token);
+  if (!state.panelUrl) {
+    url.pathname = '/browser-library.html';
+    url.searchParams.set('api', `http://${state.host}:${state.port}`);
+    url.searchParams.set('token', state.token);
+  }
   url.searchParams.set('target', JSON.stringify(target));
   return url.toString();
 }

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -218,6 +218,7 @@ test('ft navigation commands cover links tags writes app targets and location st
     port: 59971,
     token: 'test-token',
     browserUrl: 'http://127.0.0.1:59971/browser-library.html',
+    panelUrl: 'http://127.0.0.1:59971/panel',
   }));
   fs.writeFileSync(path.join(process.env.FT_LIBRARY_DIR, 'wikis', 'Alpha.md'), [
     '---',
@@ -264,30 +265,30 @@ test('ft navigation commands cover links tags writes app targets and location st
       await buildCli().parseAsync(['node', 'ft', 'panel', 'Alpha']);
     });
     const panelLine = panelOutput.trim().split('\n').at(-1) ?? '';
-    assert.match(panelLine, /http:\/\/127\.0\.0\.1:59971\/browser-library\.html/);
-    assert.match(panelLine, /api=http%3A%2F%2F127\.0\.0\.1%3A59971/);
-    assert.match(panelLine, /token=test-token/);
+    assert.match(panelLine, /http:\/\/127\.0\.0\.1:59971\/panel/);
+    assert.doesNotMatch(panelLine, /api=http%3A%2F%2F127\.0\.0\.1%3A59971/);
+    assert.doesNotMatch(panelLine, /token=test-token/);
     assert.match(panelLine, /target=%7B%22kind%22%3A%22wiki%22%2C%22path%22%3A%22wikis%2FAlpha\.md%22%7D/);
 
     const panelUrlOutput = await captureStdout(async () => {
       await buildCli().parseAsync(['node', 'ft', 'panel', 'Alpha', '--url']);
     });
     const panelUrlLine = panelUrlOutput.trim().split('\n').at(-1) ?? '';
-    assert.match(panelUrlLine, /^http:\/\/127\.0\.0\.1:59971\/browser-library\.html/);
+    assert.match(panelUrlLine, /^http:\/\/127\.0\.0\.1:59971\/panel/);
     assert.match(panelUrlLine, /target=%7B%22kind%22%3A%22wiki%22%2C%22path%22%3A%22wikis%2FAlpha\.md%22%7D/);
 
     const libraryPanelOutput = await captureStdout(async () => {
       await buildCli().parseAsync(['node', 'ft', 'panel']);
     });
     const libraryPanelLine = libraryPanelOutput.trim().split('\n').at(-1) ?? '';
-    assert.match(libraryPanelLine, /http:\/\/127\.0\.0\.1:59971\/browser-library\.html/);
+    assert.match(libraryPanelLine, /http:\/\/127\.0\.0\.1:59971\/panel/);
     assert.match(libraryPanelLine, /target=%7B%22kind%22%3A%22library%22%7D/);
 
     const codexPanelOutput = await captureStdout(async () => {
       await buildCli().parseAsync(['node', 'ft', 'codex', 'panel', 'Alpha']);
     });
     const codexPanelLine = codexPanelOutput.trim().split('\n').at(-1) ?? '';
-    assert.match(codexPanelLine, /http:\/\/127\.0\.0\.1:59971\/browser-library\.html/);
+    assert.match(codexPanelLine, /http:\/\/127\.0\.0\.1:59971\/panel/);
     assert.match(codexPanelLine, /target=%7B%22kind%22%3A%22wiki%22%2C%22path%22%3A%22wikis%2FAlpha\.md%22%7D/);
 
     const appUrlOutput = await captureStdout(async () => {


### PR DESCRIPTION
## Summary
- read the optional panelUrl from Browser Library helper state
- make ft panel prefer the stable tokenless panel URL when available
- keep the existing tokenized helper URL fallback for older app builds

## Verification
- npm test
- npm run build