### PR TITLE
Print shell-safe current document commands

### DIFF
--- a/src/current.ts
+++ b/src/current.ts
@@ -20,9 +20,11 @@ export interface CurrentDocumentSummary {
   activeDocument: {
     title: string | null;
     path: string | null;
+    shellQuotedPath: string | null;
     kind: string | null;
     contentMode: string | null;
     contentPath: string;
+    shellQuotedContentPath: string;
     lineMapping: unknown;
   };
   selection: CurrentDocumentSelection | null;
@@ -54,6 +56,10 @@ function readJsonObject(filePath: string): ManifestRecord {
 
 function stringField(value: unknown): string | null {
   return typeof value === 'string' && value.length > 0 ? value : null;
+}
+
+function quoteForPosixShell(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
 }
 
 function statMtimeMs(filePath: string): number {
@@ -206,16 +212,19 @@ export function readCurrentDocumentSummary(manifestPath = findCurrentContextMani
   }
   const sessionDir = path.dirname(manifestPath);
   assertInsideDirectory(contentPath, sessionDir);
+  const sourcePath = stringField(documentRecord.path);
 
   return {
     manifestPath,
     updatedAt: stringField(manifest.updatedAt),
     activeDocument: {
       title: stringField(documentRecord.title),
-      path: stringField(documentRecord.path),
+      path: sourcePath,
+      shellQuotedPath: stringField(documentRecord.shellQuotedPath) ?? (sourcePath ? quoteForPosixShell(sourcePath) : null),
       kind: stringField(documentRecord.kind),
       contentMode: stringField(documentRecord.contentMode),
       contentPath,
+      shellQuotedContentPath: stringField(documentRecord.shellQuotedContentPath) ?? quoteForPosixShell(contentPath),
       lineMapping: documentRecord.lineMapping ?? null,
     },
     selection: readSelection(manifest.selection, sessionDir),
@@ -233,16 +242,20 @@ export function readCurrentDocumentContext(manifestPath = findCurrentContextMani
 }
 
 export function formatCurrentDocumentContext(context: CurrentDocumentContext): string {
+  const quotedSource = context.activeDocument.shellQuotedPath ?? '(unknown)';
   const lines = [
     '# Field Theory Current Document',
     '',
     `title: ${context.activeDocument.title ?? '(untitled)'}`,
-    `source: ${context.activeDocument.path ?? '(unknown)'}`,
+    'readCurrentCommand: ft current --content-only',
+    'editCurrentCommand: ft current update --file <temp-file>',
+    `source: ${quotedSource}`,
+    `readSourceCommand: ${context.activeDocument.path ? `cat ${quotedSource}` : '(unknown)'}`,
     `kind: ${context.activeDocument.kind ?? '(unknown)'}`,
     `contentMode: ${context.activeDocument.contentMode ?? '(unknown)'}`,
     `updatedAt: ${context.updatedAt ?? '(unknown)'}`,
     `manifest: ${context.manifestPath}`,
-    `content: ${context.activeDocument.contentPath}`,
+    `content: ${context.activeDocument.shellQuotedContentPath}`,
     `lineMapping: ${context.activeDocument.lineMapping ? 'available' : '(none)'}`,
     '',
     '---',
@@ -254,14 +267,18 @@ export function formatCurrentDocumentContext(context: CurrentDocumentContext): s
 }
 
 export function formatCurrentDocumentSummary(context: CurrentDocumentSummary): string {
+  const quotedSource = context.activeDocument.shellQuotedPath ?? '(unknown)';
   return [
     `title: ${context.activeDocument.title ?? '(untitled)'}`,
-    `source: ${context.activeDocument.path ?? '(unknown)'}`,
+    'readCurrentCommand: ft current --content-only',
+    'editCurrentCommand: ft current update --file <temp-file>',
+    `source: ${quotedSource}`,
+    `readSourceCommand: ${context.activeDocument.path ? `cat ${quotedSource}` : '(unknown)'}`,
     `kind: ${context.activeDocument.kind ?? '(unknown)'}`,
     `contentMode: ${context.activeDocument.contentMode ?? '(unknown)'}`,
     `updatedAt: ${context.updatedAt ?? '(unknown)'}`,
     `manifest: ${context.manifestPath}`,
-    `content: ${context.activeDocument.contentPath}`,
+    `content: ${context.activeDocument.shellQuotedContentPath}`,
     `lineMapping: ${context.activeDocument.lineMapping ? 'available' : '(none)'}`,
     '',
   ].join('\n');

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -388,6 +388,41 @@ test('ft current keeps document content opt-in for model-facing JSON', async () 
   }
 });
 
+test('ft current prints shell-safe commands for active documents with spaces', async () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ft-current-shell-cli-'));
+  const previousExitCode = process.exitCode;
+  try {
+    const sessionDir = path.join(tmpDir, 'session');
+    fs.mkdirSync(sessionDir, { recursive: true });
+    const contentPath = path.join(sessionDir, 'active.md');
+    const manifestPath = path.join(sessionDir, 'context.json');
+    fs.writeFileSync(contentPath, '- cameras installed at home\n');
+    fs.writeFileSync(manifestPath, JSON.stringify({
+      updatedAt: '2026-01-02T00:00:00.000Z',
+      activeDocument: {
+        title: 'Sunday Jun 14th',
+        path: '/library/Sunday Jun 14th.md',
+        kind: 'wiki',
+        contentMode: 'rendered',
+        contentPath,
+      },
+    }));
+
+    const output = await captureStdout(async () => {
+      await buildCli().parseAsync(['node', 'ft', 'current', '--manifest', manifestPath]);
+    });
+
+    assert.match(output, /readCurrentCommand: ft current --content-only/);
+    assert.match(output, /editCurrentCommand: ft current update --file <temp-file>/);
+    assert.match(output, /source: '\/library\/Sunday Jun 14th\.md'/);
+    assert.match(output, /readSourceCommand: cat '\/library\/Sunday Jun 14th\.md'/);
+    assert.doesNotMatch(output, /^source: \/library\/Sunday Jun 14th\.md$/m);
+  } finally {
+    process.exitCode = previousExitCode;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
 test('ft current update edits the active Library document without passing its path', async () => {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ft-current-update-'));
   const previousLibraryDir = process.env.FT_LIBRARY_DIR;

--- a/tests/current.test.ts
+++ b/tests/current.test.ts
@@ -199,6 +199,27 @@ test('readCurrentDocumentSummary exposes active document line mapping', () => {
   }
 });
 
+test('formatCurrentDocumentSummary prints shell-safe current document commands', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ft-current-shell-'));
+  try {
+    const sessionsDir = path.join(tmpDir, 'sessions');
+    const manifestPath = writeContext(sessionsDir, 'session', 'Sunday Jun 14th', 'body', '2026-01-01T00:00:00.000Z');
+
+    const summary = readCurrentDocumentSummary(manifestPath);
+    assert.equal(summary.activeDocument.path, '/library/Sunday Jun 14th.md');
+    assert.equal(summary.activeDocument.shellQuotedPath, "'/library/Sunday Jun 14th.md'");
+
+    const output = formatCurrentDocumentSummary(summary);
+    assert.match(output, /readCurrentCommand: ft current --content-only/);
+    assert.match(output, /editCurrentCommand: ft current update --file <temp-file>/);
+    assert.match(output, /source: '\/library\/Sunday Jun 14th\.md'/);
+    assert.match(output, /readSourceCommand: cat '\/library\/Sunday Jun 14th\.md'/);
+    assert.doesNotMatch(output, /^source: \/library\/Sunday Jun 14th\.md$/m);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
 test('readCurrentDocumentContext rejects content paths outside the session directory', () => {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ft-current-'));
   try {


### PR DESCRIPTION
## Summary
- add shell-quoted current document paths to ft current metadata
- print copy-safe read/update commands in ft current human output
- cover spaced active-document paths so agents do not split filenames in shells

## Verification
- npm run build
- npm test -- --test-name-pattern "current" tests/current.test.ts tests/cli.test.ts
- gemma exec --skip-git-repo-check --ephemeral --output-last-message /tmp/gemma-ft-current-smoke.txt "Use the Field Theory CLI to list the items in the currently active Field Theory document. Do not ask me for the path. Prefer ft current --content-only over cat when reading the active document."
- gemma exec --skip-git-repo-check --ephemeral --output-last-message /tmp/gemma-ft-edit-smoke-2.txt "Use the Field Theory CLI to update the active document represented by this manifest: /tmp/gemma-ft-edit.L6JXaP/session/context.json. The temporary Field Theory Library root is /tmp/gemma-ft-edit.L6JXaP/library. Use this already-prepared replacement file: /tmp/gemma-ft-edit.L6JXaP/updated.md. Run the update with FT_LIBRARY_DIR set to the temporary Library root, using ft current update with --manifest and --file. Then report the resulting path and whether the update succeeded."