### PR TITLE
Document CLI source release boundaries

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Field Theory Mac app issues
+    url: https://github.com/afar1/fieldtheory/issues
+    about: Use this for Mac app behavior, Library UI, auth, River, sync, updater, or app packaging issues not caused by the CLI.
+  - name: Field Theory plugin issues
+    url: https://github.com/afar1/fieldtheory-plugin/issues
+    about: Use this for Codex plugin, skills, and agent integration issues.
+  - name: Field Theory release feed issues
+    url: https://github.com/afar1/field-releases/issues
+    about: Use this only for installer, download, updater-feed, or release-artifact problems.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,13 @@
+## Summary
+
+Describe the CLI behavior, docs, or packaging change.
+
+## Verification
+
+List the commands, tests, or manual checks you ran.
+
+## Safety
+
+- [ ] No browser cookies, OAuth tokens, local bookmark databases, private Library content, or private logs are included.
+- [ ] New network, filesystem, or agent-execution behavior is described clearly.
+- [ ] License, notice, or attribution updates are included when needed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md
 
-This is the Field Theory CLI — a standalone tool for syncing and querying X/Twitter bookmarks locally.
+This is the Field Theory CLI: a local-first command-line companion for X bookmark sync, Field Theory Library workflows, portable commands, app install, and agent-facing context.
 
 ## Commands
 
@@ -13,7 +13,7 @@ npm run start        # Run compiled dist/cli.js
 
 ## Architecture
 
-Single CLI application built with Commander.js. Bookmark data is stored in `~/.fieldtheory/bookmarks/`; markdown library output is stored in `~/.fieldtheory/library/`.
+Single CLI application built with Commander.js. Bookmark data is stored in `~/.fieldtheory/bookmarks/`; Library markdown is stored in `~/.fieldtheory/library/`; portable commands live under `~/.fieldtheory/commands/`; and Possible run artifacts live under `~/.fieldtheory/ideas/`.
 
 ### Key files
 
@@ -30,6 +30,12 @@ Single CLI application built with Commander.js. Bookmark data is stored in `~/.f
 | `src/chrome-cookies.ts` | Chrome cookie extraction (macOS Keychain) |
 | `src/xauth.ts` | OAuth 2.0 flow |
 | `src/db.ts` | WASM SQLite layer (sql.js-fts5) |
+| `src/library.ts` | Local Field Theory Library read/write helpers |
+| `src/commands-files.ts` | Portable command file creation and validation |
+| `src/app-open.ts` | Open Library pages in the packaged Mac app or a dev checkout |
+| `src/app-install.ts` | Download and install packaged app releases |
+| `src/skill.ts` | Install Field Theory agent skills for Claude Code and Codex |
+| `src/ideas.ts` | Possible seeds, runs, jobs, and nightly schedules |
 
 ### Data flow
 
@@ -41,10 +47,19 @@ Chrome cookies → GraphQL API → JSONL cache → SQLite FTS5 index
                          Search / List / Viz
 ```
 
+Field Theory app companion flow:
+
+```text
+~/.fieldtheory/library + ~/.fieldtheory/commands
+                    ↓
+              ft library / ft commands
+                    ↓
+    packaged Field Theory app or configured dev checkout
+```
+
 ### Dependencies
 
 All pure JavaScript/WASM — no native bindings:
 - `commander` — CLI framework
 - `sql.js` + `sql.js-fts5` — SQLite in WebAssembly
-- `zod` — schema validation
 - `dotenv` — .env file loading

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,25 @@
+# Contributing to Field Theory CLI
+
+Field Theory CLI is MIT-licensed local-first software for bookmark sync, Library workflows, portable commands, and agent-facing knowledge tools.
+
+## Local Setup
+
+```bash
+npm ci
+npm run build
+npm test
+```
+
+## Contribution Terms
+
+By submitting a PR, patch, or contribution, you certify that you have the right to contribute it and agree to license it under the MIT License.
+
+No CLA is required. No `git commit -s` signoff is required by default.
+
+Maintainers may ask for explicit signoff on larger, sensitive, or ambiguous contributions.
+
+## Security
+
+Do not include browser cookies, OAuth tokens, X session data, local bookmark databases, or private `~/.fieldtheory` content in issues, tests, fixtures, or screenshots.
+
+Use `SECURITY.md` for suspected vulnerabilities or private data exposure.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,19 @@ Sync and store bookmarks locally, manage Field Theory Library and command workfl
 
 Free and open source. Designed for Mac.
 
