### PR TITLE
Add active document update command

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -40,6 +40,7 @@ import { registerCompanionCommands } from './companion-cli.js';
 import { getPathReport } from './field-status.js';
 import { formatAgentContext, getAgentContext } from './agent-context.js';
 import { formatCurrentDocumentSummary, readCurrentDocumentContext, readCurrentDocumentSummary } from './current.js';
+import { updateLibraryDocument } from './library.js';
 import { formatWorkflowState, getWorkflowState } from './workflow-state.js';
 import {
   appendNavigationDocument,
@@ -492,6 +493,7 @@ function isInternalWorkerCommand(command: Command): boolean {
 function shouldSkipCommandChrome(command: Command): boolean {
   if (isInternalWorkerCommand(command)) return true;
   if (command.opts().json) return true;
+  if (command.parent?.name() === 'current') return true;
   if ([
     'path', 'paths', 'current', 'recent', 'state', 'ls', 'tree', 'find', 'grep', 'cat',
     'head', 'meta', 'pwd', 'context', 'open', 'tab', 'reveal', 'link', 'links',
@@ -1928,7 +1930,7 @@ export function buildCli() {
       else process.stdout.write(formatNavigationState(state));
     }));
 
-  program
+  const currentCommand = program
     .command('current')
     .description('Show the active Field Theory document attached to the Mac app terminal')
     .option('--manifest <path>', 'Read a specific context manifest')
@@ -1948,6 +1950,36 @@ export function buildCli() {
         return;
       }
       process.stdout.write(formatCurrentDocumentSummary(context));
+    }));
+
+  currentCommand
+    .command('update')
+    .description('Update the active Field Theory Library document with stdin or file content')
+    .option('--manifest <path>', 'Read a specific context manifest')
+    .option('--stdin', 'Read markdown content from stdin')
+    .option('--file <path>', 'Read markdown content from a file')
+    .option('--expected-sha256 <hash>', 'Only update if the current source file hash matches')
+    .option('--force', 'Overwrite without checking an expected hash')
+    .option('--json', 'JSON output')
+    .action(safe(async (options, command) => {
+      if (!options.stdin && !options.file) throw new Error('Pass --stdin or --file for update content.');
+      const parentOptions = command.parent?.opts() ?? {};
+      const manifest = options.manifest || parentOptions.manifest;
+      const context = readCurrentDocumentContext(manifest);
+      const targetPath = context.activeDocument.path;
+      if (!targetPath) throw new Error('Active Field Theory context has no source path to update.');
+      const doc = await updateLibraryDocument(targetPath, {
+        stdin: Boolean(options.stdin),
+        file: options.file ? String(options.file) : undefined,
+        expectedSha256: options.expectedSha256 ? String(options.expectedSha256) : undefined,
+        force: Boolean(options.force || !options.expectedSha256),
+      });
+      if (options.json || parentOptions.json) {
+        printJson(doc);
+        return;
+      }
+      console.log(`Updated: ${doc.path}`);
+      console.log(`sha256: ${doc.version.sha256}`);
     }));
 
   program

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -388,6 +388,105 @@ test('ft current keeps document content opt-in for model-facing JSON', async () 
   }
 });
 
