### PR TITLE
fix: simplify current document editing

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1970,6 +1970,7 @@ export function buildCli() {
   currentCommand
     .command('update')
     .description('Update the active Field Theory Library document with stdin or file content')
+    .argument('[unexpected...]', 'Unexpected positional content; pipe Markdown on stdin instead')
     .option('--manifest <path>', 'Read a specific context manifest')
     .option('--stdin', 'Read markdown content from stdin')
     .option('--file <path>', 'Read markdown content from a file')
@@ -1977,7 +1978,10 @@ export function buildCli() {
     .option('--force', 'Overwrite without checking an expected hash')
     .option('--allow-empty', 'Allow intentionally clearing the current document')
     .option('--json', 'JSON output')
-    .action(safe(async (options, command) => {
+    .action(safe(async (unexpectedArgs: string[], options, command) => {
+      if (unexpectedArgs.length > 0) {
+        throw new Error('ft current update does not accept document content as command arguments. Pipe the complete edited Markdown to stdin, then retry with ft current update --stdin --expected-sha256 <version.sha256>.');
+      }
       const stdin = Boolean(options.stdin || (!options.file && hasPipedStdin()));
       if (!stdin && !options.file) throw new Error('Pipe complete Markdown to stdin or pass --stdin/--file for update content.');
       if (options.stdin && options.file) throw new Error('Pass only one of --stdin or --file for update content.');

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -33,13 +33,14 @@ import { exportBookmarks } from './md-export.js';
 import { renderViz } from './bookmarks-viz.js';
 import { listBrowserIds } from './browsers.js';
 import { configureHttpProxyFromEnv } from './http-proxy.js';
-import { dataDir, ensureDataDir, isFirstRun, migrateLegacyIdeasData, twitterBookmarksIndexPath, twitterBackfillStatePath, mdDir, bookmarkMediaDir, bookmarkMediaManifestPath } from './paths.js';
+import { canonicalLibraryDir, dataDir, ensureDataDir, isFirstRun, migrateLegacyIdeasData, twitterBookmarksIndexPath, twitterBackfillStatePath, mdDir, bookmarkMediaDir, bookmarkMediaManifestPath } from './paths.js';
 import { PromptCancelledError, promptText } from './prompt.js';
 import { skillWithFrontmatter, installSkill, uninstallSkill } from './skill.js';
 import { registerCompanionCommands } from './companion-cli.js';
 import { getPathReport } from './field-status.js';
 import { formatAgentContext, getAgentContext } from './agent-context.js';
-import { formatCurrentDocumentSummary, readCurrentDocumentContext, readCurrentDocumentSummary } from './current.js';
+import { currentDocumentJson, formatCurrentDocumentSummary, isEditableCurrentSourcePath, readCurrentDocumentContext, readCurrentDocumentSummary } from './current.js';
+import { isPathInside, readContentInput, updateMarkdownFile } from './document-ops.js';
 import { updateLibraryDocument } from './library.js';
 import { formatWorkflowState, getWorkflowState } from './workflow-state.js';
 import {
@@ -312,6 +313,18 @@ function warnIfEmpty(totalBookmarks: number): void {
 
 function printJson(value: unknown): void {
   console.log(JSON.stringify(value, null, 2));
+}
+
+export function shouldInferStdinFromStats(stats: Pick<fs.Stats, 'isFIFO' | 'isFile'>): boolean {
+  return stats.isFIFO() || stats.isFile();
+}
+
+function hasPipedStdin(): boolean {
+  try {
+    return shouldInferStdinFromStats(fs.fstatSync(0));
+  } catch {
+    return false;
+  }
 }
 
 function formatMarkdownLink(label: string, href: string): string {
@@ -1935,18 +1948,20 @@ export function buildCli() {
     .description('Show the active Field Theory document attached to the Mac app terminal')
     .option('--manifest <path>', 'Read a specific context manifest')
     .option('--content-only', 'Print only the active document markdown/content')
-    .option('--include-content', 'Include active document content in --json output')
+    .option('--include-content', 'Deprecated: active document content is included in --json output by default')
+    .option('--summary', 'Omit active document content from --json output')
+    .option('--debug-paths', 'Include raw manifest/source/cache paths in --json output')
     .option('--json', 'JSON output')
     .action(safe(async (options) => {
       if (options.contentOnly) {
         process.stdout.write(readCurrentDocumentContext(options.manifest).content);
         return;
       }
-      const context = options.includeContent
+      const context = options.json && !options.summary
         ? readCurrentDocumentContext(options.manifest)
         : readCurrentDocumentSummary(options.manifest);
       if (options.json) {
-        printJson(context);
+        printJson(options.debugPaths ? context : currentDocumentJson(context));
         return;
       }
       process.stdout.write(formatCurrentDocumentSummary(context));
@@ -1960,20 +1975,32 @@ export function buildCli() {
     .option('--file <path>', 'Read markdown content from a file')
     .option('--expected-sha256 <hash>', 'Only update if the current source file hash matches')
     .option('--force', 'Overwrite without checking an expected hash')
+    .option('--allow-empty', 'Allow intentionally clearing the current document')
     .option('--json', 'JSON output')
     .action(safe(async (options, command) => {
-      if (!options.stdin && !options.file) throw new Error('Pass --stdin or --file for update content.');
+      const stdin = Boolean(options.stdin || (!options.file && hasPipedStdin()));
+      if (!stdin && !options.file) throw new Error('Pipe complete Markdown to stdin or pass --stdin/--file for update content.');
+      if (options.stdin && options.file) throw new Error('Pass only one of --stdin or --file for update content.');
       const parentOptions = command.parent?.opts() ?? {};
       const manifest = options.manifest || parentOptions.manifest;
       const context = readCurrentDocumentContext(manifest);
       const targetPath = context.activeDocument.path;
       if (!targetPath) throw new Error('Active Field Theory context has no source path to update.');
-      const doc = await updateLibraryDocument(targetPath, {
-        stdin: Boolean(options.stdin),
-        file: options.file ? String(options.file) : undefined,
+      if (!isEditableCurrentSourcePath(targetPath)) {
+        throw new Error('Active Field Theory context source is not an editable Field Theory Markdown file.');
+      }
+      const updateOptions = {
         expectedSha256: options.expectedSha256 ? String(options.expectedSha256) : undefined,
-        force: Boolean(options.force || !options.expectedSha256),
-      });
+        force: Boolean(options.force),
+        allowEmpty: Boolean(options.allowEmpty),
+      };
+      const input = {
+        stdin,
+        file: options.file ? String(options.file) : undefined,
+      };
+      const doc = isPathInside(canonicalLibraryDir(), targetPath)
+        ? await updateLibraryDocument(targetPath, { ...input, ...updateOptions })
+        : await updateMarkdownFile(targetPath, await readContentInput(input), updateOptions);
       if (options.json || parentOptions.json) {
         printJson(doc);
         return;
@@ -3305,8 +3332,10 @@ export function buildCli() {
   skill
     .command('install')
     .description('Install skill for detected agents (Claude Code, Codex)')
-    .action(safe(async () => {
-      const results = await installSkill();
+    .option('--force', 'Overwrite existing skill files without prompting')
+    .option('-y, --yes', 'Alias for --force')
+    .action(safe(async (options: { force?: boolean; yes?: boolean }) => {
+      const results = await installSkill({ force: Boolean(options.force || options.yes) });
       if (results.length === 0) {
         console.log('  No agents detected. Use `ft skill show` to copy manually.');
         return;

--- a/src/current.ts
+++ b/src/current.ts
@@ -23,6 +23,29 @@ export interface CurrentDocumentEditProtocol {
   warning: string;
 }
 
+export interface CurrentDocumentLineNumberEntry {
+  visibleLine: number;
+  sourceLine: number;
+  rowInSourceLine?: number;
+  rowsInSourceLine?: number;
+  text: string;
+}
+
+export interface CurrentDocumentLineMapping {
+  activeLineKind: string | null;
+  contentMode: string | null;
+  visibleRowsOnly: boolean;
+  lines: CurrentDocumentLineNumberEntry[];
+}
+
+export interface CurrentDocumentLineNumbers {
+  activeSurface: string | null;
+  activeLineKind: string | null;
+  visibleRowsOnly: boolean;
+  instructions: string;
+  lines: CurrentDocumentLineNumberEntry[];
+}
+
 export interface CurrentDocumentSummary {
   manifestPath: string;
   updatedAt: string | null;
@@ -34,7 +57,7 @@ export interface CurrentDocumentSummary {
     contentMode: string | null;
     contentPath: string;
     shellQuotedContentPath: string;
-    lineMapping: unknown;
+    lineMapping: CurrentDocumentLineMapping | null;
     version: DocumentVersion | null;
   };
   documentEdit: CurrentDocumentEditProtocol;
@@ -51,6 +74,7 @@ export interface CurrentDocumentAgentJson {
   title: string | null;
   kind: string | null;
   contentMode: string | null;
+  lineNumbers: CurrentDocumentLineNumbers;
   sourcePath: string | null;
   editable: boolean;
   version: DocumentVersion | null;
@@ -84,6 +108,10 @@ function stringField(value: unknown): string | null {
   return typeof value === 'string' && value.length > 0 ? value : null;
 }
 
+function positiveIntegerField(value: unknown): number | null {
+  return typeof value === 'number' && Number.isInteger(value) && value > 0 ? value : null;
+}
+
 function quoteForPosixShell(value: string): string {
   return `'${value.replace(/'/g, `'\\''`)}'`;
 }
@@ -98,6 +126,42 @@ function statMtimeMs(filePath: string): number {
 
 function arrayField(value: unknown): unknown[] {
   return Array.isArray(value) ? value : [];
+}
+
+function readLineMappingEntry(value: unknown): CurrentDocumentLineNumberEntry | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+  const record = value as ManifestRecord;
+  const visibleLine = positiveIntegerField(record.visibleLine);
+  const sourceLine = positiveIntegerField(record.sourceLine);
+  if (visibleLine === null || sourceLine === null) return null;
+
+  const entry: CurrentDocumentLineNumberEntry = {
+    visibleLine,
+    sourceLine,
+    text: typeof record.text === 'string' ? record.text : '',
+  };
+  const rowInSourceLine = positiveIntegerField(record.rowInSourceLine);
+  const rowsInSourceLine = positiveIntegerField(record.rowsInSourceLine);
+  if (rowInSourceLine !== null) entry.rowInSourceLine = rowInSourceLine;
+  if (rowsInSourceLine !== null) entry.rowsInSourceLine = rowsInSourceLine;
+  return entry;
+}
+
+function readLineMapping(value: unknown): CurrentDocumentLineMapping | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+  const record = value as ManifestRecord;
+  const activeLineKind = stringField(record.activeLineKind);
+  const contentMode = stringField(record.contentMode);
+  const lines = arrayField(record.lines)
+    .map(readLineMappingEntry)
+    .filter((line): line is CurrentDocumentLineNumberEntry => line !== null);
+  if (!activeLineKind && !contentMode && lines.length === 0) return null;
+  return {
+    activeLineKind,
+    contentMode,
+    visibleRowsOnly: typeof record.visibleRowsOnly === 'boolean' ? record.visibleRowsOnly : false,
+    lines,
+  };
 }
 
 function timestampMs(value: unknown): number {
@@ -301,7 +365,7 @@ export function readCurrentDocumentSummary(manifestPath = findCurrentContextMani
       contentMode: stringField(documentRecord.contentMode),
       contentPath,
       shellQuotedContentPath: stringField(documentRecord.shellQuotedContentPath) ?? quoteForPosixShell(contentPath),
-      lineMapping: documentRecord.lineMapping ?? null,
+      lineMapping: readLineMapping(documentRecord.lineMapping),
       version: sourceDocumentVersion(sourcePath),
     },
     documentEdit: currentDocumentEditProtocol(),
@@ -321,11 +385,36 @@ export function readCurrentDocumentContext(manifestPath = findCurrentContextMani
   };
 }
 
+function lineNumberInstructions(lineMapping: CurrentDocumentLineMapping | null, contentMode: string | null): string {
+  if (lineMapping?.activeLineKind === 'renderedVisual') {
+    return 'The user is viewing rendered visual lines. For visible or on-screen line questions, use lineNumbers.lines[].visibleLine. Do not derive visible line numbers by splitting content on newlines; sourceLine maps each visible row back to Markdown.';
+  }
+  if (lineMapping?.activeLineKind === 'source') {
+    return 'The user is viewing Markdown source lines. Visible line numbers match sourceLine and the content field newline numbers.';
+  }
+  if (contentMode && contentMode !== 'markdown') {
+    return `The user is viewing ${contentMode}, but no line map was attached. Treat content newline numbers as Markdown source lines, and say when a visible line cannot be resolved.`;
+  }
+  return 'No line map was attached. Treat content newline numbers as Markdown source lines.';
+}
+
+function currentDocumentLineNumbers(activeDocument: CurrentDocumentSummary['activeDocument']): CurrentDocumentLineNumbers {
+  const lineMapping = activeDocument.lineMapping;
+  return {
+    activeSurface: lineMapping?.contentMode ?? activeDocument.contentMode,
+    activeLineKind: lineMapping?.activeLineKind ?? (activeDocument.contentMode === 'markdown' ? 'source' : null),
+    visibleRowsOnly: lineMapping?.visibleRowsOnly ?? false,
+    instructions: lineNumberInstructions(lineMapping, activeDocument.contentMode),
+    lines: lineMapping?.lines ?? [],
+  };
+}
+
 export function currentDocumentJson(context: CurrentDocumentSummary | CurrentDocumentContext): CurrentDocumentAgentJson {
   const output: CurrentDocumentAgentJson = {
     title: context.activeDocument.title,
     kind: context.activeDocument.kind,
     contentMode: context.activeDocument.contentMode,
+    lineNumbers: currentDocumentLineNumbers(context.activeDocument),
     sourcePath: context.activeDocument.path,
     editable: context.activeDocument.version !== null,
     version: context.activeDocument.version,

--- a/src/current.ts
+++ b/src/current.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { legacyCodexContextSessionsDir, runtimeContextSessionStatePath, runtimeContextSessionsDir } from './paths.js';
+import { type DocumentVersion, isPathInside, readDocumentVersion } from './document-ops.js';
+import { canonicalLibraryDir, fieldTheoryDir, fieldTheoryRoot, legacyCodexContextSessionsDir, runtimeContextSessionStatePath, runtimeContextSessionsDir } from './paths.js';
 
 export interface CurrentDocumentSelection {
   textPath: string;
@@ -12,6 +13,14 @@ export interface CurrentDocumentRelatedPage {
   path: string | null;
   kind: string | null;
   contentPath: string | null;
+}
+
+export interface CurrentDocumentEditProtocol {
+  readCommand: string;
+  updateCommand: string;
+  expectedHashField: string;
+  instructions: string;
+  warning: string;
 }
 
 export interface CurrentDocumentSummary {
@@ -26,7 +35,9 @@ export interface CurrentDocumentSummary {
     contentPath: string;
     shellQuotedContentPath: string;
     lineMapping: unknown;
+    version: DocumentVersion | null;
   };
+  documentEdit: CurrentDocumentEditProtocol;
   selection: CurrentDocumentSelection | null;
   recent: CurrentDocumentRelatedPage[];
   includedPages: CurrentDocumentRelatedPage[];
@@ -34,6 +45,21 @@ export interface CurrentDocumentSummary {
 
 export interface CurrentDocumentContext extends CurrentDocumentSummary {
   content: string;
+}
+
+export interface CurrentDocumentAgentJson {
+  title: string | null;
+  kind: string | null;
+  contentMode: string | null;
+  sourcePath: string | null;
+  editable: boolean;
+  version: DocumentVersion | null;
+  updateCommand: string;
+  updatedAt: string | null;
+  selection: { preview: string | null } | null;
+  recent: Array<{ title: string | null; kind: string | null }>;
+  includedPages: Array<{ title: string | null; kind: string | null }>;
+  content?: string;
 }
 
 type ManifestRecord = Record<string, unknown>;
@@ -194,6 +220,56 @@ function readRelatedPages(value: unknown, sessionDir: string): CurrentDocumentRe
     .filter((item): item is CurrentDocumentRelatedPage => item !== null);
 }
 
+function currentDocumentEditProtocol(): CurrentDocumentEditProtocol {
+  return {
+    readCommand: 'ft current --json',
+    updateCommand: 'ft current update --stdin --expected-sha256 <sha>',
+    expectedHashField: 'version.sha256',
+    instructions: 'Edit the content field as normal Markdown, then pipe the complete edited Markdown to updateCommand on stdin. Never run updateCommand without stdin content.',
+    warning: 'Use sourcePath for identity/debugging only; write edits through updateCommand.',
+  };
+}
+
+function isMarkdownPath(filePath: string): boolean {
+  return /\.(md|markdown)$/i.test(path.basename(filePath));
+}
+
+export function isEditableCurrentSourcePath(sourcePath: string | null): boolean {
+  if (!sourcePath || !path.isAbsolute(sourcePath) || !isMarkdownPath(sourcePath)) {
+    return false;
+  }
+  const resolvedSourcePath = path.resolve(sourcePath);
+  const blockedRoots = [
+    path.resolve(runtimeContextSessionsDir()),
+    path.resolve(legacyCodexContextSessionsDir()),
+  ];
+  if (blockedRoots.some((root) => isPathInside(root, resolvedSourcePath))) {
+    return false;
+  }
+  const allowedRoots = Array.from(new Set([
+    path.resolve(canonicalLibraryDir()),
+    path.resolve(path.join(fieldTheoryDir(), 'librarian', 'artifacts')),
+    path.resolve(path.join(fieldTheoryRoot(), 'librarian', 'artifacts')),
+  ]));
+  if (!allowedRoots.some((root) => isPathInside(root, resolvedSourcePath))) {
+    return false;
+  }
+  try {
+    return fs.statSync(resolvedSourcePath).isFile();
+  } catch {
+    return false;
+  }
+}
+
+function sourceDocumentVersion(sourcePath: string | null): DocumentVersion | null {
+  if (!isEditableCurrentSourcePath(sourcePath)) return null;
+  try {
+    return readDocumentVersion(path.resolve(sourcePath!));
+  } catch {
+    return null;
+  }
+}
+
 export function readCurrentDocumentSummary(manifestPath = findCurrentContextManifest()): CurrentDocumentSummary {
   if (!manifestPath) {
     throw new Error('No active Field Theory context found. Open a Field Theory document and attach a Codex terminal first.');
@@ -226,7 +302,9 @@ export function readCurrentDocumentSummary(manifestPath = findCurrentContextMani
       contentPath,
       shellQuotedContentPath: stringField(documentRecord.shellQuotedContentPath) ?? quoteForPosixShell(contentPath),
       lineMapping: documentRecord.lineMapping ?? null,
+      version: sourceDocumentVersion(sourcePath),
     },
+    documentEdit: currentDocumentEditProtocol(),
     selection: readSelection(manifest.selection, sessionDir),
     recent: readRelatedPages(manifest.recent, sessionDir),
     includedPages: readRelatedPages(manifest.includedPages, sessionDir),
@@ -235,27 +313,46 @@ export function readCurrentDocumentSummary(manifestPath = findCurrentContextMani
 
 export function readCurrentDocumentContext(manifestPath = findCurrentContextManifest()): CurrentDocumentContext {
   const summary = readCurrentDocumentSummary(manifestPath);
+  const sourcePath = summary.activeDocument.path;
+  const contentPath = isEditableCurrentSourcePath(sourcePath) ? path.resolve(sourcePath!) : summary.activeDocument.contentPath;
   return {
     ...summary,
-    content: fs.readFileSync(summary.activeDocument.contentPath, 'utf-8'),
+    content: fs.readFileSync(contentPath, 'utf-8'),
   };
 }
 
+export function currentDocumentJson(context: CurrentDocumentSummary | CurrentDocumentContext): CurrentDocumentAgentJson {
+  const output: CurrentDocumentAgentJson = {
+    title: context.activeDocument.title,
+    kind: context.activeDocument.kind,
+    contentMode: context.activeDocument.contentMode,
+    sourcePath: context.activeDocument.path,
+    editable: context.activeDocument.version !== null,
+    version: context.activeDocument.version,
+    updateCommand: context.documentEdit.updateCommand,
+    updatedAt: context.updatedAt,
+    selection: context.selection ? { preview: context.selection.preview } : null,
+    recent: context.recent.map((page) => ({ title: page.title, kind: page.kind })),
+    includedPages: context.includedPages.map((page) => ({ title: page.title, kind: page.kind })),
+  };
+  if ('content' in context) output.content = context.content;
+  return output;
+}
+
 export function formatCurrentDocumentContext(context: CurrentDocumentContext): string {
-  const quotedSource = context.activeDocument.shellQuotedPath ?? '(unknown)';
   const lines = [
     '# Field Theory Current Document',
     '',
     `title: ${context.activeDocument.title ?? '(untitled)'}`,
-    'readCurrentCommand: ft current --content-only',
-    'editCurrentCommand: ft current update --file <temp-file>',
-    `source: ${quotedSource}`,
-    `readSourceCommand: ${context.activeDocument.path ? `cat ${quotedSource}` : '(unknown)'}`,
+    `readCurrentCommand: ${context.documentEdit.readCommand}`,
+    `editCurrentCommand: ${context.documentEdit.updateCommand}`,
+    `editInstructions: ${context.documentEdit.instructions}`,
+    `editWarning: ${context.documentEdit.warning}`,
+    `source: ${context.activeDocument.path ?? '(unknown)'}`,
     `kind: ${context.activeDocument.kind ?? '(unknown)'}`,
     `contentMode: ${context.activeDocument.contentMode ?? '(unknown)'}`,
     `updatedAt: ${context.updatedAt ?? '(unknown)'}`,
     `manifest: ${context.manifestPath}`,
-    `content: ${context.activeDocument.shellQuotedContentPath}`,
     `lineMapping: ${context.activeDocument.lineMapping ? 'available' : '(none)'}`,
     '',
     '---',
@@ -267,18 +364,17 @@ export function formatCurrentDocumentContext(context: CurrentDocumentContext): s
 }
 
 export function formatCurrentDocumentSummary(context: CurrentDocumentSummary): string {
-  const quotedSource = context.activeDocument.shellQuotedPath ?? '(unknown)';
   return [
     `title: ${context.activeDocument.title ?? '(untitled)'}`,
-    'readCurrentCommand: ft current --content-only',
-    'editCurrentCommand: ft current update --file <temp-file>',
-    `source: ${quotedSource}`,
-    `readSourceCommand: ${context.activeDocument.path ? `cat ${quotedSource}` : '(unknown)'}`,
+    `readCurrentCommand: ${context.documentEdit.readCommand}`,
+    `editCurrentCommand: ${context.documentEdit.updateCommand}`,
+    `editInstructions: ${context.documentEdit.instructions}`,
+    `editWarning: ${context.documentEdit.warning}`,
+    `source: ${context.activeDocument.path ?? '(unknown)'}`,
     `kind: ${context.activeDocument.kind ?? '(unknown)'}`,
     `contentMode: ${context.activeDocument.contentMode ?? '(unknown)'}`,
     `updatedAt: ${context.updatedAt ?? '(unknown)'}`,
     `manifest: ${context.manifestPath}`,
-    `content: ${context.activeDocument.shellQuotedContentPath}`,
     `lineMapping: ${context.activeDocument.lineMapping ? 'available' : '(none)'}`,
     '',
   ].join('\n');

--- a/src/document-ops.ts
+++ b/src/document-ops.ts
@@ -13,6 +13,7 @@ export interface DocumentVersion {
 export interface DocumentUpdateOptions {
   expectedSha256?: string;
   force?: boolean;
+  allowEmpty?: boolean;
 }
 
 export interface DocumentUpdateResult {
@@ -116,6 +117,9 @@ export async function createMarkdownFile(filePath: string, content: string): Pro
 export async function updateMarkdownFile(filePath: string, content: string, options: DocumentUpdateOptions): Promise<DocumentUpdateResult> {
   if (!await pathExists(filePath)) {
     throw new Error(`File not found: ${filePath}`);
+  }
+  if (content.length === 0 && !options.allowEmpty) {
+    throw new Error('Refusing to overwrite with empty content. Pipe the complete document content to stdin, or pass --allow-empty to intentionally clear it.');
   }
   const current = readDocumentVersion(filePath);
   if (options.expectedSha256 && current.sha256 !== options.expectedSha256) {

--- a/src/document-ops.ts
+++ b/src/document-ops.ts
@@ -123,7 +123,7 @@ export async function updateMarkdownFile(filePath: string, content: string, opti
   }
   const current = readDocumentVersion(filePath);
   if (options.expectedSha256 && current.sha256 !== options.expectedSha256) {
-    throw new Error(`File changed on disk. Expected ${options.expectedSha256}, found ${current.sha256}.`);
+    throw new Error(`File changed on disk. Expected ${options.expectedSha256}, found ${current.sha256}. To continue editing safely, run ft current --json, merge the requested change into the returned content, then run ft current update --stdin --expected-sha256 ${current.sha256}. Use the sha256 printed after each successful update for the next edit.`);
   }
   if (!options.force && !options.expectedSha256) {
     throw new Error('Refusing to overwrite without --expected-sha256 or --force.');

--- a/src/library.ts
+++ b/src/library.ts
@@ -42,6 +42,7 @@ export interface LibraryWriteInput {
 export interface LibraryUpdateInput extends LibraryWriteInput {
   expectedSha256?: string;
   force?: boolean;
+  allowEmpty?: boolean;
 }
 
 export interface LibraryListOptions {
@@ -199,6 +200,7 @@ export async function updateLibraryDocument(target: string, input: LibraryUpdate
   await updateMarkdownFile(filePath, content, {
     expectedSha256: input.expectedSha256,
     force: input.force,
+    allowEmpty: input.allowEmpty,
   });
   return showLibraryDocument(filePath);
 }

--- a/src/skill.ts
+++ b/src/skill.ts
@@ -36,7 +36,7 @@ Field Theory has four main local surfaces:
 ## Search Workflow
 
 1. Check paths and status when setup matters: \`ft paths --json\`, \`ft status --json\`
-2. When the user asks what Field Theory document they are looking at, run \`ft current --json\`; the JSON includes the document body, source path, editability, and hash when available
+2. When the user asks what Field Theory document they are looking at, run \`ft current --json\`; the JSON includes the document body, source path, editability, hash, content mode, and line-number mapping when available
 3. Check repo workflow state when branch/worktree/PR shape matters: \`ft state --json\`
 4. When the user says "that file" or "the recent file", inspect current repo recency with \`ft recent --json\`
 5. Search durable notes first when prior project knowledge matters: \`ft library search <query> --json\`
@@ -58,6 +58,8 @@ After a successful update, use the newly printed \`sha256\` as the expected hash
 Never run \`ft current update --stdin\` by itself. It must receive the full edited document content on stdin. For multiline edits, pipe the content on stdin; do not pass Markdown as command arguments.
 
 Do not use ad hoc \`sed -i\`, \`awk > file\`, \`cat\` against \`sourcePath\`, the Codex \`apply_patch\` tool, direct filesystem writes, context-cache files, temp-file rewrites, or invented commands such as \`ft edit\` for Field Theory document edits.
+
+When the user asks about a line number in the current document, read \`lineNumbers\` from \`ft current --json\` before answering. If \`lineNumbers.activeLineKind\` is \`renderedVisual\`, the user is referring to visible rendered rows; answer from \`lineNumbers.lines[].visibleLine\` and use \`sourceLine\` only as the Markdown source mapping. Do not answer visible-line questions by splitting \`content\` on newlines unless \`lineNumbers.activeLineKind\` is \`source\` or no line map is available.
 
 ## Possible Roadmap Workflow
 
@@ -107,7 +109,7 @@ If the user says "debate", use the existing \`ft possible\` pipeline as generate
 \`\`\`bash
 ft paths --json                # Canonical bookmarks, library, commands paths
 ft status --json               # Bookmark/classification status plus paths
-ft current --json              # Read current Markdown plus sourcePath, editable, and version.sha256
+ft current --json              # Read current Markdown plus sourcePath, contentMode, lineNumbers, editable, and version.sha256
 ft current --summary --json    # Active Field Theory document metadata without the full body
 ft current update --stdin --expected-sha256 <sha>   # Replace the actual current source file with stdin
 ft state --json                # Repo workflow state: root, workers, PRs, cleanup, next step

--- a/src/skill.ts
+++ b/src/skill.ts
@@ -57,7 +57,7 @@ After a successful update, use the newly printed \`sha256\` as the expected hash
 
 Never run \`ft current update --stdin\` by itself. It must receive the full edited document content on stdin. For multiline edits, pipe the content on stdin; do not pass Markdown as command arguments.
 
-Do not use ad hoc \`sed -i\`, \`awk > file\`, direct filesystem writes, context-cache files, temp-file rewrites, or invented commands such as \`ft edit\` for Field Theory document edits.
+Do not use ad hoc \`sed -i\`, \`awk > file\`, \`cat\` against \`sourcePath\`, the Codex \`apply_patch\` tool, direct filesystem writes, context-cache files, temp-file rewrites, or invented commands such as \`ft edit\` for Field Theory document edits.
 
 ## Possible Roadmap Workflow
 

--- a/src/skill.ts
+++ b/src/skill.ts
@@ -53,7 +53,9 @@ When the user asks you to edit the current Field Theory document, there is one s
 2. Edit the returned \`content\` as normal Markdown.
 3. Send the complete edited Markdown back on stdin: \`ft current update --stdin --expected-sha256 <version.sha256>\`
 
-Never run \`ft current update --stdin\` by itself. It must receive the full edited document content on stdin.
+After a successful update, use the newly printed \`sha256\` as the expected hash for the next edit to the same document. If the update says the file changed on disk, run \`ft current --json\` again, merge the user's requested change into the returned \`content\`, then retry once with the new \`version.sha256\`.
+
+Never run \`ft current update --stdin\` by itself. It must receive the full edited document content on stdin. For multiline edits, pipe the content on stdin; do not pass Markdown as command arguments.
 
 Do not use ad hoc \`sed -i\`, \`awk > file\`, direct filesystem writes, context-cache files, temp-file rewrites, or invented commands such as \`ft edit\` for Field Theory document edits.
 

--- a/src/skill.ts
+++ b/src/skill.ts
@@ -15,11 +15,12 @@ const BODY = `
 
 Use the Field Theory CLI to inspect and work with the user's local context.
 
-Field Theory has three main local surfaces:
+Field Theory has four main local surfaces:
 
 - bookmarks: raw synced X/Twitter bookmark data
 - library: readable markdown knowledge and authored notes
 - commands: portable markdown actions in \`~/.fieldtheory/library/Commands\`
+- current document: the active Field Theory document attached to the app terminal
 
 ## When to trigger
 
@@ -35,7 +36,7 @@ Field Theory has three main local surfaces:
 ## Search Workflow
 
 1. Check paths and status when setup matters: \`ft paths --json\`, \`ft status --json\`
-2. When the user asks what Field Theory document they are looking at, run \`ft current --json\`; only use \`ft current --content-only\` when the document body is needed
+2. When the user asks what Field Theory document they are looking at, run \`ft current --json\`; the JSON includes the document body, source path, editability, and hash when available
 3. Check repo workflow state when branch/worktree/PR shape matters: \`ft state --json\`
 4. When the user says "that file" or "the recent file", inspect current repo recency with \`ft recent --json\`
 5. Search durable notes first when prior project knowledge matters: \`ft library search <query> --json\`
@@ -43,6 +44,18 @@ Field Theory has three main local surfaces:
 7. Inspect exact files or bookmarks with \`ft library show <path> --json\`, \`ft show <id> --json\`, or \`ft commands show <name> --json\`
 8. Create or update durable Library notes and portable commands only when the user asks for a saved artifact
 9. Open useful Library pages in the Mac app with \`ft library open <path>\`
+
+## Current Document Editing Workflow
+
+When the user asks you to edit the current Field Theory document, there is one supported path: read it through \`ft current\`, edit the Markdown normally, and write the complete edited Markdown back through \`ft current update\`.
+
+1. Read the document, content, and hash: \`ft current --json\`
+2. Edit the returned \`content\` as normal Markdown.
+3. Send the complete edited Markdown back on stdin: \`ft current update --stdin --expected-sha256 <version.sha256>\`
+
+Never run \`ft current update --stdin\` by itself. It must receive the full edited document content on stdin.
+
+Do not use ad hoc \`sed -i\`, \`awk > file\`, direct filesystem writes, context-cache files, temp-file rewrites, or invented commands such as \`ft edit\` for Field Theory document edits.
 
 ## Possible Roadmap Workflow
 
@@ -92,8 +105,9 @@ If the user says "debate", use the existing \`ft possible\` pipeline as generate
 \`\`\`bash
 ft paths --json                # Canonical bookmarks, library, commands paths
 ft status --json               # Bookmark/classification status plus paths
-ft current --json              # Active Field Theory document metadata without the full body
-ft current --content-only      # Active document body when the user/model actually needs it
+ft current --json              # Read current Markdown plus sourcePath, editable, and version.sha256
+ft current --summary --json    # Active Field Theory document metadata without the full body
+ft current update --stdin --expected-sha256 <sha>   # Replace the actual current source file with stdin
 ft state --json                # Repo workflow state: root, workers, PRs, cleanup, next step
 ft recent --json               # Current repo last-modified file and recent files for agent references
 
@@ -138,6 +152,7 @@ Combine filters: \`ft list --category tool --domain ai --limit 10\`
 - Ground roadmap work in actual bookmark-backed seeds
 - Lead roadmap reports with the plotted grid and concrete next actions, not just prose
 - For updates, use \`--expected-sha256\` from a prior \`show --json\` result or pass \`--force\` only when explicitly appropriate
+- For current-document edits, use \`ft current --json\` followed by \`ft current update --stdin --expected-sha256 <sha>\`; treat \`sourcePath\` as identity/debugging context, not an invitation to bypass the update command
 - In local app development, set \`FT_APP_DEV_DIR\` before \`ft library open\` so the CLI targets the Field Theory dev checkout instead of a generic Electron URL handler
 - Deletes move local files to Trash; the Mac app owns Library sync and remote tombstones
 `;
@@ -184,7 +199,11 @@ export interface SkillResult {
   action: 'installed' | 'updated' | 'up-to-date' | 'removed';
 }
 
-export async function installSkill(): Promise<SkillResult[]> {
+export interface InstallSkillOptions {
+  force?: boolean;
+}
+
+export async function installSkill(options: InstallSkillOptions = {}): Promise<SkillResult[]> {
   const detected = detectAgents();
   const targets = detected.filter((a) => a.detected);
 
@@ -213,19 +232,21 @@ export async function installSkill(): Promise<SkillResult[]> {
         continue;
       }
 
-      const answer = await promptText(`  ${agent.name} skill already exists. Overwrite? (y/n/compare) `);
-      if (answer.kind !== 'answer') continue;
-      const val = answer.value.toLowerCase();
+      if (!options.force) {
+        const answer = await promptText(`  ${agent.name} skill already exists. Overwrite? (y/n/compare) `);
+        if (answer.kind !== 'answer') continue;
+        const val = answer.value.toLowerCase();
 
-      if (val === 'compare' || val === 'c') {
-        console.log(`\n  ── Installed (${agent.installPath}) ──`);
-        console.log(existing);
-        console.log(`  ── New ──`);
-        console.log(content);
-        const confirm = await promptText(`  Overwrite with new version? (y/n) `);
-        if (confirm.kind !== 'answer' || confirm.value.toLowerCase() !== 'y') continue;
-      } else if (val !== 'y') {
-        continue;
+        if (val === 'compare' || val === 'c') {
+          console.log(`\n  ── Installed (${agent.installPath}) ──`);
+          console.log(existing);
+          console.log(`  ── New ──`);
+          console.log(content);
+          const confirm = await promptText(`  Overwrite with new version? (y/n) `);
+          if (confirm.kind !== 'answer' || confirm.value.toLowerCase() !== 'y') continue;
+        } else if (val !== 'y') {
+          continue;
+        }
       }
     }
 

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -407,6 +407,18 @@ test('ft current includes document content in model-facing JSON by default', asy
         kind: 'wiki',
         contentMode: 'rendered',
         contentPath,
+        lineMapping: {
+          activeLineKind: 'renderedVisual',
+          contentMode: 'rendered',
+          visibleRowsOnly: true,
+          lines: [{
+            visibleLine: 27,
+            sourceLine: 22,
+            rowInSourceLine: 1,
+            rowsInSourceLine: 2,
+            text: 'visible row text',
+          }],
+        },
       },
     }));
 
@@ -427,6 +439,11 @@ test('ft current includes document content in model-facing JSON by default', asy
     assert.equal(summary.contentPath, undefined);
     assert.equal(summary.shellQuotedPath, undefined);
     assert.equal(summary.lineMapping, undefined);
+    assert.equal(summary.lineNumbers.activeSurface, 'rendered');
+    assert.equal(summary.lineNumbers.activeLineKind, 'renderedVisual');
+    assert.equal(summary.lineNumbers.lines[0].visibleLine, 27);
+    assert.equal(summary.lineNumbers.lines[0].sourceLine, 22);
+    assert.match(summary.lineNumbers.instructions, /Do not derive visible line numbers/);
     assert.equal(summary.manifestPath, undefined);
 
     const debugOutput = await captureStdout(async () => {

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
-import { compareVersions, runWithSpinner, buildCli, parseCookieOption } from '../src/cli.js';
+import { compareVersions, runWithSpinner, buildCli, parseCookieOption, shouldInferStdinFromStats } from '../src/cli.js';
 import { dataDir } from '../src/paths.js';
 import { skillWithFrontmatter } from '../src/skill.js';
 
@@ -102,6 +102,28 @@ test('ft paths, current, state, recent, navigation aliases, library, commands, a
   ]) {
     assert.ok(program.commands.find((c: any) => c.name() === name), `${name} command should be registered`);
   }
+});
+
+test('ft skill install exposes a non-interactive force option', () => {
+  const program = buildCli();
+  const skillCmd = program.commands.find((c: any) => c.name() === 'skill');
+  assert.ok(skillCmd, 'skill command should be registered');
+  const installCmd = skillCmd.commands.find((c: any) => c.name() === 'install');
+  assert.ok(installCmd, 'skill install command should be registered');
+  const opts = installCmd.options.map((o: any) => o.long);
+  assert.ok(opts.includes('--force'), `expected --force among ${opts.join(', ')}`);
+  assert.ok(opts.includes('--yes'), `expected --yes among ${opts.join(', ')}`);
+});
+
+test('current update infers stdin only from piped or redirected input', () => {
+  const stats = (fifo: boolean, file: boolean) => ({
+    isFIFO: () => fifo,
+    isFile: () => file,
+  });
+
+  assert.equal(shouldInferStdinFromStats(stats(true, false)), true);
+  assert.equal(shouldInferStdinFromStats(stats(false, true)), true);
+  assert.equal(shouldInferStdinFromStats(stats(false, false)), false);
 });
 
 test('ft navigation aliases inspect Field Theory library markdown', async () => {
@@ -346,20 +368,26 @@ test('ft navigation commands cover links tags writes app targets and location st
   }
 });
 
-test('ft current keeps document content opt-in for model-facing JSON', async () => {
+test('ft current includes document content in model-facing JSON by default', async () => {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ft-current-cli-'));
   const previousExitCode = process.exitCode;
+  const previousLibraryDir = process.env.FT_LIBRARY_DIR;
   try {
+    const libraryDir = path.join(tmpDir, 'library');
+    process.env.FT_LIBRARY_DIR = libraryDir;
+    const sourcePath = path.join(libraryDir, 'current-body.md');
     const sessionDir = path.join(tmpDir, 'session');
     fs.mkdirSync(sessionDir, { recursive: true });
+    fs.mkdirSync(libraryDir, { recursive: true });
     const contentPath = path.join(sessionDir, 'active.md');
     const manifestPath = path.join(sessionDir, 'context.json');
-    fs.writeFileSync(contentPath, '# Current Body\n\nprivate working text\n');
+    fs.writeFileSync(sourcePath, '# Current Body\n\nprivate working text\n');
+    fs.writeFileSync(contentPath, '# stale rendered copy\n');
     fs.writeFileSync(manifestPath, JSON.stringify({
       updatedAt: '2026-01-02T00:00:00.000Z',
       activeDocument: {
         title: 'Current Body',
-        path: '/library/current-body.md',
+        path: sourcePath,
         kind: 'wiki',
         contentMode: 'rendered',
         contentPath,
@@ -370,25 +398,49 @@ test('ft current keeps document content opt-in for model-facing JSON', async () 
       await buildCli().parseAsync(['node', 'ft', 'current', '--manifest', manifestPath, '--json']);
     });
     const summary = JSON.parse(summaryOutput);
-    assert.equal(summary.activeDocument.title, 'Current Body');
-    assert.equal(summary.content, undefined);
+    assert.equal(summaryOutput.trimStart().startsWith('{\n  "title"'), true);
+    assert.equal(summary.title, 'Current Body');
+    assert.equal(summary.sourcePath, sourcePath);
+    assert.equal(summary.editable, true);
+    assert.equal(summary.version.sha256.length, 64);
+    assert.equal(summary.updateCommand, 'ft current update --stdin --expected-sha256 <sha>');
+    assert.match(summary.content, /private working text/);
+    assert.equal(summary.content.includes('stale rendered copy'), false);
+    assert.equal(summary.activeDocument, undefined);
+    assert.equal(summary.documentEdit, undefined);
+    assert.equal(summary.contentPath, undefined);
+    assert.equal(summary.shellQuotedPath, undefined);
+    assert.equal(summary.lineMapping, undefined);
+    assert.equal(summary.manifestPath, undefined);
+
+    const debugOutput = await captureStdout(async () => {
+      await buildCli().parseAsync(['node', 'ft', 'current', '--manifest', manifestPath, '--json', '--debug-paths']);
+    });
+    assert.equal(JSON.parse(debugOutput).activeDocument.path, sourcePath);
 
     const contentOutput = await captureStdout(async () => {
       await buildCli().parseAsync(['node', 'ft', 'current', '--manifest', manifestPath, '--content-only']);
     });
     assert.equal(contentOutput, '# Current Body\n\nprivate working text\n');
 
-    const fullOutput = await captureStdout(async () => {
+    const summaryOnlyOutput = await captureStdout(async () => {
+      await buildCli().parseAsync(['node', 'ft', 'current', '--manifest', manifestPath, '--summary', '--json']);
+    });
+    assert.equal(JSON.parse(summaryOnlyOutput).content, undefined);
+
+    const legacyIncludeOutput = await captureStdout(async () => {
       await buildCli().parseAsync(['node', 'ft', 'current', '--manifest', manifestPath, '--include-content', '--json']);
     });
-    assert.match(JSON.parse(fullOutput).content, /private working text/);
+    assert.match(JSON.parse(legacyIncludeOutput).content, /private working text/);
   } finally {
+    if (previousLibraryDir === undefined) delete process.env.FT_LIBRARY_DIR;
+    else process.env.FT_LIBRARY_DIR = previousLibraryDir;
     process.exitCode = previousExitCode;
     fs.rmSync(tmpDir, { recursive: true, force: true });
   }
 });
 
-test('ft current prints shell-safe commands for active documents with spaces', async () => {
+test('ft current prints the single current-document edit protocol', async () => {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ft-current-shell-cli-'));
   const previousExitCode = process.exitCode;
   try {
@@ -412,11 +464,13 @@ test('ft current prints shell-safe commands for active documents with spaces', a
       await buildCli().parseAsync(['node', 'ft', 'current', '--manifest', manifestPath]);
     });
 
-    assert.match(output, /readCurrentCommand: ft current --content-only/);
-    assert.match(output, /editCurrentCommand: ft current update --file <temp-file>/);
-    assert.match(output, /source: '\/library\/Sunday Jun 14th\.md'/);
-    assert.match(output, /readSourceCommand: cat '\/library\/Sunday Jun 14th\.md'/);
-    assert.doesNotMatch(output, /^source: \/library\/Sunday Jun 14th\.md$/m);
+    assert.match(output, /readCurrentCommand: ft current --json/);
+    assert.match(output, /editCurrentCommand: ft current update --stdin --expected-sha256 <sha>/);
+    assert.match(output, /editInstructions: Edit the content field as normal Markdown/);
+    assert.match(output, /editWarning: Use sourcePath for identity\/debugging only; write edits through updateCommand\./);
+    assert.match(output, /source: \/library\/Sunday Jun 14th\.md/);
+    assert.doesNotMatch(output, /readSourceCommand/);
+    assert.doesNotMatch(output, /cat '\/library\/Sunday Jun 14th\.md'/);
   } finally {
     process.exitCode = previousExitCode;
     fs.rmSync(tmpDir, { recursive: true, force: true });
@@ -442,6 +496,8 @@ test('ft current update edits the active Library document without passing its pa
     fs.writeFileSync(sourcePath, initialContent);
     fs.writeFileSync(contentPath, initialContent);
     fs.writeFileSync(updatePath, updatedContent);
+    const emptyUpdatePath = path.join(tmpDir, 'empty.md');
+    fs.writeFileSync(emptyUpdatePath, '');
     fs.writeFileSync(manifestPath, JSON.stringify({
       updatedAt: '2026-01-02T00:00:00.000Z',
       activeDocument: {
@@ -453,8 +509,54 @@ test('ft current update edits the active Library document without passing its pa
       },
     }));
 
+    const noHashStderr = await captureStderr(async () => {
+      await buildCli().parseAsync(['node', 'ft', 'current', 'update', '--manifest', manifestPath, '--file', updatePath]);
+    });
+    assert.match(noHashStderr, /Refusing to overwrite without --expected-sha256 or --force/);
+    assert.equal(process.exitCode, 1);
+    assert.equal(fs.readFileSync(sourcePath, 'utf-8'), initialContent);
+    process.exitCode = previousExitCode;
+
+    const readOutput = await captureStdout(async () => {
+      await buildCli().parseAsync(['node', 'ft', 'current', '--manifest', manifestPath, '--json']);
+    });
+    const current = JSON.parse(readOutput);
+    assert.equal(current.content, initialContent);
+    assert.equal(current.version.sha256.length, 64);
+
+    const emptyStderr = await captureStderr(async () => {
+      await buildCli().parseAsync([
+        'node',
+        'ft',
+        'current',
+        'update',
+        '--manifest',
+        manifestPath,
+        '--file',
+        emptyUpdatePath,
+        '--expected-sha256',
+        current.version.sha256,
+      ]);
+    });
+    assert.match(emptyStderr, /Refusing to overwrite with empty content/);
+    assert.equal(process.exitCode, 1);
+    assert.equal(fs.readFileSync(sourcePath, 'utf-8'), initialContent);
+    process.exitCode = previousExitCode;
+
     const output = await captureStdout(async () => {
-      await buildCli().parseAsync(['node', 'ft', 'current', 'update', '--manifest', manifestPath, '--file', updatePath, '--json']);
+      await buildCli().parseAsync([
+        'node',
+        'ft',
+        'current',
+        'update',
+        '--manifest',
+        manifestPath,
+        '--file',
+        updatePath,
+        '--expected-sha256',
+        current.version.sha256,
+        '--json',
+      ]);
     });
 
     assert.equal(fs.readFileSync(sourcePath, 'utf-8'), updatedContent);
@@ -462,6 +564,158 @@ test('ft current update edits the active Library document without passing its pa
     assert.notEqual(jsonStart, -1);
     assert.equal(JSON.parse(output.slice(jsonStart)).path, sourcePath);
   } finally {
+    if (previousLibraryDir === undefined) delete process.env.FT_LIBRARY_DIR;
+    else process.env.FT_LIBRARY_DIR = previousLibraryDir;
+    process.exitCode = previousExitCode;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test('ft current update edits an active Field Theory markdown source outside the Library root', async () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ft-current-update-artifact-'));
+  const previousHome = process.env.HOME;
+  const previousLibraryDir = process.env.FT_LIBRARY_DIR;
+  const previousExitCode = process.exitCode;
+  try {
+    process.env.HOME = tmpDir;
+    const libraryDir = path.join(tmpDir, '.fieldtheory', 'library');
+    const sourcePath = path.join(tmpDir, '.fieldtheory', 'librarian', 'artifacts', 'Artifact.md');
+    const sessionDir = path.join(tmpDir, 'session');
+    const contentPath = path.join(sessionDir, 'active.md');
+    const manifestPath = path.join(sessionDir, 'context.json');
+    const updatePath = path.join(tmpDir, 'updated.md');
+    process.env.FT_LIBRARY_DIR = libraryDir;
+    fs.mkdirSync(path.dirname(sourcePath), { recursive: true });
+    fs.mkdirSync(sessionDir, { recursive: true });
+    fs.writeFileSync(sourcePath, '- [ ] artifact task\n');
+    fs.writeFileSync(contentPath, '- stale rendered context\n');
+    fs.writeFileSync(updatePath, '- [x] artifact task\n');
+    fs.writeFileSync(manifestPath, JSON.stringify({
+      activeDocument: {
+        title: 'Artifact',
+        path: sourcePath,
+        kind: 'artifact',
+        contentMode: 'rendered',
+        contentPath,
+      },
+    }));
+
+    const readOutput = await captureStdout(async () => {
+      await buildCli().parseAsync(['node', 'ft', 'current', '--manifest', manifestPath, '--json']);
+    });
+    const current = JSON.parse(readOutput);
+    assert.equal(current.content, '- [ ] artifact task\n');
+    assert.equal(current.version.sha256.length, 64);
+
+    const output = await captureStdout(async () => {
+      await buildCli().parseAsync([
+        'node',
+        'ft',
+        'current',
+        'update',
+        '--manifest',
+        manifestPath,
+        '--file',
+        updatePath,
+        '--expected-sha256',
+        current.version.sha256,
+        '--json',
+      ]);
+    });
+
+    assert.equal(fs.readFileSync(sourcePath, 'utf-8'), '- [x] artifact task\n');
+    const jsonStart = output.indexOf('{\n  "path"');
+    assert.notEqual(jsonStart, -1);
+    assert.equal(JSON.parse(output.slice(jsonStart)).path, sourcePath);
+  } finally {
+    if (previousHome === undefined) delete process.env.HOME;
+    else process.env.HOME = previousHome;
+    if (previousLibraryDir === undefined) delete process.env.FT_LIBRARY_DIR;
+    else process.env.FT_LIBRARY_DIR = previousLibraryDir;
+    process.exitCode = previousExitCode;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test('ft current update rejects markdown sources outside Field Theory roots', async () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ft-current-update-outside-'));
+  const previousHome = process.env.HOME;
+  const previousLibraryDir = process.env.FT_LIBRARY_DIR;
+  const previousExitCode = process.exitCode;
+  try {
+    process.env.HOME = path.join(tmpDir, 'home');
+    process.env.FT_LIBRARY_DIR = path.join(process.env.HOME, '.fieldtheory', 'library');
+    const sourcePath = path.join(tmpDir, 'outside.md');
+    const sessionDir = path.join(tmpDir, 'session');
+    const contentPath = path.join(sessionDir, 'active.md');
+    const updatePath = path.join(tmpDir, 'updated.md');
+    const manifestPath = path.join(sessionDir, 'context.json');
+    fs.mkdirSync(sessionDir, { recursive: true });
+    fs.writeFileSync(sourcePath, '- [ ] outside task\n');
+    fs.writeFileSync(contentPath, '- stale rendered context\n');
+    fs.writeFileSync(updatePath, '- [x] outside task\n');
+    fs.writeFileSync(manifestPath, JSON.stringify({
+      activeDocument: {
+        title: 'Outside',
+        path: sourcePath,
+        kind: 'external',
+        contentMode: 'rendered',
+        contentPath,
+      },
+    }));
+
+    const stderr = await captureStderr(async () => {
+      await buildCli().parseAsync(['node', 'ft', 'current', 'update', '--manifest', manifestPath, '--file', updatePath, '--force']);
+    });
+
+    assert.match(stderr, /not an editable Field Theory Markdown file/);
+    assert.equal(process.exitCode, 1);
+    assert.equal(fs.readFileSync(sourcePath, 'utf-8'), '- [ ] outside task\n');
+  } finally {
+    if (previousHome === undefined) delete process.env.HOME;
+    else process.env.HOME = previousHome;
+    if (previousLibraryDir === undefined) delete process.env.FT_LIBRARY_DIR;
+    else process.env.FT_LIBRARY_DIR = previousLibraryDir;
+    process.exitCode = previousExitCode;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test('ft current update rejects Field Theory session cache files as editable sources', async () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ft-current-update-cache-'));
+  const previousHome = process.env.HOME;
+  const previousLibraryDir = process.env.FT_LIBRARY_DIR;
+  const previousExitCode = process.exitCode;
+  try {
+    process.env.HOME = path.join(tmpDir, 'home');
+    process.env.FT_LIBRARY_DIR = path.join(process.env.HOME, '.fieldtheory', 'library');
+    const sessionDir = path.join(process.env.HOME, '.fieldtheory', '.codex-context', 'sessions', 'session');
+    const sourcePath = path.join(sessionDir, 'active.md');
+    const updatePath = path.join(tmpDir, 'updated.md');
+    const manifestPath = path.join(sessionDir, 'context.json');
+    fs.mkdirSync(sessionDir, { recursive: true });
+    fs.writeFileSync(sourcePath, '- [ ] rendered cache task\n');
+    fs.writeFileSync(updatePath, '- [x] rendered cache task\n');
+    fs.writeFileSync(manifestPath, JSON.stringify({
+      activeDocument: {
+        title: 'Cache Copy',
+        path: sourcePath,
+        kind: 'wiki',
+        contentMode: 'rendered',
+        contentPath: sourcePath,
+      },
+    }));
+
+    const stderr = await captureStderr(async () => {
+      await buildCli().parseAsync(['node', 'ft', 'current', 'update', '--manifest', manifestPath, '--file', updatePath, '--force']);
+    });
+
+    assert.match(stderr, /not an editable Field Theory Markdown file/);
+    assert.equal(process.exitCode, 1);
+    assert.equal(fs.readFileSync(sourcePath, 'utf-8'), '- [ ] rendered cache task\n');
+  } finally {
+    if (previousHome === undefined) delete process.env.HOME;
+    else process.env.HOME = previousHome;
     if (previousLibraryDir === undefined) delete process.env.FT_LIBRARY_DIR;
     else process.env.FT_LIBRARY_DIR = previousLibraryDir;
     process.exitCode = previousExitCode;

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -126,6 +126,22 @@ test('current update infers stdin only from piped or redirected input', () => {
   assert.equal(shouldInferStdinFromStats(stats(false, false)), false);
 });
 
+test('ft current update rejects document content passed as arguments with recovery guidance', async () => {
+  const previousExitCode = process.exitCode;
+  try {
+    const stderr = await captureStderr(async () => {
+      await buildCli().parseAsync(['node', 'ft', 'current', 'update', '## Heading', 'body text']);
+    });
+
+    assert.match(stderr, /does not accept document content as command arguments/);
+    assert.match(stderr, /Pipe the complete edited Markdown to stdin/);
+    assert.match(stderr, /ft current update --stdin --expected-sha256 <version\.sha256>/);
+    assert.equal(process.exitCode, 1);
+  } finally {
+    process.exitCode = previousExitCode;
+  }
+});
+
 test('ft navigation aliases inspect Field Theory library markdown', async () => {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ft-nav-'));
   const origEnv = {
@@ -766,6 +782,9 @@ test('ft current update honors explicit expected hashes', async () => {
     });
 
     assert.match(stderr, /File changed on disk/);
+    assert.match(stderr, /To continue editing safely, run ft current --json/);
+    assert.match(stderr, /merge the requested change into the returned content/);
+    assert.match(stderr, /Use the sha256 printed after each successful update for the next edit/);
     assert.equal(process.exitCode, 1);
     assert.equal(fs.readFileSync(sourcePath, 'utf-8'), 'current source\n');
   } finally {

--- a/tests/current.test.ts
+++ b/tests/current.test.ts
@@ -5,6 +5,7 @@ import path from 'node:path';
 import test from 'node:test';
 
 import {
+  currentDocumentJson,
   findCurrentContextManifest,
   formatCurrentDocumentContext,
   formatCurrentDocumentSummary,
@@ -48,17 +49,138 @@ test('readCurrentDocumentContext reads newest Field Theory context manifest', ()
 
     const summary = readCurrentDocumentSummary(newerManifest);
     assert.equal(summary.activeDocument.title, 'Newer Page');
+    assert.equal(summary.documentEdit.readCommand, 'ft current --json');
+    assert.equal(summary.documentEdit.updateCommand, 'ft current update --stdin --expected-sha256 <sha>');
+    assert.equal(summary.documentEdit.expectedHashField, 'version.sha256');
+    assert.match(summary.documentEdit.warning, /write edits through updateCommand/);
     assert.equal('content' in summary, false);
+    const agentSummary = currentDocumentJson(summary);
+    assert.deepEqual(Object.keys(agentSummary).slice(0, 2), ['title', 'kind']);
+    assert.equal(agentSummary.sourcePath, '/library/Newer Page.md');
+    assert.equal(agentSummary.updateCommand, 'ft current update --stdin --expected-sha256 <sha>');
+    assert.equal('activeDocument' in agentSummary, false);
+    assert.equal('documentEdit' in agentSummary, false);
+    assert.equal('contentPath' in agentSummary, false);
+    assert.equal('manifestPath' in agentSummary, false);
+    assert.equal('content' in agentSummary, false);
 
     const context = readCurrentDocumentContext(newerManifest);
     assert.equal(context.activeDocument.title, 'Newer Page');
     assert.equal(context.content, '# Newer\n');
+    assert.equal(currentDocumentJson(context).content, '# Newer\n');
     assert.match(formatCurrentDocumentContext(context), /title: Newer Page/);
     assert.match(formatCurrentDocumentContext(context), /# Newer/);
     assert.match(formatCurrentDocumentSummary(context), /title: Newer Page/);
     assert.doesNotMatch(formatCurrentDocumentSummary(context), /# Newer/);
   } finally {
     fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test('readCurrentDocumentContext prefers the active source file over stale rendered context', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ft-current-source-'));
+  const originalLibraryDir = process.env.FT_LIBRARY_DIR;
+  process.env.FT_LIBRARY_DIR = path.join(tmpDir, 'library');
+  try {
+    const sourcePath = path.join(process.env.FT_LIBRARY_DIR, 'scratchpad', 'Sunday Jun 14th.md');
+    const sessionDir = path.join(tmpDir, 'session');
+    fs.mkdirSync(path.dirname(sourcePath), { recursive: true });
+    fs.mkdirSync(sessionDir, { recursive: true });
+    fs.writeFileSync(sourcePath, '- real source\n');
+    const contentPath = path.join(sessionDir, 'active.md');
+    const manifestPath = path.join(sessionDir, 'context.json');
+    fs.writeFileSync(contentPath, '- stale context\n');
+    fs.writeFileSync(manifestPath, JSON.stringify({
+      activeDocument: {
+        title: 'Sunday Jun 14th',
+        path: sourcePath,
+        kind: 'wiki',
+        contentMode: 'rendered',
+        contentPath,
+      },
+    }));
+
+    const context = readCurrentDocumentContext(manifestPath);
+    assert.equal(context.content, '- real source\n');
+    assert.equal(context.activeDocument.version?.sha256.length, 64);
+  } finally {
+    if (originalLibraryDir === undefined) delete process.env.FT_LIBRARY_DIR;
+    else process.env.FT_LIBRARY_DIR = originalLibraryDir;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test('readCurrentDocumentContext supports Field Theory markdown sources outside the Library root', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ft-current-librarian-source-'));
+  const originalHome = process.env.HOME;
+  const originalLibraryDir = process.env.FT_LIBRARY_DIR;
+  process.env.HOME = tmpDir;
+  process.env.FT_LIBRARY_DIR = path.join(tmpDir, '.fieldtheory', 'library');
+  try {
+    const sourcePath = path.join(tmpDir, '.fieldtheory', 'librarian', 'artifacts', 'artifact.md');
+    const sessionDir = path.join(tmpDir, 'session');
+    fs.mkdirSync(path.dirname(sourcePath), { recursive: true });
+    fs.mkdirSync(sessionDir, { recursive: true });
+    fs.writeFileSync(sourcePath, '- real artifact source\n');
+    const contentPath = path.join(sessionDir, 'active.md');
+    const manifestPath = path.join(sessionDir, 'context.json');
+    fs.writeFileSync(contentPath, '- stale rendered context\n');
+    fs.writeFileSync(manifestPath, JSON.stringify({
+      activeDocument: {
+        title: 'Artifact',
+        path: sourcePath,
+        kind: 'artifact',
+        contentMode: 'rendered',
+        contentPath,
+      },
+    }));
+
+    const context = readCurrentDocumentContext(manifestPath);
+    assert.equal(context.content, '- real artifact source\n');
+    assert.equal(context.activeDocument.version?.sha256.length, 64);
+  } finally {
+    if (originalHome === undefined) delete process.env.HOME;
+    else process.env.HOME = originalHome;
+    if (originalLibraryDir === undefined) delete process.env.FT_LIBRARY_DIR;
+    else process.env.FT_LIBRARY_DIR = originalLibraryDir;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test('readCurrentDocumentContext treats context cache paths as rendered copies, not editable source files', () => {
+  const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ft-current-cache-source-'));
+  const originalHome = process.env.HOME;
+  const originalLibraryDir = process.env.FT_LIBRARY_DIR;
+  process.env.HOME = homeDir;
+  process.env.FT_LIBRARY_DIR = path.join(homeDir, '.fieldtheory', 'library');
+  try {
+    const sourcePath = path.join(homeDir, '.fieldtheory', '.codex-context', 'sessions', 'session', 'active.md');
+    const sessionDir = path.dirname(sourcePath);
+    const manifestPath = path.join(sessionDir, 'context.json');
+    fs.mkdirSync(sessionDir, { recursive: true });
+    fs.writeFileSync(sourcePath, '- rendered cache only\n');
+    fs.writeFileSync(manifestPath, JSON.stringify({
+      activeDocument: {
+        title: 'Cache Copy',
+        path: sourcePath,
+        kind: 'wiki',
+        contentMode: 'rendered',
+        contentPath: sourcePath,
+      },
+    }));
+
+    const context = readCurrentDocumentContext(manifestPath);
+    assert.equal(context.content, '- rendered cache only\n');
+    assert.equal(context.activeDocument.version, null);
+    const agentJson = currentDocumentJson(context);
+    assert.equal(agentJson.editable, false);
+    assert.equal(agentJson.version, null);
+  } finally {
+    if (originalHome === undefined) delete process.env.HOME;
+    else process.env.HOME = originalHome;
+    if (originalLibraryDir === undefined) delete process.env.FT_LIBRARY_DIR;
+    else process.env.FT_LIBRARY_DIR = originalLibraryDir;
+    fs.rmSync(homeDir, { recursive: true, force: true });
   }
 });
 
@@ -199,7 +321,7 @@ test('readCurrentDocumentSummary exposes active document line mapping', () => {
   }
 });
 
-test('formatCurrentDocumentSummary prints shell-safe current document commands', () => {
+test('formatCurrentDocumentSummary prints the single current-document edit protocol', () => {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ft-current-shell-'));
   try {
     const sessionsDir = path.join(tmpDir, 'sessions');
@@ -210,11 +332,13 @@ test('formatCurrentDocumentSummary prints shell-safe current document commands',
     assert.equal(summary.activeDocument.shellQuotedPath, "'/library/Sunday Jun 14th.md'");
 
     const output = formatCurrentDocumentSummary(summary);
-    assert.match(output, /readCurrentCommand: ft current --content-only/);
-    assert.match(output, /editCurrentCommand: ft current update --file <temp-file>/);
-    assert.match(output, /source: '\/library\/Sunday Jun 14th\.md'/);
-    assert.match(output, /readSourceCommand: cat '\/library\/Sunday Jun 14th\.md'/);
-    assert.doesNotMatch(output, /^source: \/library\/Sunday Jun 14th\.md$/m);
+    assert.match(output, /readCurrentCommand: ft current --json/);
+    assert.match(output, /editCurrentCommand: ft current update --stdin --expected-sha256 <sha>/);
+    assert.match(output, /editInstructions: Edit the content field as normal Markdown/);
+    assert.match(output, /editWarning: Use sourcePath for identity\/debugging only; write edits through updateCommand\./);
+    assert.match(output, /source: \/library\/Sunday Jun 14th\.md/);
+    assert.doesNotMatch(output, /readSourceCommand/);
+    assert.doesNotMatch(output, /cat '\/library\/Sunday Jun 14th\.md'/);
   } finally {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   }

--- a/tests/current.test.ts
+++ b/tests/current.test.ts
@@ -57,6 +57,9 @@ test('readCurrentDocumentContext reads newest Field Theory context manifest', ()
     const agentSummary = currentDocumentJson(summary);
     assert.deepEqual(Object.keys(agentSummary).slice(0, 2), ['title', 'kind']);
     assert.equal(agentSummary.sourcePath, '/library/Newer Page.md');
+    assert.equal(agentSummary.lineNumbers.activeSurface, 'rendered');
+    assert.equal(agentSummary.lineNumbers.activeLineKind, null);
+    assert.match(agentSummary.lineNumbers.instructions, /no line map was attached/i);
     assert.equal(agentSummary.updateCommand, 'ft current update --stdin --expected-sha256 <sha>');
     assert.equal('activeDocument' in agentSummary, false);
     assert.equal('documentEdit' in agentSummary, false);
@@ -316,6 +319,12 @@ test('readCurrentDocumentSummary exposes active document line mapping', () => {
     const summary = readCurrentDocumentSummary(manifestPath);
     assert.deepEqual(summary.activeDocument.lineMapping, lineMapping);
     assert.match(formatCurrentDocumentSummary(summary), /lineMapping: available/);
+    const agentJson = currentDocumentJson(summary);
+    assert.equal(agentJson.lineNumbers.activeSurface, 'rendered');
+    assert.equal(agentJson.lineNumbers.activeLineKind, 'renderedVisual');
+    assert.equal(agentJson.lineNumbers.visibleRowsOnly, true);
+    assert.match(agentJson.lineNumbers.instructions, /visible or on-screen line questions/);
+    assert.deepEqual(agentJson.lineNumbers.lines, lineMapping.lines);
   } finally {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   }

--- a/tests/skill.test.ts
+++ b/tests/skill.test.ts
@@ -57,6 +57,9 @@ describe('skill content', () => {
     assert.ok(content.includes('there is one supported path'));
     assert.ok(content.includes('Edit the returned `content` as normal Markdown'));
     assert.ok(content.includes('Send the complete edited Markdown back on stdin'));
+    assert.ok(content.includes('After a successful update, use the newly printed `sha256`'));
+    assert.ok(content.includes('run `ft current --json` again, merge the user'));
+    assert.ok(content.includes('For multiline edits, pipe the content on stdin'));
     assert.ok(content.includes('Never run `ft current update --stdin` by itself'));
     assert.ok(content.includes('Do not use ad hoc `sed -i`'));
     assert.ok(content.includes('sourcePath` as identity/debugging context'));

--- a/tests/skill.test.ts
+++ b/tests/skill.test.ts
@@ -1,6 +1,9 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { skillWithFrontmatter, skillBody } from '../src/skill.js';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { skillWithFrontmatter, skillBody, installSkill } from '../src/skill.js';
 
 describe('skill content', () => {
   it('skillWithFrontmatter includes YAML frontmatter', () => {
@@ -22,6 +25,9 @@ describe('skill content', () => {
     for (const content of [skillWithFrontmatter(), skillBody()]) {
       assert.ok(content.includes('ft paths --json'));
       assert.ok(content.includes('ft status --json'));
+      assert.ok(content.includes('ft current --json'));
+      assert.ok(content.includes('ft current --summary --json'));
+      assert.ok(content.includes('ft current update --stdin --expected-sha256 <sha>'));
       assert.ok(content.includes('ft search'));
       assert.ok(content.includes('ft list'));
       assert.ok(content.includes('ft stats'));
@@ -46,8 +52,46 @@ describe('skill content', () => {
     assert.ok(content.includes('generate -> critique -> score'));
   });
 
+  it('skill teaches agents not to bypass the document edit protocol', () => {
+    const content = skillWithFrontmatter();
+    assert.ok(content.includes('there is one supported path'));
+    assert.ok(content.includes('Edit the returned `content` as normal Markdown'));
+    assert.ok(content.includes('Send the complete edited Markdown back on stdin'));
+    assert.ok(content.includes('Never run `ft current update --stdin` by itself'));
+    assert.ok(content.includes('Do not use ad hoc `sed -i`'));
+    assert.ok(content.includes('sourcePath` as identity/debugging context'));
+    assert.ok(!content.includes('ft current --content-only'));
+    assert.ok(!content.includes('ft current update --file <temp-file>'));
+    assert.ok(!content.includes('ft current --include-content --json'));
+  });
+
   it('skill content ends with newline', () => {
     assert.ok(skillWithFrontmatter().endsWith('\n'));
     assert.ok(skillBody().endsWith('\n'));
+  });
+
+  it('installSkill can force-update existing agent skill files', async () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'ft-skill-home-'));
+    const previousHome = process.env.HOME;
+    process.env.HOME = home;
+
+    try {
+      fs.mkdirSync(path.join(home, '.claude', 'commands'), { recursive: true });
+      fs.mkdirSync(path.join(home, '.codex', 'instructions'), { recursive: true });
+      const claudePath = path.join(home, '.claude', 'commands', 'fieldtheory.md');
+      const codexPath = path.join(home, '.codex', 'instructions', 'fieldtheory.md');
+      fs.writeFileSync(claudePath, 'old claude skill', 'utf-8');
+      fs.writeFileSync(codexPath, 'old codex skill', 'utf-8');
+
+      const results = await installSkill({ force: true });
+
+      assert.deepEqual(results.map((r) => r.action), ['updated', 'updated']);
+      assert.ok(fs.readFileSync(claudePath, 'utf-8').includes('ft current --json'));
+      assert.ok(fs.readFileSync(codexPath, 'utf-8').includes('ft current --json'));
+    } finally {
+      if (previousHome === undefined) delete process.env.HOME;
+      else process.env.HOME = previousHome;
+      fs.rmSync(home, { recursive: true, force: true });
+    }
   });
 });

--- a/tests/skill.test.ts
+++ b/tests/skill.test.ts
@@ -62,6 +62,7 @@ describe('skill content', () => {
     assert.ok(content.includes('For multiline edits, pipe the content on stdin'));
     assert.ok(content.includes('Never run `ft current update --stdin` by itself'));
     assert.ok(content.includes('Do not use ad hoc `sed -i`'));
+    assert.ok(content.includes('the Codex `apply_patch` tool'));
     assert.ok(content.includes('sourcePath` as identity/debugging context'));
     assert.ok(!content.includes('ft current --content-only'));
     assert.ok(!content.includes('ft current update --file <temp-file>'));


### PR DESCRIPTION
## Summary

Current-document editing now gives agents one reliable read shape and one guarded write path. `ft current --json` returns the full Markdown content, source identity, editability, and `version.sha256`; `ft current update` rejects empty writes unless explicitly allowed and can infer piped stdin when a model forgets the `--stdin` flag.

This also prevents agents from editing rendered context caches or stale session files by narrowing which Field Theory Markdown sources are writable.

## Verification

- `npm run build`
- `npx tsx --test tests/cli.test.ts tests/current.test.ts tests/skill.test.ts tests/library.test.ts`
- `npm test`
- live temp-doc smoke for piped `ft current update --expected-sha256 <sha>` without `--stdin`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