+Field Theory CLI also acts as the command-line companion to the Field Theory Mac app: it knows the local `~/.fieldtheory` paths, can open Library pages in the packaged app, installs agent skills, and can download packaged app releases from the release feed.
+
+## Repository Family
+
+Field Theory is split across sibling repositories:
+
+- `afar1/fieldtheory`: Field Theory Mac app source.
+- `afar1/fieldtheory-cli`: this CLI, licensed under MIT.
+- `afar1/fieldtheory-plugin`: Field Theory Codex plugin and skills.
+- `afar1/field-releases`: packaged Mac app release artifacts and updater metadata.
+
+Use the app source repo for Mac app issues, this repo for CLI issues, the plugin repo for agent-plugin issues, and the release feed only for installer, download, update-feed, or release-artifact problems.
+
 ## Install
 
 ```bash
@@ -225,10 +238,10 @@ To remove bookmark and Library data: `rm -rf ~/.fieldtheory/bookmarks ~/.fieldth
 
 The CLI is one piece of the Field Theory repo family.
 
-- `afar1/fieldtheory-cli`: this CLI, licensed under MIT.
 - `afar1/fieldtheory`: Field Theory Mac app source, licensed under AGPL-3.0-or-later.
-- `afar1/fieldtheory-plugin`: Field Theory plugin ecosystem, licensed under MIT.
-- `afar1/field-releases`: packaged Mac app release artifacts only.
+- `afar1/fieldtheory-cli`: this CLI, licensed under MIT.
+- `afar1/fieldtheory-plugin`: Field Theory Codex plugin and skills, licensed under MIT.
+- `afar1/field-releases`: packaged Mac app release artifacts and updater metadata only.
 
 File app-source issues in the app source repo. Keep binary installer, updater, and release-feed issues out of this CLI repo unless the bug is caused by `ft install app` or CLI launch behavior.
 

--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ Field Theory CLI also acts as the command-line companion to the Field Theory Mac
 
 Field Theory is split across sibling repositories:
 
