### PR TITLE
Harden current document JSON workflow

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -39,7 +39,7 @@ import { skillWithFrontmatter, installSkill, uninstallSkill } from './skill.js';
 import { registerCompanionCommands } from './companion-cli.js';
 import { getPathReport } from './field-status.js';
 import { formatAgentContext, getAgentContext } from './agent-context.js';
-import { formatCurrentDocumentSummary, readCurrentDocumentContext, readCurrentDocumentSummary } from './current.js';
+import { formatCurrentDocumentJson, formatCurrentDocumentSummary, readCurrentDocumentContext, readCurrentDocumentSummary } from './current.js';
 import { updateLibraryDocument } from './library.js';
 import { formatWorkflowState, getWorkflowState } from './workflow-state.js';
 import {
@@ -1946,7 +1946,7 @@ export function buildCli() {
         ? readCurrentDocumentContext(options.manifest)
         : readCurrentDocumentSummary(options.manifest);
       if (options.json) {
-        printJson(context);
+        printJson(formatCurrentDocumentJson(context));
         return;
       }
       process.stdout.write(formatCurrentDocumentSummary(context));
@@ -3305,8 +3305,9 @@ export function buildCli() {
   skill
     .command('install')
     .description('Install skill for detected agents (Claude Code, Codex)')
-    .action(safe(async () => {
-      const results = await installSkill();
+    .option('--force', 'Overwrite existing skill files without prompting')
+    .action(safe(async (options) => {
+      const results = await installSkill({ force: Boolean(options.force) });
       if (results.length === 0) {
         console.log('  No agents detected. Use `ft skill show` to copy manually.');
         return;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import { Command, InvalidArgumentError, Option } from 'commander';
+import { spawn } from 'node:child_process';
 import { syncTwitterBookmarks } from './bookmarks.js';
 import { getBookmarkStatusView, formatBookmarkStatus } from './bookmarks-service.js';
 import { runTwitterOAuthFlow } from './xauth.js';
@@ -312,6 +313,30 @@ function warnIfEmpty(totalBookmarks: number): void {
 
 function printJson(value: unknown): void {
   console.log(JSON.stringify(value, null, 2));
+}
+
+async function pipeContentThroughCommand(command: string, input: string): Promise<string> {
+  if (!command.trim()) throw new Error('--pipe requires a command.');
+
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, { shell: true, stdio: ['pipe', 'pipe', 'pipe'] });
+    const stdout: Buffer[] = [];
+    const stderr: Buffer[] = [];
+
+    child.stdout.on('data', (chunk) => stdout.push(Buffer.from(chunk)));
+    child.stderr.on('data', (chunk) => stderr.push(Buffer.from(chunk)));
+    child.on('error', reject);
+    child.on('close', (code) => {
+      if (code === 0) {
+        resolve(Buffer.concat(stdout).toString('utf-8'));
+        return;
+      }
+      const message = Buffer.concat(stderr).toString('utf-8').trim();
+      reject(new Error(message || `--pipe command exited with status ${code}`));
+    });
+
+    child.stdin.end(input);
+  });
 }
 
 function formatMarkdownLink(label: string, href: string): string {
@@ -1958,21 +1983,29 @@ export function buildCli() {
     .option('--manifest <path>', 'Read a specific context manifest')
     .option('--stdin', 'Read markdown content from stdin')
     .option('--file <path>', 'Read markdown content from a file')
+    .option('--pipe <command>', 'Transform the active document by piping it through a shell command')
     .option('--expected-sha256 <hash>', 'Only update if the current source file hash matches')
     .option('--force', 'Overwrite without checking an expected hash')
     .option('--json', 'JSON output')
     .action(safe(async (options, command) => {
-      if (!options.stdin && !options.file) throw new Error('Pass --stdin or --file for update content.');
+      const inputCount = [options.stdin, options.file, options.pipe].filter(Boolean).length;
+      if (inputCount !== 1) throw new Error('Pass exactly one of --stdin, --file, or --pipe for update content.');
       const parentOptions = command.parent?.opts() ?? {};
       const manifest = options.manifest || parentOptions.manifest;
       const context = readCurrentDocumentContext(manifest);
       const targetPath = context.activeDocument.path;
       if (!targetPath) throw new Error('Active Field Theory context has no source path to update.');
+      const pipedContent = options.pipe
+        ? await pipeContentThroughCommand(String(options.pipe), context.content)
+        : undefined;
       const doc = await updateLibraryDocument(targetPath, {
         stdin: Boolean(options.stdin),
         file: options.file ? String(options.file) : undefined,
+        content: pipedContent,
         expectedSha256: options.expectedSha256 ? String(options.expectedSha256) : undefined,
         force: Boolean(options.force || !options.expectedSha256),
+        rejectEmptyContent: true,
+        rejectUnchangedContent: true,
       });
       if (options.json || parentOptions.json) {
         printJson(doc);

--- a/src/current.ts
+++ b/src/current.ts
@@ -14,9 +14,18 @@ export interface CurrentDocumentRelatedPage {
   contentPath: string | null;
 }
 
+export interface CurrentDocumentCommands {
+  readContent: string;
+  updateFromFile: string;
+  updateFromStdin: string;
+  readSource: string | null;
+  note: string;
+}
+
 export interface CurrentDocumentSummary {
   manifestPath: string;
   updatedAt: string | null;
+  commands: CurrentDocumentCommands;
   activeDocument: {
     title: string | null;
     path: string | null;
@@ -60,6 +69,16 @@ function stringField(value: unknown): string | null {
 
 function quoteForPosixShell(value: string): string {
   return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+function currentDocumentCommands(quotedSourcePath: string | null): CurrentDocumentCommands {
+  return {
+    readContent: 'ft current --content-only',
+    updateFromFile: 'ft current update --file <temp-file>',
+    updateFromStdin: 'ft current update --stdin',
+    readSource: quotedSourcePath ? `cat ${quotedSourcePath}` : null,
+    note: 'To edit the active document, write the complete updated markdown to a temp file, then run updateFromFile. Avoid shelling against activeDocument.path because it may contain spaces.',
+  };
 }
 
 function statMtimeMs(filePath: string): number {
@@ -213,14 +232,16 @@ export function readCurrentDocumentSummary(manifestPath = findCurrentContextMani
   const sessionDir = path.dirname(manifestPath);
   assertInsideDirectory(contentPath, sessionDir);
   const sourcePath = stringField(documentRecord.path);
+  const shellQuotedPath = stringField(documentRecord.shellQuotedPath) ?? (sourcePath ? quoteForPosixShell(sourcePath) : null);
 
   return {
     manifestPath,
     updatedAt: stringField(manifest.updatedAt),
+    commands: currentDocumentCommands(shellQuotedPath),
     activeDocument: {
       title: stringField(documentRecord.title),
       path: sourcePath,
-      shellQuotedPath: stringField(documentRecord.shellQuotedPath) ?? (sourcePath ? quoteForPosixShell(sourcePath) : null),
+      shellQuotedPath,
       kind: stringField(documentRecord.kind),
       contentMode: stringField(documentRecord.contentMode),
       contentPath,
@@ -247,8 +268,8 @@ export function formatCurrentDocumentContext(context: CurrentDocumentContext): s
     '# Field Theory Current Document',
     '',
     `title: ${context.activeDocument.title ?? '(untitled)'}`,
-    'readCurrentCommand: ft current --content-only',
-    'editCurrentCommand: ft current update --file <temp-file>',
+    `readCurrentCommand: ${context.commands.readContent}`,
+    `editCurrentCommand: ${context.commands.updateFromFile}`,
     `source: ${quotedSource}`,
     `readSourceCommand: ${context.activeDocument.path ? `cat ${quotedSource}` : '(unknown)'}`,
     `kind: ${context.activeDocument.kind ?? '(unknown)'}`,
@@ -266,12 +287,22 @@ export function formatCurrentDocumentContext(context: CurrentDocumentContext): s
   return `${lines.join('\n')}${context.content.endsWith('\n') ? '' : '\n'}`;
 }
 
+export function formatCurrentDocumentJson<T extends CurrentDocumentSummary>(context: T): T {
+  return {
+    ...context,
+    activeDocument: {
+      ...context.activeDocument,
+      path: context.activeDocument.shellQuotedPath ?? context.activeDocument.path,
+    },
+  };
+}
+
 export function formatCurrentDocumentSummary(context: CurrentDocumentSummary): string {
   const quotedSource = context.activeDocument.shellQuotedPath ?? '(unknown)';
   return [
     `title: ${context.activeDocument.title ?? '(untitled)'}`,
-    'readCurrentCommand: ft current --content-only',
-    'editCurrentCommand: ft current update --file <temp-file>',
+    `readCurrentCommand: ${context.commands.readContent}`,
+    `editCurrentCommand: ${context.commands.updateFromFile}`,
     `source: ${quotedSource}`,
     `readSourceCommand: ${context.activeDocument.path ? `cat ${quotedSource}` : '(unknown)'}`,
     `kind: ${context.activeDocument.kind ?? '(unknown)'}`,

--- a/src/current.ts
+++ b/src/current.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { legacyCodexContextSessionsDir, runtimeContextSessionStatePath, runtimeContextSessionsDir } from './paths.js';
+import { isPathInside } from './document-ops.js';
+import { canonicalLibraryDir, legacyCodexContextSessionsDir, runtimeContextSessionStatePath, runtimeContextSessionsDir } from './paths.js';
 
 export interface CurrentDocumentSelection {
   textPath: string;
@@ -17,8 +18,8 @@ export interface CurrentDocumentRelatedPage {
 export interface CurrentDocumentCommands {
   readContent: string;
   updateFromFile: string;
-  updateFromStdin: string;
-  readSource: string | null;
+  transformWithPipe: string;
+  plainBulletsToUncheckedTodos: string;
   note: string;
 }
 
@@ -30,6 +31,7 @@ export interface CurrentDocumentSummary {
     title: string | null;
     path: string | null;
     shellQuotedPath: string | null;
+    shellEscapedPath: string | null;
     kind: string | null;
     contentMode: string | null;
     contentPath: string;
@@ -71,13 +73,17 @@ function quoteForPosixShell(value: string): string {
   return `'${value.replace(/'/g, `'\\''`)}'`;
 }
 
-function currentDocumentCommands(quotedSourcePath: string | null): CurrentDocumentCommands {
+function escapeForPosixShellToken(value: string): string {
+  return value.replace(/([\\\s"'`$!&;()<>|*?\[\]{}])/g, '\\$1');
+}
+
+function currentDocumentCommands(): CurrentDocumentCommands {
   return {
     readContent: 'ft current --content-only',
     updateFromFile: 'ft current update --file <temp-file>',
-    updateFromStdin: 'ft current update --stdin',
-    readSource: quotedSourcePath ? `cat ${quotedSourcePath}` : null,
-    note: 'To edit the active document, write the complete updated markdown to a temp file, then run updateFromFile. Avoid shelling against activeDocument.path because it may contain spaces.',
+    transformWithPipe: 'ft current update --pipe <command>',
+    plainBulletsToUncheckedTodos: 'ft current update --pipe "sed \'s/^- /- [ ] /\'"',
+    note: 'For the active document body, run readContent exactly. Do not run cat/sed/open on activeDocument.path; it is display metadata and may contain spaces. For mechanical edits, prefer transformWithPipe or a specific command example; otherwise write complete markdown to a temp file, then run updateFromFile.',
   };
 }
 
@@ -233,15 +239,17 @@ export function readCurrentDocumentSummary(manifestPath = findCurrentContextMani
   assertInsideDirectory(contentPath, sessionDir);
   const sourcePath = stringField(documentRecord.path);
   const shellQuotedPath = stringField(documentRecord.shellQuotedPath) ?? (sourcePath ? quoteForPosixShell(sourcePath) : null);
+  const shellEscapedPath = sourcePath ? escapeForPosixShellToken(sourcePath) : null;
 
   return {
     manifestPath,
     updatedAt: stringField(manifest.updatedAt),
-    commands: currentDocumentCommands(shellQuotedPath),
+    commands: currentDocumentCommands(),
     activeDocument: {
       title: stringField(documentRecord.title),
       path: sourcePath,
       shellQuotedPath,
+      shellEscapedPath,
       kind: stringField(documentRecord.kind),
       contentMode: stringField(documentRecord.contentMode),
       contentPath,
@@ -256,9 +264,14 @@ export function readCurrentDocumentSummary(manifestPath = findCurrentContextMani
 
 export function readCurrentDocumentContext(manifestPath = findCurrentContextManifest()): CurrentDocumentContext {
   const summary = readCurrentDocumentSummary(manifestPath);
+  const sourcePath = summary.activeDocument.path;
+  const contentPath = sourcePath && isPathInside(canonicalLibraryDir(), sourcePath) && fs.existsSync(sourcePath)
+    ? sourcePath
+    : summary.activeDocument.contentPath;
+
   return {
     ...summary,
-    content: fs.readFileSync(summary.activeDocument.contentPath, 'utf-8'),
+    content: fs.readFileSync(contentPath, 'utf-8'),
   };
 }
 
@@ -288,11 +301,15 @@ export function formatCurrentDocumentContext(context: CurrentDocumentContext): s
 }
 
 export function formatCurrentDocumentJson<T extends CurrentDocumentSummary>(context: T): T {
+  const shellEscapedPath = context.activeDocument.shellEscapedPath ?? context.activeDocument.shellQuotedPath ?? context.activeDocument.path;
   return {
     ...context,
     activeDocument: {
       ...context.activeDocument,
-      path: context.activeDocument.shellQuotedPath ?? context.activeDocument.path,
+      path: shellEscapedPath,
+      lineMapping: context.activeDocument.lineMapping
+        ? { available: true, note: 'Line mapping text is omitted from model-facing JSON. Run commands.readContent for current source text.' }
+        : null,
     },
   };
 }

--- a/src/document-ops.ts
+++ b/src/document-ops.ts
@@ -13,6 +13,7 @@ export interface DocumentVersion {
 export interface DocumentUpdateOptions {
   expectedSha256?: string;
   force?: boolean;
+  rejectUnchanged?: boolean;
 }
 
 export interface DocumentUpdateResult {
@@ -117,9 +118,13 @@ export async function updateMarkdownFile(filePath: string, content: string, opti
   if (!await pathExists(filePath)) {
     throw new Error(`File not found: ${filePath}`);
   }
+  const currentContent = fs.readFileSync(filePath, 'utf-8');
   const current = readDocumentVersion(filePath);
   if (options.expectedSha256 && current.sha256 !== options.expectedSha256) {
     throw new Error(`File changed on disk. Expected ${options.expectedSha256}, found ${current.sha256}.`);
+  }
+  if (options.rejectUnchanged && content === currentContent) {
+    throw new Error('Refusing no-op active document update because the content is unchanged.');
   }
   if (!options.force && !options.expectedSha256) {
     throw new Error('Refusing to overwrite without --expected-sha256 or --force.');

--- a/src/library.ts
+++ b/src/library.ts
@@ -42,6 +42,8 @@ export interface LibraryWriteInput {
 export interface LibraryUpdateInput extends LibraryWriteInput {
   expectedSha256?: string;
   force?: boolean;
+  rejectEmptyContent?: boolean;
+  rejectUnchangedContent?: boolean;
 }
 
 export interface LibraryListOptions {
@@ -196,9 +198,13 @@ export async function createLibraryDocument(target: string, input: LibraryWriteI
 export async function updateLibraryDocument(target: string, input: LibraryUpdateInput): Promise<LibraryDocument> {
   const filePath = resolveLibraryPath(target);
   const content = await readContentInput({ stdin: input.stdin, file: input.file, fallback: input.content });
+  if (input.rejectEmptyContent && content.length === 0) {
+    throw new Error('Refusing to replace the active Field Theory document with empty content.');
+  }
   await updateMarkdownFile(filePath, content, {
     expectedSha256: input.expectedSha256,
     force: input.force,
+    rejectUnchanged: input.rejectUnchangedContent,
   });
   return showLibraryDocument(filePath);
 }

--- a/src/skill.ts
+++ b/src/skill.ts
@@ -37,13 +37,15 @@ Field Theory has three main local surfaces:
 1. Check paths and status when setup matters: \`ft paths --json\`, \`ft status --json\`
 2. When the user asks what Field Theory document they are looking at, run \`ft current --json\`; use the returned \`commands.readContent\` when the document body is needed
 3. When the user asks to edit the active Field Theory document, read it with \`ft current --content-only\`, write the complete updated markdown to a temp file, then run \`ft current update --file <temp-file>\`
-4. Check repo workflow state when branch/worktree/PR shape matters: \`ft state --json\`
-5. When the user says "that file" or "the recent file", inspect current repo recency with \`ft recent --json\`
-6. Search durable notes first when prior project knowledge matters: \`ft library search <query> --json\`
-7. Search bookmarks when reading history or saved X/Twitter posts matter: \`ft search <query> --json\`
-8. Inspect exact files or bookmarks with \`ft library show <path> --json\`, \`ft show <id> --json\`, or \`ft commands show <name> --json\`
-9. Create or update durable Library notes and portable commands only when the user asks for a saved artifact
-10. Open useful Library pages in the Mac app with \`ft library open <path>\`
+4. For mechanical active-document edits, use \`ft current update --pipe <command>\`; this pipes the active source into the command and writes stdout back without shelling against the file path
+   - Example: convert plain bullets to unchecked todos with \`ft current update --pipe "sed 's/^- /- [ ] /'"\`
+5. Check repo workflow state when branch/worktree/PR shape matters: \`ft state --json\`
+6. When the user says "that file" or "the recent file", inspect current repo recency with \`ft recent --json\`
+7. Search durable notes first when prior project knowledge matters: \`ft library search <query> --json\`
+8. Search bookmarks when reading history or saved X/Twitter posts matter: \`ft search <query> --json\`
+9. Inspect exact files or bookmarks with \`ft library show <path> --json\`, \`ft show <id> --json\`, or \`ft commands show <name> --json\`
+10. Create or update durable Library notes and portable commands only when the user asks for a saved artifact
+11. Open useful Library pages in the Mac app with \`ft library open <path>\`
 
 ## Possible Roadmap Workflow
 
@@ -96,6 +98,8 @@ ft status --json               # Bookmark/classification status plus paths
 ft current --json              # Active Field Theory document metadata without the full body
 ft current --content-only      # Active document body when the user/model actually needs it
 ft current update --file <tmp> # Replace the active source document with complete updated markdown
+ft current update --pipe <cmd> # Transform the active source by piping it through a command
+ft current update --pipe "sed 's/^- /- [ ] /'" # Convert plain bullets to unchecked todos
 ft state --json                # Repo workflow state: root, workers, PRs, cleanup, next step
 ft recent --json               # Current repo last-modified file and recent files for agent references
 
@@ -133,6 +137,7 @@ Combine filters: \`ft list --category tool --domain ai --limit 10\`
 ## Guidelines
 
 - Prefer JSON output when you need to inspect or cite exact fields
+- For active-document reads and edits, never run \`cat\`, \`sed\`, or another shell command against \`activeDocument.path\`; use \`ft current --content-only\`, \`ft current update --pipe <command>\`, or \`ft current update --file <temp-file>\`
 - Start with Library pages for durable project knowledge, then search bookmarks for source material
 - Don't dump raw output; summarize and connect findings to the user's current work
 - Cross-reference multiple queries to build a complete picture
@@ -140,7 +145,6 @@ Combine filters: \`ft list --category tool --domain ai --limit 10\`
 - Ground roadmap work in actual bookmark-backed seeds
 - Lead roadmap reports with the plotted grid and concrete next actions, not just prose
 - For updates, use \`--expected-sha256\` from a prior \`show --json\` result or pass \`--force\` only when explicitly appropriate
-- For active-document edits, do not use raw \`activeDocument.path\` in shell commands; it may contain spaces. Use \`ft current --content-only\` and \`ft current update --file <temp-file>\`
 - In local app development, set \`FT_APP_DEV_DIR\` before \`ft library open\` so the CLI targets the Field Theory dev checkout instead of a generic Electron URL handler
 - Deletes move local files to Trash; the Mac app owns Library sync and remote tombstones
 `;

--- a/src/skill.ts
+++ b/src/skill.ts
@@ -138,6 +138,7 @@ Combine filters: \`ft list --category tool --domain ai --limit 10\`
 
 - Prefer JSON output when you need to inspect or cite exact fields
 - For active-document reads and edits, never run \`cat\`, \`sed\`, or another shell command against \`activeDocument.path\`; use \`ft current --content-only\`, \`ft current update --pipe <command>\`, or \`ft current update --file <temp-file>\`
+- Field Theory command files are markdown instructions, not shell scripts; when an automation references a \`.md\` command file, read it with \`ft commands show <name>\` or a normal file read instead of executing the path
 - Start with Library pages for durable project knowledge, then search bookmarks for source material
 - Don't dump raw output; summarize and connect findings to the user's current work
 - Cross-reference multiple queries to build a complete picture

--- a/src/skill.ts
+++ b/src/skill.ts
@@ -35,14 +35,15 @@ Field Theory has three main local surfaces:
 ## Search Workflow
 
 1. Check paths and status when setup matters: \`ft paths --json\`, \`ft status --json\`
-2. When the user asks what Field Theory document they are looking at, run \`ft current --json\`; only use \`ft current --content-only\` when the document body is needed
-3. Check repo workflow state when branch/worktree/PR shape matters: \`ft state --json\`
-4. When the user says "that file" or "the recent file", inspect current repo recency with \`ft recent --json\`
-5. Search durable notes first when prior project knowledge matters: \`ft library search <query> --json\`
-6. Search bookmarks when reading history or saved X/Twitter posts matter: \`ft search <query> --json\`
-7. Inspect exact files or bookmarks with \`ft library show <path> --json\`, \`ft show <id> --json\`, or \`ft commands show <name> --json\`
-8. Create or update durable Library notes and portable commands only when the user asks for a saved artifact
-9. Open useful Library pages in the Mac app with \`ft library open <path>\`
+2. When the user asks what Field Theory document they are looking at, run \`ft current --json\`; use the returned \`commands.readContent\` when the document body is needed
+3. When the user asks to edit the active Field Theory document, read it with \`ft current --content-only\`, write the complete updated markdown to a temp file, then run \`ft current update --file <temp-file>\`
+4. Check repo workflow state when branch/worktree/PR shape matters: \`ft state --json\`
+5. When the user says "that file" or "the recent file", inspect current repo recency with \`ft recent --json\`
+6. Search durable notes first when prior project knowledge matters: \`ft library search <query> --json\`
+7. Search bookmarks when reading history or saved X/Twitter posts matter: \`ft search <query> --json\`
+8. Inspect exact files or bookmarks with \`ft library show <path> --json\`, \`ft show <id> --json\`, or \`ft commands show <name> --json\`
+9. Create or update durable Library notes and portable commands only when the user asks for a saved artifact
+10. Open useful Library pages in the Mac app with \`ft library open <path>\`
 
 ## Possible Roadmap Workflow
 
@@ -94,6 +95,7 @@ ft paths --json                # Canonical bookmarks, library, commands paths
 ft status --json               # Bookmark/classification status plus paths
 ft current --json              # Active Field Theory document metadata without the full body
 ft current --content-only      # Active document body when the user/model actually needs it
+ft current update --file <tmp> # Replace the active source document with complete updated markdown
 ft state --json                # Repo workflow state: root, workers, PRs, cleanup, next step
 ft recent --json               # Current repo last-modified file and recent files for agent references
 
@@ -138,6 +140,7 @@ Combine filters: \`ft list --category tool --domain ai --limit 10\`
 - Ground roadmap work in actual bookmark-backed seeds
 - Lead roadmap reports with the plotted grid and concrete next actions, not just prose
 - For updates, use \`--expected-sha256\` from a prior \`show --json\` result or pass \`--force\` only when explicitly appropriate
+- For active-document edits, do not use raw \`activeDocument.path\` in shell commands; it may contain spaces. Use \`ft current --content-only\` and \`ft current update --file <temp-file>\`
 - In local app development, set \`FT_APP_DEV_DIR\` before \`ft library open\` so the CLI targets the Field Theory dev checkout instead of a generic Electron URL handler
 - Deletes move local files to Trash; the Mac app owns Library sync and remote tombstones
 `;
@@ -184,7 +187,7 @@ export interface SkillResult {
   action: 'installed' | 'updated' | 'up-to-date' | 'removed';
 }
 
-export async function installSkill(): Promise<SkillResult[]> {
+export async function installSkill(options: { force?: boolean } = {}): Promise<SkillResult[]> {
   const detected = detectAgents();
   const targets = detected.filter((a) => a.detected);
 
@@ -206,7 +209,7 @@ export async function installSkill(): Promise<SkillResult[]> {
     const content = agent.name === 'Codex' ? skillBody() : skillWithFrontmatter();
     const exists = fs.existsSync(agent.installPath);
 
-    if (exists) {
+    if (exists && !options.force) {
       const existing = fs.readFileSync(agent.installPath, 'utf-8');
       if (existing === content) {
         results.push({ agent: agent.name, path: agent.installPath, action: 'up-to-date' });

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -372,6 +372,8 @@ test('ft current keeps document content opt-in for model-facing JSON', async () 
     const summary = JSON.parse(summaryOutput);
     assert.equal(summary.activeDocument.title, 'Current Body');
     assert.equal(summary.content, undefined);
+    assert.equal(summary.commands.readContent, 'ft current --content-only');
+    assert.equal(summary.commands.updateFromFile, 'ft current update --file <temp-file>');
 
     const contentOutput = await captureStdout(async () => {
       await buildCli().parseAsync(['node', 'ft', 'current', '--manifest', manifestPath, '--content-only']);
@@ -417,6 +419,17 @@ test('ft current prints shell-safe commands for active documents with spaces', a
     assert.match(output, /source: '\/library\/Sunday Jun 14th\.md'/);
     assert.match(output, /readSourceCommand: cat '\/library\/Sunday Jun 14th\.md'/);
     assert.doesNotMatch(output, /^source: \/library\/Sunday Jun 14th\.md$/m);
+
+    const jsonOutput = await captureStdout(async () => {
+      await buildCli().parseAsync(['node', 'ft', 'current', '--manifest', manifestPath, '--json']);
+    });
+    assert.ok(jsonOutput.indexOf('"commands"') < jsonOutput.indexOf('"activeDocument"'));
+    const parsed = JSON.parse(jsonOutput);
+    assert.equal(parsed.commands.readContent, 'ft current --content-only');
+    assert.equal(parsed.commands.updateFromFile, 'ft current update --file <temp-file>');
+    assert.equal(parsed.commands.readSource, "cat '/library/Sunday Jun 14th.md'");
+    assert.match(parsed.commands.note, /Avoid shelling against activeDocument\.path/);
+    assert.equal(parsed.activeDocument.path, "'/library/Sunday Jun 14th.md'");
   } finally {
     process.exitCode = previousExitCode;
     fs.rmSync(tmpDir, { recursive: true, force: true });

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -374,6 +374,8 @@ test('ft current keeps document content opt-in for model-facing JSON', async () 
     assert.equal(summary.content, undefined);
     assert.equal(summary.commands.readContent, 'ft current --content-only');
     assert.equal(summary.commands.updateFromFile, 'ft current update --file <temp-file>');
+    assert.equal(summary.commands.transformWithPipe, 'ft current update --pipe <command>');
+    assert.equal(summary.commands.plainBulletsToUncheckedTodos, 'ft current update --pipe "sed \'s/^- /- [ ] /\'"');
 
     const contentOutput = await captureStdout(async () => {
       await buildCli().parseAsync(['node', 'ft', 'current', '--manifest', manifestPath, '--content-only']);
@@ -385,6 +387,44 @@ test('ft current keeps document content opt-in for model-facing JSON', async () 
     });
     assert.match(JSON.parse(fullOutput).content, /private working text/);
   } finally {
+    process.exitCode = previousExitCode;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test('ft current --content-only reads the active source file when available', async () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ft-current-source-cli-'));
+  const previousLibraryDir = process.env.FT_LIBRARY_DIR;
+  const previousExitCode = process.exitCode;
+  try {
+    const libraryDir = path.join(tmpDir, 'library');
+    const sourcePath = path.join(libraryDir, 'scratchpad', 'Sunday Jun 14th.md');
+    const sessionDir = path.join(tmpDir, 'session');
+    const contentPath = path.join(sessionDir, 'active.md');
+    const manifestPath = path.join(sessionDir, 'context.json');
+    process.env.FT_LIBRARY_DIR = libraryDir;
+    fs.mkdirSync(path.dirname(sourcePath), { recursive: true });
+    fs.mkdirSync(sessionDir, { recursive: true });
+    fs.writeFileSync(sourcePath, '- real source\n');
+    fs.writeFileSync(contentPath, '- stale context\n');
+    fs.writeFileSync(manifestPath, JSON.stringify({
+      activeDocument: {
+        title: 'Sunday Jun 14th',
+        path: sourcePath,
+        kind: 'wiki',
+        contentMode: 'rendered',
+        contentPath,
+      },
+    }));
+
+    const output = await captureStdout(async () => {
+      await buildCli().parseAsync(['node', 'ft', 'current', '--manifest', manifestPath, '--content-only']);
+    });
+
+    assert.equal(output, '- real source\n');
+  } finally {
+    if (previousLibraryDir === undefined) delete process.env.FT_LIBRARY_DIR;
+    else process.env.FT_LIBRARY_DIR = previousLibraryDir;
     process.exitCode = previousExitCode;
     fs.rmSync(tmpDir, { recursive: true, force: true });
   }
@@ -427,9 +467,12 @@ test('ft current prints shell-safe commands for active documents with spaces', a
     const parsed = JSON.parse(jsonOutput);
     assert.equal(parsed.commands.readContent, 'ft current --content-only');
     assert.equal(parsed.commands.updateFromFile, 'ft current update --file <temp-file>');
-    assert.equal(parsed.commands.readSource, "cat '/library/Sunday Jun 14th.md'");
-    assert.match(parsed.commands.note, /Avoid shelling against activeDocument\.path/);
-    assert.equal(parsed.activeDocument.path, "'/library/Sunday Jun 14th.md'");
+    assert.equal(parsed.commands.transformWithPipe, 'ft current update --pipe <command>');
+    assert.equal(parsed.commands.plainBulletsToUncheckedTodos, 'ft current update --pipe "sed \'s/^- /- [ ] /\'"');
+    assert.equal('readSource' in parsed.commands, false);
+    assert.match(parsed.commands.note, /Do not run cat\/sed\/open on activeDocument\.path/);
+    assert.equal(parsed.activeDocument.path, '/library/Sunday\\ Jun\\ 14th.md');
+    assert.equal(parsed.activeDocument.shellEscapedPath, '/library/Sunday\\ Jun\\ 14th.md');
   } finally {
     process.exitCode = previousExitCode;
     fs.rmSync(tmpDir, { recursive: true, force: true });
@@ -474,6 +517,137 @@ test('ft current update edits the active Library document without passing its pa
     const jsonStart = output.indexOf('{\n  "path"');
     assert.notEqual(jsonStart, -1);
     assert.equal(JSON.parse(output.slice(jsonStart)).path, sourcePath);
+  } finally {
+    if (previousLibraryDir === undefined) delete process.env.FT_LIBRARY_DIR;
+    else process.env.FT_LIBRARY_DIR = previousLibraryDir;
+    process.exitCode = previousExitCode;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test('ft current update can transform the active document without shelling against its path', async () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ft-current-update-pipe-'));
+  const previousLibraryDir = process.env.FT_LIBRARY_DIR;
+  const previousExitCode = process.exitCode;
+  try {
+    const libraryDir = path.join(tmpDir, 'library');
+    const sourcePath = path.join(libraryDir, 'scratchpad', 'Sunday Jun 14th.md');
+    const sessionDir = path.join(tmpDir, 'session');
+    const contentPath = path.join(sessionDir, 'active.md');
+    const manifestPath = path.join(sessionDir, 'context.json');
+    process.env.FT_LIBRARY_DIR = libraryDir;
+    fs.mkdirSync(path.dirname(sourcePath), { recursive: true });
+    fs.mkdirSync(sessionDir, { recursive: true });
+    fs.writeFileSync(sourcePath, '- cameras installed at home\n- figure out car seats\n');
+    fs.writeFileSync(contentPath, '- stale context\n');
+    fs.writeFileSync(manifestPath, JSON.stringify({
+      activeDocument: {
+        title: 'Sunday Jun 14th',
+        path: sourcePath,
+        kind: 'wiki',
+        contentMode: 'rendered',
+        contentPath,
+      },
+    }));
+
+    await captureStdout(async () => {
+      await buildCli().parseAsync([
+        'node',
+        'ft',
+        'current',
+        'update',
+        '--manifest',
+        manifestPath,
+        '--pipe',
+        "sed 's/^- /- [ ] /'",
+      ]);
+    });
+
+    assert.equal(fs.readFileSync(sourcePath, 'utf-8'), '- [ ] cameras installed at home\n- [ ] figure out car seats\n');
+  } finally {
+    if (previousLibraryDir === undefined) delete process.env.FT_LIBRARY_DIR;
+    else process.env.FT_LIBRARY_DIR = previousLibraryDir;
+    process.exitCode = previousExitCode;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test('ft current update refuses to blank the active document', async () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ft-current-update-empty-'));
+  const previousLibraryDir = process.env.FT_LIBRARY_DIR;
+  const previousExitCode = process.exitCode;
+  try {
+    const libraryDir = path.join(tmpDir, 'library');
+    const sourcePath = path.join(libraryDir, 'scratchpad', 'Sunday Jun 14th.md');
+    const sessionDir = path.join(tmpDir, 'session');
+    const contentPath = path.join(sessionDir, 'active.md');
+    const manifestPath = path.join(sessionDir, 'context.json');
+    const emptyPath = path.join(tmpDir, 'empty.md');
+    process.env.FT_LIBRARY_DIR = libraryDir;
+    fs.mkdirSync(path.dirname(sourcePath), { recursive: true });
+    fs.mkdirSync(sessionDir, { recursive: true });
+    fs.writeFileSync(sourcePath, 'current source\n');
+    fs.writeFileSync(contentPath, 'current source\n');
+    fs.writeFileSync(emptyPath, '');
+    fs.writeFileSync(manifestPath, JSON.stringify({
+      activeDocument: {
+        title: 'Sunday Jun 14th',
+        path: sourcePath,
+        kind: 'wiki',
+        contentMode: 'rendered',
+        contentPath,
+      },
+    }));
+
+    const stderr = await captureStderr(async () => {
+      await buildCli().parseAsync(['node', 'ft', 'current', 'update', '--manifest', manifestPath, '--file', emptyPath]);
+    });
+
+    assert.match(stderr, /Refusing to replace the active Field Theory document with empty content/);
+    assert.equal(process.exitCode, 1);
+    assert.equal(fs.readFileSync(sourcePath, 'utf-8'), 'current source\n');
+  } finally {
+    if (previousLibraryDir === undefined) delete process.env.FT_LIBRARY_DIR;
+    else process.env.FT_LIBRARY_DIR = previousLibraryDir;
+    process.exitCode = previousExitCode;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test('ft current update refuses no-op active document updates', async () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ft-current-update-noop-'));
+  const previousLibraryDir = process.env.FT_LIBRARY_DIR;
+  const previousExitCode = process.exitCode;
+  try {
+    const libraryDir = path.join(tmpDir, 'library');
+    const sourcePath = path.join(libraryDir, 'scratchpad', 'Sunday Jun 14th.md');
+    const sessionDir = path.join(tmpDir, 'session');
+    const contentPath = path.join(sessionDir, 'active.md');
+    const manifestPath = path.join(sessionDir, 'context.json');
+    const updatePath = path.join(tmpDir, 'same.md');
+    process.env.FT_LIBRARY_DIR = libraryDir;
+    fs.mkdirSync(path.dirname(sourcePath), { recursive: true });
+    fs.mkdirSync(sessionDir, { recursive: true });
+    fs.writeFileSync(sourcePath, 'current source\n');
+    fs.writeFileSync(contentPath, 'current source\n');
+    fs.writeFileSync(updatePath, 'current source\n');
+    fs.writeFileSync(manifestPath, JSON.stringify({
+      activeDocument: {
+        title: 'Sunday Jun 14th',
+        path: sourcePath,
+        kind: 'wiki',
+        contentMode: 'rendered',
+        contentPath,
+      },
+    }));
+
+    const stderr = await captureStderr(async () => {
+      await buildCli().parseAsync(['node', 'ft', 'current', 'update', '--manifest', manifestPath, '--file', updatePath]);
+    });
+
+    assert.match(stderr, /Refusing no-op active document update/);
+    assert.equal(process.exitCode, 1);
+    assert.equal(fs.readFileSync(sourcePath, 'utf-8'), 'current source\n');
   } finally {
     if (previousLibraryDir === undefined) delete process.env.FT_LIBRARY_DIR;
     else process.env.FT_LIBRARY_DIR = previousLibraryDir;

--- a/tests/current.test.ts
+++ b/tests/current.test.ts
@@ -7,6 +7,7 @@ import test from 'node:test';
 import {
   findCurrentContextManifest,
   formatCurrentDocumentContext,
+  formatCurrentDocumentJson,
   formatCurrentDocumentSummary,
   readCurrentDocumentContext,
   readCurrentDocumentSummary,
@@ -208,6 +209,15 @@ test('formatCurrentDocumentSummary prints shell-safe current document commands',
     const summary = readCurrentDocumentSummary(manifestPath);
     assert.equal(summary.activeDocument.path, '/library/Sunday Jun 14th.md');
     assert.equal(summary.activeDocument.shellQuotedPath, "'/library/Sunday Jun 14th.md'");
+    assert.equal(summary.commands.readContent, 'ft current --content-only');
+    assert.equal(summary.commands.updateFromFile, 'ft current update --file <temp-file>');
+    assert.equal(summary.commands.updateFromStdin, 'ft current update --stdin');
+    assert.equal(summary.commands.readSource, "cat '/library/Sunday Jun 14th.md'");
+    assert.match(summary.commands.note, /temp file/);
+
+    const jsonSummary = formatCurrentDocumentJson(summary);
+    assert.equal(jsonSummary.activeDocument.path, "'/library/Sunday Jun 14th.md'");
+    assert.equal(summary.activeDocument.path, '/library/Sunday Jun 14th.md');
 
     const output = formatCurrentDocumentSummary(summary);
     assert.match(output, /readCurrentCommand: ft current --content-only/);

--- a/tests/current.test.ts
+++ b/tests/current.test.ts
@@ -63,6 +63,39 @@ test('readCurrentDocumentContext reads newest Field Theory context manifest', ()
   }
 });
 
+test('readCurrentDocumentContext prefers the active source file over stale rendered context', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ft-current-source-'));
+  const previousLibraryDir = process.env.FT_LIBRARY_DIR;
+  try {
+    const libraryDir = path.join(tmpDir, 'library');
+    const sourcePath = path.join(libraryDir, 'scratchpad', 'Sunday Jun 14th.md');
+    const sessionDir = path.join(tmpDir, 'session');
+    const contentPath = path.join(sessionDir, 'active.md');
+    const manifestPath = path.join(sessionDir, 'context.json');
+    process.env.FT_LIBRARY_DIR = libraryDir;
+    fs.mkdirSync(path.dirname(sourcePath), { recursive: true });
+    fs.mkdirSync(sessionDir, { recursive: true });
+    fs.writeFileSync(sourcePath, '- real source\n');
+    fs.writeFileSync(contentPath, '- stale rendered context\n');
+    fs.writeFileSync(manifestPath, JSON.stringify({
+      version: 1,
+      activeDocument: {
+        title: 'Sunday Jun 14th',
+        path: sourcePath,
+        kind: 'wiki',
+        contentMode: 'rendered',
+        contentPath,
+      },
+    }));
+
+    assert.equal(readCurrentDocumentContext(manifestPath).content, '- real source\n');
+  } finally {
+    if (previousLibraryDir === undefined) delete process.env.FT_LIBRARY_DIR;
+    else process.env.FT_LIBRARY_DIR = previousLibraryDir;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
 test('findCurrentContextManifest reads the app runtime context before legacy Library context', () => {
   const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ft-current-home-'));
   const originalHome = process.env.HOME;
@@ -205,18 +238,30 @@ test('formatCurrentDocumentSummary prints shell-safe current document commands',
   try {
     const sessionsDir = path.join(tmpDir, 'sessions');
     const manifestPath = writeContext(sessionsDir, 'session', 'Sunday Jun 14th', 'body', '2026-01-01T00:00:00.000Z');
+    const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf-8'));
+    manifest.activeDocument.lineMapping = {
+      lines: [{ visibleLine: 1, sourceLine: 1, text: 'rendered line' }],
+    };
+    fs.writeFileSync(manifestPath, JSON.stringify(manifest));
 
     const summary = readCurrentDocumentSummary(manifestPath);
     assert.equal(summary.activeDocument.path, '/library/Sunday Jun 14th.md');
     assert.equal(summary.activeDocument.shellQuotedPath, "'/library/Sunday Jun 14th.md'");
+    assert.equal(summary.activeDocument.shellEscapedPath, '/library/Sunday\\ Jun\\ 14th.md');
     assert.equal(summary.commands.readContent, 'ft current --content-only');
     assert.equal(summary.commands.updateFromFile, 'ft current update --file <temp-file>');
-    assert.equal(summary.commands.updateFromStdin, 'ft current update --stdin');
-    assert.equal(summary.commands.readSource, "cat '/library/Sunday Jun 14th.md'");
+    assert.equal(summary.commands.transformWithPipe, 'ft current update --pipe <command>');
+    assert.equal(summary.commands.plainBulletsToUncheckedTodos, 'ft current update --pipe "sed \'s/^- /- [ ] /\'"');
+    assert.equal('readSource' in summary.commands, false);
     assert.match(summary.commands.note, /temp file/);
 
     const jsonSummary = formatCurrentDocumentJson(summary);
-    assert.equal(jsonSummary.activeDocument.path, "'/library/Sunday Jun 14th.md'");
+    assert.equal(jsonSummary.activeDocument.path, '/library/Sunday\\ Jun\\ 14th.md');
+    assert.equal('readSource' in jsonSummary.commands, false);
+    assert.deepEqual(jsonSummary.activeDocument.lineMapping, {
+      available: true,
+      note: 'Line mapping text is omitted from model-facing JSON. Run commands.readContent for current source text.',
+    });
     assert.equal(summary.activeDocument.path, '/library/Sunday Jun 14th.md');
 
     const output = formatCurrentDocumentSummary(summary);

--- a/tests/skill.test.ts
+++ b/tests/skill.test.ts
@@ -55,7 +55,9 @@ describe('skill content', () => {
     assert.ok(content.includes('commands.readContent'));
     assert.ok(content.includes('ft current --content-only'));
     assert.ok(content.includes('ft current update --file <temp-file>'));
-    assert.ok(content.includes('do not use raw `activeDocument.path`'));
+    assert.ok(content.includes('ft current update --pipe <command>'));
+    assert.ok(content.includes('ft current update --pipe "sed \'s/^- /- [ ] /\'"'));
+    assert.ok(content.includes('never run `cat`, `sed`, or another shell command against `activeDocument.path`'));
   });
 
   it('force install overwrites stale Codex instructions', async () => {

--- a/tests/skill.test.ts
+++ b/tests/skill.test.ts
@@ -1,6 +1,9 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { skillWithFrontmatter, skillBody } from '../src/skill.js';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { skillWithFrontmatter, skillBody, installSkill } from '../src/skill.js';
 
 describe('skill content', () => {
   it('skillWithFrontmatter includes YAML frontmatter', () => {
@@ -22,6 +25,7 @@ describe('skill content', () => {
     for (const content of [skillWithFrontmatter(), skillBody()]) {
       assert.ok(content.includes('ft paths --json'));
       assert.ok(content.includes('ft status --json'));
+      assert.ok(content.includes('ft current update --file <tmp>'));
       assert.ok(content.includes('ft search'));
       assert.ok(content.includes('ft list'));
       assert.ok(content.includes('ft stats'));
@@ -44,6 +48,39 @@ describe('skill content', () => {
     assert.ok(content.includes('roadmap plotted in the grid'));
     assert.ok(content.includes('these projects'));
     assert.ok(content.includes('generate -> critique -> score'));
+  });
+
+  it('skill teaches active document edit workflow', () => {
+    const content = skillWithFrontmatter();
+    assert.ok(content.includes('commands.readContent'));
+    assert.ok(content.includes('ft current --content-only'));
+    assert.ok(content.includes('ft current update --file <temp-file>'));
+    assert.ok(content.includes('do not use raw `activeDocument.path`'));
+  });
+
+  it('force install overwrites stale Codex instructions', async () => {
+    const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ft-skill-home-'));
+    const previousHome = process.env.HOME;
+    try {
+      const instructionsDir = path.join(homeDir, '.codex', 'instructions');
+      fs.mkdirSync(instructionsDir, { recursive: true });
+      const installPath = path.join(instructionsDir, 'fieldtheory.md');
+      fs.writeFileSync(installPath, '# old bookmark-only skill\n');
+      process.env.HOME = homeDir;
+
+      const results = await installSkill({ force: true });
+
+      assert.deepEqual(results, [{
+        agent: 'Codex',
+        path: installPath,
+        action: 'updated',
+      }]);
+      assert.equal(fs.readFileSync(installPath, 'utf-8'), skillBody());
+    } finally {
+      if (previousHome === undefined) delete process.env.HOME;
+      else process.env.HOME = previousHome;
+      fs.rmSync(homeDir, { recursive: true, force: true });
+    }
   });
 
   it('skill content ends with newline', () => {

--- a/tests/skill.test.ts
+++ b/tests/skill.test.ts
@@ -58,6 +58,7 @@ describe('skill content', () => {
     assert.ok(content.includes('ft current update --pipe <command>'));
     assert.ok(content.includes('ft current update --pipe "sed \'s/^- /- [ ] /\'"'));
     assert.ok(content.includes('never run `cat`, `sed`, or another shell command against `activeDocument.path`'));
+    assert.ok(content.includes('Field Theory command files are markdown instructions, not shell scripts'));
   });
 
   it('force install overwrites stale Codex instructions', async () => {


### PR DESCRIPTION
## Status

Superseded by #178, which has merged.

This PR was the first pass at hardening the active Field Theory document workflow for agents. It helped expose the right direction, but the final implementation moved to #178 with a simpler contract.

Do not merge this PR as-is.

## What This Attempt Covered

- Added safer `ft current --json` behavior for active document content and metadata.
- Added guarded `ft current update` paths for agent-driven Markdown edits.
- Updated the Field Theory skill/install guidance around active document editing.
- Added tests around current document reads, updates, and skill output.

## Why It Is Superseded

#178 replaces the command-bundle/temp-file direction with one clearer workflow:

- Read the full active Markdown from `ft current --json`.
- Edit the returned `content` as normal Markdown.
- Write the complete document through `ft current update --stdin --expected-sha256 <sha>`.
- Use line-number metadata only when the user asks about visible/source line positions.

That is simpler for models and safer for the user's real document.

## Verification From This Branch

- `./node_modules/.bin/tsx --test tests/current.test.ts tests/cli.test.ts tests/skill.test.ts`
- `npm run build`
- local `gemma` smoke test against `ft current`

## Next

Close this PR after confirming #178 covers the intended behavior.