+test('ft current update edits the active Library document without passing its path', async () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ft-current-update-'));
+  const previousLibraryDir = process.env.FT_LIBRARY_DIR;
+  const previousExitCode = process.exitCode;
+  try {
+    const libraryDir = path.join(tmpDir, 'library');
+    const sourcePath = path.join(libraryDir, 'scratchpad', 'Sunday Jun 14th.md');
+    const sessionDir = path.join(tmpDir, 'session');
+    const contentPath = path.join(sessionDir, 'active.md');
+    const manifestPath = path.join(sessionDir, 'context.json');
+    const initialContent = '[] cameras installed at home\n[] figure out car seats\n';
+    const updatedContent = '- cameras installed at home\n- figure out car seats\n';
+    const updatePath = path.join(tmpDir, 'updated.md');
+    process.env.FT_LIBRARY_DIR = libraryDir;
+    fs.mkdirSync(path.dirname(sourcePath), { recursive: true });
+    fs.mkdirSync(sessionDir, { recursive: true });
+    fs.writeFileSync(sourcePath, initialContent);
+    fs.writeFileSync(contentPath, initialContent);
+    fs.writeFileSync(updatePath, updatedContent);
+    fs.writeFileSync(manifestPath, JSON.stringify({
+      updatedAt: '2026-01-02T00:00:00.000Z',
+      activeDocument: {
+        title: 'Sunday Jun 14th',
+        path: sourcePath,
+        kind: 'wiki',
+        contentMode: 'rendered',
+        contentPath,
+      },
+    }));
+
+    const output = await captureStdout(async () => {
+      await buildCli().parseAsync(['node', 'ft', 'current', 'update', '--manifest', manifestPath, '--file', updatePath, '--json']);
+    });
+
+    assert.equal(fs.readFileSync(sourcePath, 'utf-8'), updatedContent);
+    const jsonStart = output.indexOf('{\n  "path"');
+    assert.notEqual(jsonStart, -1);
+    assert.equal(JSON.parse(output.slice(jsonStart)).path, sourcePath);
+  } finally {
+    if (previousLibraryDir === undefined) delete process.env.FT_LIBRARY_DIR;
+    else process.env.FT_LIBRARY_DIR = previousLibraryDir;
+    process.exitCode = previousExitCode;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test('ft current update honors explicit expected hashes', async () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ft-current-update-guard-'));
+  const previousLibraryDir = process.env.FT_LIBRARY_DIR;
+  const previousExitCode = process.exitCode;
+  try {
+    const libraryDir = path.join(tmpDir, 'library');
+    const sourcePath = path.join(libraryDir, 'scratchpad', 'Sunday Jun 14th.md');
+    const sessionDir = path.join(tmpDir, 'session');
+    const contentPath = path.join(sessionDir, 'active.md');
+    const manifestPath = path.join(sessionDir, 'context.json');
+    const updatePath = path.join(tmpDir, 'updated.md');
+    process.env.FT_LIBRARY_DIR = libraryDir;
+    fs.mkdirSync(path.dirname(sourcePath), { recursive: true });
+    fs.mkdirSync(sessionDir, { recursive: true });
+    fs.writeFileSync(sourcePath, 'current source\n');
+    fs.writeFileSync(contentPath, 'rendered context may differ\n');
+    fs.writeFileSync(updatePath, 'agent update\n');
+    fs.writeFileSync(manifestPath, JSON.stringify({
+      activeDocument: {
+        title: 'Sunday Jun 14th',
+        path: sourcePath,
+        kind: 'wiki',
+        contentMode: 'rendered',
+        contentPath,
+      },
+    }));
+
+    const stderr = await captureStderr(async () => {
+      await buildCli().parseAsync([
+        'node',
+        'ft',
+        'current',
+        'update',
+        '--manifest',
+        manifestPath,
+        '--file',
+        updatePath,
+        '--expected-sha256',
+        '0000000000000000000000000000000000000000000000000000000000000000',
+      ]);
+    });
+
+    assert.match(stderr, /File changed on disk/);
+    assert.equal(process.exitCode, 1);
+    assert.equal(fs.readFileSync(sourcePath, 'utf-8'), 'current source\n');
+  } finally {
+    if (previousLibraryDir === undefined) delete process.env.FT_LIBRARY_DIR;
+    else process.env.FT_LIBRARY_DIR = previousLibraryDir;
+    process.exitCode = previousExitCode;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
 test('ft current reports missing context without a stack trace', async () => {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ft-current-missing-'));
   const previousHome = process.env.HOME;


### PR DESCRIPTION
## Summary
- add `ft current update` so agents can edit the active Field Theory Library document without passing the source path through the shell
- keep `--expected-sha256` available for explicit conflict guards
- skip interactive chrome/banner behavior for `ft current` subcommands so JSON output stays machine-readable

## Verification
- `node --test --test-name-pattern "ft current update" --import tsx tests/cli.test.ts`
- `npm run build`
- `npm test -- tests/cli.test.ts tests/current.test.ts`
- local smoke: installed this worktree globally and updated `/Users/afar/.fieldtheory/library/scratchpad/Sunday Jun 14th.md` via `ft current update --file <tmp>`