-- `afar1/fieldtheory`: Field Theory Mac app source.
-- `afar1/fieldtheory-cli`: this CLI, licensed under MIT.
-- `afar1/fieldtheory-plugin`: Field Theory Codex plugin and skills.
-- `afar1/field-releases`: packaged Mac app release artifacts and updater metadata.
+- [`afar1/fieldtheory`](https://github.com/afar1/fieldtheory): Field Theory Mac app source.
+- [`afar1/fieldtheory-cli`](https://github.com/afar1/fieldtheory-cli): this CLI, licensed under MIT.
+- [`afar1/fieldtheory-plugin`](https://github.com/afar1/fieldtheory-plugin): Field Theory Codex plugin and skills.
+- [`afar1/field-releases`](https://github.com/afar1/field-releases): packaged Mac app release artifacts and updater metadata.
 
 Use the app source repo for Mac app issues, this repo for CLI issues, the plugin repo for agent-plugin issues, and the release feed only for installer, download, update-feed, or release-artifact problems.
 
@@ -238,10 +238,10 @@ To remove bookmark and Library data: `rm -rf ~/.fieldtheory/bookmarks ~/.fieldth
 
 The CLI is one piece of the Field Theory repo family.
 
-- `afar1/fieldtheory`: Field Theory Mac app source, licensed under AGPL-3.0-or-later.
-- `afar1/fieldtheory-cli`: this CLI, licensed under MIT.
-- `afar1/fieldtheory-plugin`: Field Theory Codex plugin and skills, licensed under MIT.
-- `afar1/field-releases`: packaged Mac app release artifacts and updater metadata only.
+- [`afar1/fieldtheory`](https://github.com/afar1/fieldtheory): Field Theory Mac app source, licensed under AGPL-3.0-or-later.
+- [`afar1/fieldtheory-cli`](https://github.com/afar1/fieldtheory-cli): this CLI, licensed under MIT.
+- [`afar1/fieldtheory-plugin`](https://github.com/afar1/fieldtheory-plugin): Field Theory Codex plugin and skills, licensed under MIT.
+- [`afar1/field-releases`](https://github.com/afar1/field-releases): packaged Mac app release artifacts and updater metadata only.
 
 File app-source issues in the app source repo. Keep binary installer, updater, and release-feed issues out of this CLI repo unless the bug is caused by `ft install app` or CLI launch behavior.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Field Theory CLI
 
-Sync and store locally all of your X/Twitter bookmarks. Search, classify, and make them available to Claude Code, Codex, or any agent with shell access.
+Sync and store bookmarks locally, manage Field Theory Library and command workflows, and make local context available to Claude Code, Codex, or any agent with shell access.
 
 Free and open source. Designed for Mac.
 
@@ -223,14 +223,14 @@ To remove bookmark and Library data: `rm -rf ~/.fieldtheory/bookmarks ~/.fieldth
 
 ## Field Theory Repos
 
-The CLI is one piece of the Field Theory source release.
+The CLI is one piece of the Field Theory repo family.
 
 - `afar1/fieldtheory-cli`: this CLI, licensed under MIT.
+- `afar1/fieldtheory`: Field Theory Mac app source, licensed under AGPL-3.0-or-later.
+- `afar1/fieldtheory-plugin`: Field Theory plugin ecosystem, licensed under MIT.
 - `afar1/field-releases`: packaged Mac app release artifacts only.
-- `afar1/fieldtheory`: planned canonical Mac app source repo after the private-first app audit is complete.
-- `afar1/fieldtheory-plugin`: planned plugin ecosystem repo.
 
-File app-source issues in the app source repo once it is available. Keep binary installer, updater, and release-feed issues out of this CLI repo unless the bug is caused by `ft install app` or CLI launch behavior.
+File app-source issues in the app source repo. Keep binary installer, updater, and release-feed issues out of this CLI repo unless the bug is caused by `ft install app` or CLI launch behavior.
 
 ## Categories
 

--- a/README.md
+++ b/README.md
@@ -221,6 +221,17 @@ export FT_COMMANDS_DIR=/path/to/custom/commands
 
 To remove bookmark and Library data: `rm -rf ~/.fieldtheory/bookmarks ~/.fieldtheory/library`
 
+## Field Theory Repos
+
+The CLI is one piece of the Field Theory source release.
+
+- `afar1/fieldtheory-cli`: this CLI, licensed under MIT.
+- `afar1/field-releases`: packaged Mac app release artifacts only.
+- `afar1/fieldtheory`: planned canonical Mac app source repo after the private-first app audit is complete.
+- `afar1/fieldtheory-plugin`: planned plugin ecosystem repo.
+
+File app-source issues in the app source repo once it is available. Keep binary installer, updater, and release-feed issues out of this CLI repo unless the bug is caused by `ft install app` or CLI launch behavior.
+
 ## Categories
 
 | Category | What it catches |
@@ -275,6 +286,14 @@ Session sync extracts cookies from your browser's local database. Use `ft sync -
 **OAuth tokens** are stored with `chmod 600` (owner-only). Treat `~/.fieldtheory/bookmarks/oauth-token.json` like a password.
 
 **The default sync uses X's internal GraphQL API**, the same API that x.com uses in your browser. For the official v2 API, use `ft auth` + `ft sync --api`.
+
+Do not open a public issue for suspected vulnerabilities, exposed credentials, auth bypasses, token-handling bugs, or private data exposure. Use the private maintainer contact in `SECURITY.md`.
+
+## Contributing
+
+By submitting a PR, patch, or contribution, you certify that you have the right to contribute it and agree to license it under the MIT License.
+
+No CLA is required. Maintainers may ask for explicit signoff on larger, sensitive, or ambiguous contributions.
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,22 @@
+# Security Policy
+
+## Reporting Vulnerabilities
+
+Do not open a public issue for suspected vulnerabilities, exposed credentials, auth bypasses, token-handling bugs, or private data exposure.
+
+Use private maintainer contact until a public security advisory process is configured.
+
+## Sensitive Areas
+
+Field Theory CLI can read browser session cookies for X bookmark sync, store OAuth tokens for API sync, and write local Field Theory data under `~/.fieldtheory`.
+
+Do not share:
+
+- browser cookies;
+- X auth tokens;
+- OAuth token files;
+- local bookmark databases;
+- private Library or Commands content;
+- logs that include request headers or token values.
+
+OAuth token files should be owner-readable only. Treat `~/.fieldtheory/bookmarks/oauth-token.json` like a password.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,9 @@
 
 Do not open a public issue for suspected vulnerabilities, exposed credentials, auth bypasses, token-handling bugs, or private data exposure.
 
-Use private maintainer contact until a public security advisory process is configured.
+Email `support@fieldtheory.dev` with `[security]` in the subject.
+
+Include the affected command, version, platform, and enough reproduction detail for a maintainer to confirm the issue without receiving your cookies, OAuth tokens, bookmark database, or private Library content.
 
 ## Sensitive Areas
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fieldtheory",
   "version": "1.3.22",
-  "description": "Field Theory CLI. Self-custody for your X/Twitter bookmarks. Local sync, full-text search, classification, and terminal dashboards.",
+  "description": "Field Theory CLI for bookmarks, Library, commands, app install, and agent workflows.",
   "type": "module",
   "bin": {
     "ft": "bin/ft.mjs",
@@ -28,10 +28,18 @@
     "type": "git",
     "url": "git+https://github.com/afar1/fieldtheory-cli.git"
   },
+  "homepage": "https://fieldtheory.dev/cli",
+  "bugs": {
+    "url": "https://github.com/afar1/fieldtheory-cli/issues"
+  },
   "keywords": [
+    "field-theory",
     "bookmarks",
     "twitter",
     "x",
+    "library",
+    "commands",
+    "agent-tools",
     "search",
     "fts5",
     "sqlite",


### PR DESCRIPTION
## Summary
- update README, contributing, and security docs for the Field Theory repo family
- clarify CLI issue routing across app, CLI, plugin, and release-feed repos
- update npm package metadata so the CLI is described as bookmarks + Library + commands + app install + agent workflows
- refresh `CLAUDE.md` so the repo-local agent guide reflects current Library, commands, app install, skills, and Possible workflows
- add GitHub issue-routing config and a PR template with safety checks

## Verification
- `npm run build`
- `npm test` (`555` passing tests)
- `git diff --check`
- package JSON parse check
- targeted public-facing phrase scan
- issue-template YAML validation
