### PR TITLE
feat: add bounded exact bookmark materialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ On first run, `ft sync` extracts your X session from your browser and downloads 
 | `ft list` | Filter by author, date, category, domain, or folder |
 | `ft list --folder <name>` | Show bookmarks in an X bookmark folder |
 | `ft show <id>` | Show one bookmark in detail |
+| `ft materialize <id> --json` | Emit source/component depth and explicit gaps for one exact archived X bookmark |
 | `ft sample <category>` | Random sample from a category |
 | `ft stats` | Top authors, languages, date range |
 | `ft viz` | Terminal dashboard with sparklines, categories, and domains |
@@ -174,6 +175,21 @@ Then ask your agent:
 > "Every day please sync any new X bookmarks using the Field Theory CLI."
 
 Works with Claude Code, Codex, or any agent with shell access.
+
+### Exact bookmark materialization
+
+`ft materialize <id> --json` is a bounded, non-LLM foreground read of one
+archived X bookmark. It emits the root, author/time identity, parent context,
+same-author continuations, quote post, X Article, outbound identities, media
+metadata, exact source-local media hashes when available, and explicit
+unresolved or unavailable component dispositions. Local asset paths are never
+emitted.
+
+Use `--refresh` to refresh only that bookmark's thread through the existing
+signed-in X route, and `--fetch-media` to fetch only that bookmark's media.
+Neither option searches the corpus, classifies content, follows outbound pages,
+or invokes an LLM. Outbound PDFs/pages and media interpretation remain explicit
+gaps for the destination source owner or consuming research system.
 
 ## Scheduling
 

--- a/src/bookmark-materialization.ts
+++ b/src/bookmark-materialization.ts
@@ -78,8 +78,20 @@ function componentId(rootId: string, label: string): string {
   return `${rootId}-${label}-${sha256(label).slice(0, 8)}`.slice(0, 96);
 }
 
+function canonicalJsonValue(value: unknown): unknown {
+  // Materialization payloads are plain JSON values; recursively order object keys
+  // without attempting to serialize runtime objects such as Date, Map, or Set.
+  if (Array.isArray(value)) return value.map(canonicalJsonValue);
+  if (!value || typeof value !== 'object') return value;
+  return Object.fromEntries(
+    Object.keys(value as Record<string, unknown>)
+      .sort()
+      .map((key) => [key, canonicalJsonValue((value as Record<string, unknown>)[key])]),
+  );
+}
+
 function canonicalJson(value: unknown): string {
-  return JSON.stringify(value, Object.keys(value as Record<string, unknown>).sort());
+  return JSON.stringify(canonicalJsonValue(value));
 }
 
 function component(
@@ -333,6 +345,8 @@ async function appendTweetComponents(
     source.text.trim() ? 'source post text recovered' : 'source post text unavailable',
     { hop },
   ));
+  // Source-owned media stays at its tweet's hop; following an outbound locator
+  // crosses into a destination source and therefore increments traversal depth.
   appendOutboundComponents(target, rootId, source, label, hop + 1);
   await appendMediaComponents(target, rootId, source, label, hop, manifest, verificationCache);
 }

--- a/src/bookmark-materialization.ts
+++ b/src/bookmark-materialization.ts
@@ -130,16 +130,19 @@ function sourceTweetLinks(source: SourceTweet): string[] {
   return uniquePublicLinks(source.links ?? []);
 }
 
+function isXArticleLink(value: string): boolean {
+  try {
+    const parsed = new URL(value);
+    return (parsed.hostname === 'x.com' || parsed.hostname === 'twitter.com')
+      && parsed.pathname.startsWith('/i/article/');
+  } catch {
+    return false;
+  }
+}
+
 function xArticleLink(values: string[]): string | undefined {
-  return values.find((value) => {
-    try {
-      const parsed = new URL(value);
-      return (parsed.hostname === 'x.com' || parsed.hostname === 'twitter.com')
-        && parsed.pathname.startsWith('/i/article/');
-    } catch {
-      return false;
-    }
-  });
+  const articleLinks = values.filter(isXArticleLink);
+  return articleLinks.find((value) => new URL(value).hostname === 'x.com') ?? articleLinks[0];
 }
 
 function mediaUrls(mediaObject: BookmarkMediaObject): string[] {
@@ -383,7 +386,7 @@ export async function materializeBookmark(
     authorName: item.authorName,
     postedAt: item.postedAt,
     links: recoveredArticleLink
-      ? rootLinks.filter((link) => link !== recoveredArticleLink)
+      ? rootLinks.filter((link) => !isXArticleLink(link))
       : rootLinks,
     media: item.media,
     mediaObjects: item.mediaObjects,

--- a/src/bookmark-materialization.ts
+++ b/src/bookmark-materialization.ts
@@ -1,9 +1,18 @@
 import { createHash } from 'node:crypto';
-import { readFile } from 'node:fs/promises';
-import type { MediaFetchEntry, MediaFetchManifest } from './bookmark-media.js';
+import {
+  verifyDownloadedMediaEntry,
+  type MediaFetchEntry,
+  type MediaFetchManifest,
+  type MediaVerificationCache,
+} from './bookmark-media.js';
 import type { BookmarkMediaObject, BookmarkRecord, QuotedTweetSnapshot, ThreadTweetSnapshot } from './types.js';
 import type { ExactXRefreshObservation } from './x-materialize.js';
-import { bindArticleLocator, isXArticleLocator, sameSourceLocator } from './source-bindings.js';
+import {
+  bindArticleEnrichment,
+  bindArticleLocator,
+  isXArticleLocator,
+  sameSourceLocator,
+} from './source-bindings.js';
 
 export type MaterializationDisposition =
   | 'used'
@@ -156,19 +165,17 @@ function mediaEntriesFor(
   ));
 }
 
-async function exactAsset(entry: MediaFetchEntry | undefined): Promise<SourceComponent['source_asset']> {
-  if (!entry || entry.status !== 'downloaded' || !entry.localPath) return null;
-  try {
-    const bytes = await readFile(entry.localPath);
-    if (entry.bytes !== undefined && entry.bytes !== bytes.byteLength) return null;
-    return {
-      sha256: sha256(bytes),
-      bytes: bytes.byteLength,
-      content_type: entry.contentType ?? null,
-    };
-  } catch {
-    return null;
-  }
+async function exactAsset(
+  entry: MediaFetchEntry | undefined,
+  verificationCache: MediaVerificationCache,
+): Promise<SourceComponent['source_asset']> {
+  if (!entry) return null;
+  const verified = await verifyDownloadedMediaEntry(entry, verificationCache);
+  return verified ? {
+    sha256: verified.sha256,
+    bytes: verified.bytes,
+    content_type: entry.contentType ?? null,
+  } : null;
 }
 
 async function appendMediaComponents(
@@ -178,6 +185,7 @@ async function appendMediaComponents(
   relationPrefix: string,
   hop: number,
   manifest: MediaFetchManifest | null,
+  verificationCache: MediaVerificationCache,
 ): Promise<void> {
   const entries = mediaEntriesFor(source, manifest);
   const objects = source.mediaObjects ?? [];
@@ -209,7 +217,7 @@ async function appendMediaComponents(
     for (const [assetIndex, candidate] of assets.entries()) {
       const locator = candidate.url!;
       const matchingEntry = entries.find((entry) => entry.sourceUrl === locator);
-      const asset = await exactAsset(matchingEntry);
+      const asset = await exactAsset(matchingEntry, verificationCache);
       target.push(component(
         rootId,
         `${relationPrefix}-media-${objectIndex + 1}-asset-${assetIndex + 1}`,
@@ -251,7 +259,7 @@ async function appendMediaComponents(
 
   for (const [index, locator] of fallbackUrls.entries()) {
     const matchingEntry = entries.find((entry) => entry.sourceUrl === locator);
-    const asset = await exactAsset(matchingEntry);
+    const asset = await exactAsset(matchingEntry, verificationCache);
     target.push(component(
       rootId,
       `${relationPrefix}-fallback-media-${index + 1}`,
@@ -313,6 +321,7 @@ async function appendTweetComponents(
   relation: string,
   hop: number,
   manifest: MediaFetchManifest | null,
+  verificationCache: MediaVerificationCache,
 ): Promise<void> {
   target.push(component(
     rootId,
@@ -325,7 +334,7 @@ async function appendTweetComponents(
     { hop },
   ));
   appendOutboundComponents(target, rootId, source, label, hop + 1);
-  await appendMediaComponents(target, rootId, source, label, hop, manifest);
+  await appendMediaComponents(target, rootId, source, label, hop, manifest, verificationCache);
 }
 
 function quotedSource(value: QuotedTweetSnapshot): SourceTweet {
@@ -363,11 +372,13 @@ export async function materializeBookmark(
 ): Promise<BookmarkMaterialization> {
   const rootId = `x-${sha256(item.tweetId).slice(0, 20)}`;
   const components: SourceComponent[] = [];
+  const verificationCache: MediaVerificationCache = new Map();
   const rootLinks = uniquePublicLinks(item.links ?? []);
-  const recoveredArticleLink = item.articleText
-    && item.articleSourceTweetId === item.tweetId
-      ? bindArticleLocator(rootLinks, item.articleLocator)
-      : undefined;
+  const recoveredArticleLink = bindArticleEnrichment(item.tweetId, rootLinks, {
+    articleText: item.articleText,
+    sourceTweetId: item.articleSourceTweetId,
+    sourceLocator: item.articleLocator,
+  });
   const boundManifest = manifest
     ? { ...manifest, entries: manifest.entries.filter((entry) => entry.bookmarkId === item.id) }
     : null;
@@ -399,7 +410,7 @@ export async function materializeBookmark(
     'used',
     'exact stored root identity recovered',
   ));
-  await appendTweetComponents(components, rootId, rootSource, 'post', 'root_post', 1, boundManifest);
+  await appendTweetComponents(components, rootId, rootSource, 'post', 'root_post', 1, boundManifest, verificationCache);
 
   for (const [index, row] of (item.threadContext ?? []).entries()) {
     await appendTweetComponents(
@@ -410,6 +421,7 @@ export async function materializeBookmark(
       'thread_parent_context',
       1,
       boundManifest,
+      verificationCache,
     );
   }
   for (const [index, row] of (item.threadBelow ?? []).entries()) {
@@ -421,6 +433,7 @@ export async function materializeBookmark(
       'thread_same_author_continuation',
       1,
       boundManifest,
+      verificationCache,
     );
   }
   if (!item.threadExpandedAt) {
@@ -463,6 +476,7 @@ export async function materializeBookmark(
         'quoted_post',
         1,
         boundManifest,
+        verificationCache,
       );
     } else {
       components.push(component(

--- a/src/bookmark-materialization.ts
+++ b/src/bookmark-materialization.ts
@@ -130,6 +130,18 @@ function sourceTweetLinks(source: SourceTweet): string[] {
   return uniquePublicLinks(source.links ?? []);
 }
 
+function xArticleLink(values: string[]): string | undefined {
+  return values.find((value) => {
+    try {
+      const parsed = new URL(value);
+      return (parsed.hostname === 'x.com' || parsed.hostname === 'twitter.com')
+        && parsed.pathname.startsWith('/i/article/');
+    } catch {
+      return false;
+    }
+  });
+}
+
 function mediaUrls(mediaObject: BookmarkMediaObject): string[] {
   const variantUrls = (mediaObject.videoVariants ?? mediaObject.variants ?? [])
     .map((variant) => variant.url);
@@ -361,6 +373,8 @@ export async function materializeBookmark(
 ): Promise<BookmarkMaterialization> {
   const rootId = `x-${sha256(item.tweetId).slice(0, 20)}`;
   const components: SourceComponent[] = [];
+  const rootLinks = uniquePublicLinks(item.links ?? []);
+  const recoveredArticleLink = item.articleText ? xArticleLink(rootLinks) : undefined;
   const rootSource: SourceTweet = {
     id: item.tweetId,
     text: item.text,
@@ -368,7 +382,9 @@ export async function materializeBookmark(
     authorHandle: item.authorHandle,
     authorName: item.authorName,
     postedAt: item.postedAt,
-    links: uniquePublicLinks(item.links ?? []),
+    links: recoveredArticleLink
+      ? rootLinks.filter((link) => link !== recoveredArticleLink)
+      : rootLinks,
     media: item.media,
     mediaObjects: item.mediaObjects,
   };
@@ -470,7 +486,7 @@ export async function materializeBookmark(
       rootId,
       'x-article',
       'embedded_x_article',
-      item.url,
+      recoveredArticleLink ?? item.url,
       item.articleText,
       'used',
       'X long-form article content recovered',

--- a/src/bookmark-materialization.ts
+++ b/src/bookmark-materialization.ts
@@ -117,6 +117,15 @@ function uniquePublicLinks(values: Array<string | undefined>): string[] {
   }))].sort();
 }
 
+function isPublicHttpUrl(value: string): boolean {
+  try {
+    const parsed = new URL(value);
+    return parsed.protocol === 'https:' || parsed.protocol === 'http:';
+  } catch {
+    return false;
+  }
+}
+
 function sourceTweetLinks(source: SourceTweet): string[] {
   return uniquePublicLinks(source.links ?? []);
 }
@@ -171,48 +180,101 @@ async function appendMediaComponents(
   const entries = mediaEntriesFor(source, manifest);
   const objects = source.mediaObjects ?? [];
   const fallbackUrls = objects.length === 0 ? uniquePublicLinks(source.media ?? []) : [];
-  const rows: Array<{ metadata: Record<string, unknown>; urls: string[] }> = [
-    ...objects.map((item) => ({
-      metadata: {
-        type: item.type ?? null,
-        width: item.width ?? null,
-        height: item.height ?? null,
-        alt_text: item.altText ?? null,
-      },
-      urls: mediaUrls(item),
-    })),
-    ...fallbackUrls.map((url) => ({ metadata: { type: null }, urls: [url] })),
-  ];
+  for (const [objectIndex, item] of objects.entries()) {
+    const candidates: Array<{
+      url?: string;
+      role: 'preview' | 'media' | 'video_variant';
+      contentType?: string;
+      bitrate?: number;
+    }> = [
+      { url: item.previewUrl, role: 'preview' },
+      { url: item.url, role: 'media' },
+      { url: item.mediaUrl, role: 'media' },
+      ...(item.videoVariants ?? item.variants ?? []).map((variant) => ({
+        url: variant.url,
+        role: 'video_variant' as const,
+        contentType: variant.contentType,
+        bitrate: variant.bitrate,
+      })),
+    ];
+    const seen = new Set<string>();
+    const assets = candidates.filter((candidate) => {
+      if (!candidate.url || !isPublicHttpUrl(candidate.url) || seen.has(candidate.url)) return false;
+      seen.add(candidate.url);
+      return true;
+    });
 
-  for (const [index, row] of rows.entries()) {
-    const locator = row.urls[0] ?? source.url;
-    const matchingEntry = entries.find((entry) => row.urls.includes(entry.sourceUrl));
-    const asset = await exactAsset(matchingEntry);
+    for (const [assetIndex, candidate] of assets.entries()) {
+      const locator = candidate.url!;
+      const matchingEntry = entries.find((entry) => entry.sourceUrl === locator);
+      const asset = await exactAsset(matchingEntry);
+      target.push(component(
+        rootId,
+        `${relationPrefix}-media-${objectIndex + 1}-asset-${assetIndex + 1}`,
+        `${relationPrefix}_attached_media`,
+        locator,
+        canonicalJson({
+          type: item.type ?? null,
+          width: item.width ?? null,
+          height: item.height ?? null,
+          alt_text: item.altText ?? null,
+          asset_role: candidate.role,
+          declared_content_type: candidate.contentType ?? null,
+          bitrate: candidate.bitrate ?? null,
+          source_url: locator,
+        }),
+        'used',
+        asset ? 'media metadata and exact source-local asset recovered' : 'media metadata recovered; exact source-local asset unavailable',
+        {
+          hop,
+          achievedDepth: asset
+            ? 'exact media metadata plus source-local asset hash and byte count'
+            : 'exact media metadata only; source bytes are not recovered',
+          sourceAsset: asset,
+        },
+      ));
+    }
+    const locator = assets[0]?.url ?? source.url;
     target.push(component(
       rootId,
-      `${relationPrefix}-media-${index + 1}`,
-      `${relationPrefix}_attached_media`,
-      locator,
-      canonicalJson({ ...row.metadata, source_urls: row.urls }),
-      'used',
-      asset ? 'media metadata and exact source-local asset recovered' : 'media metadata recovered; exact source-local asset unavailable',
-      {
-        hop,
-        achievedDepth: asset
-          ? 'exact media metadata plus source-local asset hash and byte count'
-          : 'exact media metadata only; source bytes are not recovered',
-        sourceAsset: asset,
-      },
-    ));
-    target.push(component(
-      rootId,
-      `${relationPrefix}-media-${index + 1}-interpretation`,
+      `${relationPrefix}-media-${objectIndex + 1}-interpretation`,
       `${relationPrefix}_media_interpretation`,
       locator,
       null,
       'unresolved',
       'OCR, transcript, captions, or material visual interpretation are not produced by Field Theory',
       { hop, achievedDepth: 'media identity and metadata only' },
+    ));
+  }
+
+  for (const [index, locator] of fallbackUrls.entries()) {
+    const matchingEntry = entries.find((entry) => entry.sourceUrl === locator);
+    const asset = await exactAsset(matchingEntry);
+    target.push(component(
+      rootId,
+      `${relationPrefix}-fallback-media-${index + 1}`,
+      `${relationPrefix}_attached_media`,
+      locator,
+      canonicalJson({ type: null, asset_role: 'media', source_url: locator }),
+      'used',
+      asset ? 'media identity and exact source-local asset recovered' : 'media identity recovered; exact source-local asset unavailable',
+      {
+        hop,
+        achievedDepth: asset
+          ? 'exact media identity plus source-local asset hash and byte count'
+          : 'exact media identity only; source bytes are not recovered',
+        sourceAsset: asset,
+      },
+    ));
+    target.push(component(
+      rootId,
+      `${relationPrefix}-fallback-media-${index + 1}-interpretation`,
+      `${relationPrefix}_media_interpretation`,
+      locator,
+      null,
+      'unresolved',
+      'OCR, transcript, captions, or material visual interpretation are not produced by Field Theory',
+      { hop, achievedDepth: 'media identity only' },
     ));
   }
 }
@@ -413,7 +475,11 @@ export async function materializeBookmark(
       'used',
       'X long-form article content recovered',
     ));
-  } else if ((item.links ?? []).some((link) => link.includes('x.com/i/article/'))) {
+  } else if (
+    item.articleTitle
+    || item.articleSite
+    || (item.links ?? []).some((link) => link.includes('x.com/i/article/'))
+  ) {
     components.push(component(
       rootId,
       'x-article',

--- a/src/bookmark-materialization.ts
+++ b/src/bookmark-materialization.ts
@@ -3,6 +3,7 @@ import { readFile } from 'node:fs/promises';
 import type { MediaFetchEntry, MediaFetchManifest } from './bookmark-media.js';
 import type { BookmarkMediaObject, BookmarkRecord, QuotedTweetSnapshot, ThreadTweetSnapshot } from './types.js';
 import type { ExactXRefreshObservation } from './x-materialize.js';
+import { bindArticleLocator, isXArticleLocator, sameSourceLocator } from './source-bindings.js';
 
 export type MaterializationDisposition =
   | 'used'
@@ -129,37 +130,6 @@ function isPublicHttpUrl(value: string): boolean {
 
 function sourceTweetLinks(source: SourceTweet): string[] {
   return uniquePublicLinks(source.links ?? []);
-}
-
-function isXArticleLink(value: string): boolean {
-  try {
-    const parsed = new URL(value);
-    return (parsed.hostname === 'x.com' || parsed.hostname === 'twitter.com')
-      && parsed.pathname.startsWith('/i/article/');
-  } catch {
-    return false;
-  }
-}
-
-function xArticleLink(values: string[]): string | undefined {
-  const articleLinks = values.filter(isXArticleLink);
-  const identities = new Set(articleLinks.map(xArticleIdentity).filter((value): value is string => value !== null));
-  if (identities.size !== 1) return undefined;
-  const identity = identities.values().next().value as string;
-  return articleLinks.find((value) => (
-    new URL(value).hostname === 'x.com' && xArticleIdentity(value) === identity
-  )) ?? articleLinks[0];
-}
-
-function xArticleIdentity(value: string): string | null {
-  if (!isXArticleLink(value)) return null;
-  const parsed = new URL(value);
-  return parsed.pathname.replace(/\/+$/, '');
-}
-
-function isSameXArticleLink(value: string, recovered: string): boolean {
-  const valueIdentity = xArticleIdentity(value);
-  return valueIdentity !== null && valueIdentity === xArticleIdentity(recovered);
 }
 
 function mediaUrls(mediaObject: BookmarkMediaObject): string[] {
@@ -394,7 +364,13 @@ export async function materializeBookmark(
   const rootId = `x-${sha256(item.tweetId).slice(0, 20)}`;
   const components: SourceComponent[] = [];
   const rootLinks = uniquePublicLinks(item.links ?? []);
-  const recoveredArticleLink = item.articleText ? xArticleLink(item.links ?? []) : undefined;
+  const recoveredArticleLink = item.articleText
+    && item.articleSourceTweetId === item.tweetId
+      ? bindArticleLocator(rootLinks, item.articleLocator)
+      : undefined;
+  const boundManifest = manifest
+    ? { ...manifest, entries: manifest.entries.filter((entry) => entry.bookmarkId === item.id) }
+    : null;
   const rootSource: SourceTweet = {
     id: item.tweetId,
     text: item.text,
@@ -403,7 +379,7 @@ export async function materializeBookmark(
     authorName: item.authorName,
     postedAt: item.postedAt,
     links: recoveredArticleLink
-      ? rootLinks.filter((link) => !isSameXArticleLink(link, recoveredArticleLink))
+      ? rootLinks.filter((link) => !sameSourceLocator(link, recoveredArticleLink))
       : rootLinks,
     media: item.media,
     mediaObjects: item.mediaObjects,
@@ -423,7 +399,7 @@ export async function materializeBookmark(
     'used',
     'exact stored root identity recovered',
   ));
-  await appendTweetComponents(components, rootId, rootSource, 'post', 'root_post', 1, manifest);
+  await appendTweetComponents(components, rootId, rootSource, 'post', 'root_post', 1, boundManifest);
 
   for (const [index, row] of (item.threadContext ?? []).entries()) {
     await appendTweetComponents(
@@ -433,7 +409,7 @@ export async function materializeBookmark(
       `thread-context-${index + 1}`,
       'thread_parent_context',
       1,
-      manifest,
+      boundManifest,
     );
   }
   for (const [index, row] of (item.threadBelow ?? []).entries()) {
@@ -444,7 +420,7 @@ export async function materializeBookmark(
       `thread-continuation-${index + 1}`,
       'thread_same_author_continuation',
       1,
-      manifest,
+      boundManifest,
     );
   }
   if (!item.threadExpandedAt) {
@@ -478,7 +454,7 @@ export async function materializeBookmark(
   }
 
   if (item.quotedStatusId) {
-    if (item.quotedTweet) {
+    if (item.quotedTweet?.id === item.quotedStatusId) {
       await appendTweetComponents(
         components,
         rootId,
@@ -486,7 +462,7 @@ export async function materializeBookmark(
         'quoted-post',
         'quoted_post',
         1,
-        manifest,
+        boundManifest,
       );
     } else {
       components.push(component(
@@ -501,29 +477,34 @@ export async function materializeBookmark(
     }
   }
 
-  if (item.articleText) {
+  if (item.articleText && recoveredArticleLink) {
     components.push(component(
       rootId,
       'x-article',
       'embedded_x_article',
-      recoveredArticleLink ?? item.url,
+      recoveredArticleLink,
       item.articleText,
       'used',
       'X long-form article content recovered',
     ));
   } else if (
-    item.articleTitle
+    item.articleText
+    || item.articleTitle
     || item.articleSite
-    || (item.links ?? []).some((link) => link.includes('x.com/i/article/'))
+    || (item.links ?? []).some(isXArticleLocator)
   ) {
     components.push(component(
       rootId,
       'x-article',
       'embedded_x_article',
-      (item.links ?? []).find((link) => link.includes('x.com/i/article/')) ?? item.url,
+      bindArticleLocator(rootLinks, item.articleLocator)
+        ?? rootLinks.find(isXArticleLocator)
+        ?? item.url,
       null,
       'unresolved',
-      'X long-form article identity exists but article content is absent',
+      item.articleText
+        ? 'X long-form article content is present but source-tweet or locator identity is unbound'
+        : 'X long-form article identity exists but article content is absent',
     ));
   }
 

--- a/src/bookmark-materialization.ts
+++ b/src/bookmark-materialization.ts
@@ -143,7 +143,23 @@ function isXArticleLink(value: string): boolean {
 
 function xArticleLink(values: string[]): string | undefined {
   const articleLinks = values.filter(isXArticleLink);
-  return articleLinks.find((value) => new URL(value).hostname === 'x.com') ?? articleLinks[0];
+  const first = articleLinks[0];
+  if (!first) return undefined;
+  const identity = xArticleIdentity(first);
+  return articleLinks.find((value) => (
+    new URL(value).hostname === 'x.com' && xArticleIdentity(value) === identity
+  )) ?? first;
+}
+
+function xArticleIdentity(value: string): string | null {
+  if (!isXArticleLink(value)) return null;
+  const parsed = new URL(value);
+  return parsed.pathname.replace(/\/+$/, '');
+}
+
+function isSameXArticleLink(value: string, recovered: string): boolean {
+  const valueIdentity = xArticleIdentity(value);
+  return valueIdentity !== null && valueIdentity === xArticleIdentity(recovered);
 }
 
 function mediaUrls(mediaObject: BookmarkMediaObject): string[] {
@@ -378,7 +394,7 @@ export async function materializeBookmark(
   const rootId = `x-${sha256(item.tweetId).slice(0, 20)}`;
   const components: SourceComponent[] = [];
   const rootLinks = uniquePublicLinks(item.links ?? []);
-  const recoveredArticleLink = item.articleText ? xArticleLink(rootLinks) : undefined;
+  const recoveredArticleLink = item.articleText ? xArticleLink(item.links ?? []) : undefined;
   const rootSource: SourceTweet = {
     id: item.tweetId,
     text: item.text,
@@ -387,7 +403,7 @@ export async function materializeBookmark(
     authorName: item.authorName,
     postedAt: item.postedAt,
     links: recoveredArticleLink
-      ? rootLinks.filter((link) => !isXArticleLink(link))
+      ? rootLinks.filter((link) => !isSameXArticleLink(link, recoveredArticleLink))
       : rootLinks,
     media: item.media,
     mediaObjects: item.mediaObjects,

--- a/src/bookmark-materialization.ts
+++ b/src/bookmark-materialization.ts
@@ -1,0 +1,448 @@
+import { createHash } from 'node:crypto';
+import { readFile } from 'node:fs/promises';
+import type { MediaFetchEntry, MediaFetchManifest } from './bookmark-media.js';
+import type { BookmarkMediaObject, BookmarkRecord, QuotedTweetSnapshot, ThreadTweetSnapshot } from './types.js';
+import type { ExactXRefreshObservation } from './x-materialize.js';
+
+export type MaterializationDisposition =
+  | 'used'
+  | 'duplicate'
+  | 'contradicted'
+  | 'unavailable'
+  | 'excluded'
+  | 'unresolved';
+
+export interface SourceComponent {
+  component_id: string;
+  relation: string;
+  traversal_hop: number;
+  mandatory_direct: boolean;
+  materiality: 'answer_required' | 'material';
+  achieved_depth: string;
+  source_locator: string;
+  content: string | null;
+  disposition: MaterializationDisposition;
+  disposition_reason: string;
+  source_asset?: {
+    sha256: string;
+    bytes: number;
+    content_type: string | null;
+  } | null;
+}
+
+export interface BookmarkMaterialization {
+  root_id: string;
+  source_family: 'field_theory_x';
+  source_id: string;
+  locator: string;
+  author_handle: string | null;
+  posted_at: string | null;
+  source_cutoff: string | null;
+  achieved_depth: string;
+  topology: {
+    enumeration_complete: boolean;
+    component_count: number;
+    thread_context_count: number;
+    thread_continuation_count: number;
+  };
+  components: SourceComponent[];
+}
+
+interface SourceTweet {
+  id: string;
+  text: string;
+  url: string;
+  authorHandle?: string;
+  authorName?: string;
+  postedAt?: string | null;
+  links?: string[];
+  media?: string[];
+  mediaObjects?: BookmarkMediaObject[];
+}
+
+function sha256(value: string | Buffer): string {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+function componentId(rootId: string, label: string): string {
+  return `${rootId}-${label}-${sha256(label).slice(0, 8)}`.slice(0, 96);
+}
+
+function canonicalJson(value: unknown): string {
+  return JSON.stringify(value, Object.keys(value as Record<string, unknown>).sort());
+}
+
+function component(
+  rootId: string,
+  label: string,
+  relation: string,
+  locator: string,
+  content: string | null,
+  disposition: MaterializationDisposition,
+  dispositionReason: string,
+  options: {
+    hop?: number;
+    mandatory?: boolean;
+    materiality?: 'answer_required' | 'material';
+    achievedDepth?: string;
+    sourceAsset?: SourceComponent['source_asset'];
+  } = {},
+): SourceComponent {
+  return {
+    component_id: componentId(rootId, label),
+    relation,
+    traversal_hop: options.hop ?? 1,
+    mandatory_direct: options.mandatory ?? true,
+    materiality: options.materiality ?? 'answer_required',
+    achieved_depth: options.achievedDepth ?? (disposition === 'used'
+      ? 'exact source-owned representation at materialization time'
+      : 'identity only; source content was not recovered'),
+    source_locator: locator,
+    content,
+    disposition,
+    disposition_reason: dispositionReason,
+    ...(options.sourceAsset !== undefined ? { source_asset: options.sourceAsset } : {}),
+  };
+}
+
+function uniquePublicLinks(values: Array<string | undefined>): string[] {
+  return [...new Set(values.filter((value): value is string => {
+    if (!value) return false;
+    try {
+      const parsed = new URL(value);
+      return parsed.protocol === 'https:' || parsed.protocol === 'http:';
+    } catch {
+      return false;
+    }
+  }))].sort();
+}
+
+function sourceTweetLinks(source: SourceTweet): string[] {
+  return uniquePublicLinks(source.links ?? []);
+}
+
+function mediaUrls(mediaObject: BookmarkMediaObject): string[] {
+  const variantUrls = (mediaObject.videoVariants ?? mediaObject.variants ?? [])
+    .map((variant) => variant.url);
+  return uniquePublicLinks([
+    mediaObject.previewUrl,
+    mediaObject.url,
+    mediaObject.mediaUrl,
+    ...variantUrls,
+  ]);
+}
+
+function mediaEntriesFor(
+  source: SourceTweet,
+  manifest: MediaFetchManifest | null,
+): MediaFetchEntry[] {
+  const allowed = new Set([
+    ...(source.media ?? []),
+    ...(source.mediaObjects ?? []).flatMap(mediaUrls),
+  ]);
+  return (manifest?.entries ?? []).filter((entry) => (
+    entry.tweetId === source.id && allowed.has(entry.sourceUrl)
+  ));
+}
+
+async function exactAsset(entry: MediaFetchEntry | undefined): Promise<SourceComponent['source_asset']> {
+  if (!entry || entry.status !== 'downloaded' || !entry.localPath) return null;
+  try {
+    const bytes = await readFile(entry.localPath);
+    if (entry.bytes !== undefined && entry.bytes !== bytes.byteLength) return null;
+    return {
+      sha256: sha256(bytes),
+      bytes: bytes.byteLength,
+      content_type: entry.contentType ?? null,
+    };
+  } catch {
+    return null;
+  }
+}
+
+async function appendMediaComponents(
+  target: SourceComponent[],
+  rootId: string,
+  source: SourceTweet,
+  relationPrefix: string,
+  hop: number,
+  manifest: MediaFetchManifest | null,
+): Promise<void> {
+  const entries = mediaEntriesFor(source, manifest);
+  const objects = source.mediaObjects ?? [];
+  const fallbackUrls = objects.length === 0 ? uniquePublicLinks(source.media ?? []) : [];
+  const rows: Array<{ metadata: Record<string, unknown>; urls: string[] }> = [
+    ...objects.map((item) => ({
+      metadata: {
+        type: item.type ?? null,
+        width: item.width ?? null,
+        height: item.height ?? null,
+        alt_text: item.altText ?? null,
+      },
+      urls: mediaUrls(item),
+    })),
+    ...fallbackUrls.map((url) => ({ metadata: { type: null }, urls: [url] })),
+  ];
+
+  for (const [index, row] of rows.entries()) {
+    const locator = row.urls[0] ?? source.url;
+    const matchingEntry = entries.find((entry) => row.urls.includes(entry.sourceUrl));
+    const asset = await exactAsset(matchingEntry);
+    target.push(component(
+      rootId,
+      `${relationPrefix}-media-${index + 1}`,
+      `${relationPrefix}_attached_media`,
+      locator,
+      canonicalJson({ ...row.metadata, source_urls: row.urls }),
+      'used',
+      asset ? 'media metadata and exact source-local asset recovered' : 'media metadata recovered; exact source-local asset unavailable',
+      {
+        hop,
+        achievedDepth: asset
+          ? 'exact media metadata plus source-local asset hash and byte count'
+          : 'exact media metadata only; source bytes are not recovered',
+        sourceAsset: asset,
+      },
+    ));
+    target.push(component(
+      rootId,
+      `${relationPrefix}-media-${index + 1}-interpretation`,
+      `${relationPrefix}_media_interpretation`,
+      locator,
+      null,
+      'unresolved',
+      'OCR, transcript, captions, or material visual interpretation are not produced by Field Theory',
+      { hop, achievedDepth: 'media identity and metadata only' },
+    ));
+  }
+}
+
+function appendOutboundComponents(
+  target: SourceComponent[],
+  rootId: string,
+  source: SourceTweet,
+  relationPrefix: string,
+  hop: number,
+): void {
+  for (const [index, link] of sourceTweetLinks(source).entries()) {
+    const isPdf = /\.pdf(?:$|[?#])/i.test(link);
+    target.push(component(
+      rootId,
+      `${relationPrefix}-link-${index + 1}`,
+      isPdf ? `${relationPrefix}_outbound_pdf` : `${relationPrefix}_outbound_link`,
+      link,
+      link,
+      'unresolved',
+      isPdf
+        ? 'PDF identity recovered; PDF text, figures, and tables require the destination source owner'
+        : 'outbound identity recovered; destination content requires the destination source owner',
+      { hop, materiality: 'material', achievedDepth: 'exact outbound identity only' },
+    ));
+  }
+}
+
+async function appendTweetComponents(
+  target: SourceComponent[],
+  rootId: string,
+  source: SourceTweet,
+  label: string,
+  relation: string,
+  hop: number,
+  manifest: MediaFetchManifest | null,
+): Promise<void> {
+  target.push(component(
+    rootId,
+    label,
+    relation,
+    source.url,
+    source.text,
+    source.text.trim() ? 'used' : 'unavailable',
+    source.text.trim() ? 'source post text recovered' : 'source post text unavailable',
+    { hop },
+  ));
+  appendOutboundComponents(target, rootId, source, label, hop + 1);
+  await appendMediaComponents(target, rootId, source, label, hop, manifest);
+}
+
+function quotedSource(value: QuotedTweetSnapshot): SourceTweet {
+  return {
+    id: value.id,
+    text: value.text,
+    url: value.url,
+    authorHandle: value.authorHandle,
+    authorName: value.authorName,
+    postedAt: value.postedAt,
+    links: value.links,
+    media: value.media,
+    mediaObjects: value.mediaObjects,
+  };
+}
+
+function threadSource(value: ThreadTweetSnapshot): SourceTweet {
+  return {
+    id: value.id,
+    text: value.text,
+    url: value.url,
+    authorHandle: value.authorHandle,
+    authorName: value.authorName,
+    postedAt: value.postedAt,
+    links: value.links,
+    media: value.media,
+    mediaObjects: value.mediaObjects,
+  };
+}
+
+export async function materializeBookmark(
+  item: BookmarkRecord,
+  manifest: MediaFetchManifest | null = null,
+  refresh: ExactXRefreshObservation | null = null,
+): Promise<BookmarkMaterialization> {
+  const rootId = `x-${sha256(item.tweetId).slice(0, 20)}`;
+  const components: SourceComponent[] = [];
+  const rootSource: SourceTweet = {
+    id: item.tweetId,
+    text: item.text,
+    url: item.url,
+    authorHandle: item.authorHandle,
+    authorName: item.authorName,
+    postedAt: item.postedAt,
+    links: uniquePublicLinks(item.links ?? []),
+    media: item.media,
+    mediaObjects: item.mediaObjects,
+  };
+
+  components.push(component(
+    rootId,
+    'author-time-identity',
+    'root_author_time_identity',
+    item.url,
+    canonicalJson({
+      author_handle: item.authorHandle ?? null,
+      author_name: item.authorName ?? null,
+      posted_at: item.postedAt ?? null,
+      source_id: item.tweetId,
+    }),
+    'used',
+    'exact stored root identity recovered',
+  ));
+  await appendTweetComponents(components, rootId, rootSource, 'post', 'root_post', 1, manifest);
+
+  for (const [index, row] of (item.threadContext ?? []).entries()) {
+    await appendTweetComponents(
+      components,
+      rootId,
+      threadSource(row),
+      `thread-context-${index + 1}`,
+      'thread_parent_context',
+      1,
+      manifest,
+    );
+  }
+  for (const [index, row] of (item.threadBelow ?? []).entries()) {
+    await appendTweetComponents(
+      components,
+      rootId,
+      threadSource(row),
+      `thread-continuation-${index + 1}`,
+      'thread_same_author_continuation',
+      1,
+      manifest,
+    );
+  }
+  if (!item.threadExpandedAt) {
+    components.push(component(
+      rootId,
+      'thread-completeness',
+      'thread_completeness',
+      item.url,
+      null,
+      item.threadExpansionFailedAt ? 'unavailable' : 'unresolved',
+      item.threadExpansionFailedAt
+        ? 'exact thread expansion ended in a permanent source-local failure'
+        : 'exact thread expansion has not completed for this root',
+      { achievedDepth: 'root identity only; thread topology is not complete' },
+    ));
+  }
+
+  if (refresh) {
+    components.push(component(
+      rootId,
+      'source-currentness',
+      'source_currentness',
+      item.url,
+      canonicalJson(refresh),
+      refresh.status === 'complete' ? 'used' : refresh.status === 'unavailable' ? 'unavailable' : 'unresolved',
+      refresh.status === 'complete'
+        ? 'exact root and bounded thread traversal completed on the current source route'
+        : 'exact source refresh left one or more currentness or topology gaps',
+      { achievedDepth: `exact source refresh status: ${refresh.status}` },
+    ));
+  }
+
+  if (item.quotedStatusId) {
+    if (item.quotedTweet) {
+      await appendTweetComponents(
+        components,
+        rootId,
+        quotedSource(item.quotedTweet),
+        'quoted-post',
+        'quoted_post',
+        1,
+        manifest,
+      );
+    } else {
+      components.push(component(
+        rootId,
+        'quoted-post',
+        'quoted_post',
+        `https://x.com/i/status/${item.quotedStatusId}`,
+        null,
+        'unavailable',
+        'quoted post identity exists but source content is absent',
+      ));
+    }
+  }
+
+  if (item.articleText) {
+    components.push(component(
+      rootId,
+      'x-article',
+      'embedded_x_article',
+      item.url,
+      item.articleText,
+      'used',
+      'X long-form article content recovered',
+    ));
+  } else if ((item.links ?? []).some((link) => link.includes('x.com/i/article/'))) {
+    components.push(component(
+      rootId,
+      'x-article',
+      'embedded_x_article',
+      (item.links ?? []).find((link) => link.includes('x.com/i/article/')) ?? item.url,
+      null,
+      'unresolved',
+      'X long-form article identity exists but article content is absent',
+    ));
+  }
+
+  const incomplete = components.some((row) => row.disposition === 'unavailable' || row.disposition === 'unresolved');
+  return {
+    root_id: rootId,
+    source_family: 'field_theory_x',
+    source_id: item.tweetId,
+    locator: item.url,
+    author_handle: item.authorHandle ?? null,
+    posted_at: item.postedAt ?? null,
+    source_cutoff: item.threadExpandedAt ?? item.enrichedAt ?? item.syncedAt ?? null,
+    achieved_depth: incomplete
+      ? 'source-owned root and enumerated components with explicit unresolved depth'
+      : 'source-owned root and enumerated components recovered',
+    topology: {
+      enumeration_complete: Boolean(item.threadExpandedAt),
+      component_count: components.length,
+      thread_context_count: item.threadContext?.length ?? 0,
+      thread_continuation_count: item.threadBelow?.length ?? 0,
+    },
+    components,
+  };
+}

--- a/src/bookmark-materialization.ts
+++ b/src/bookmark-materialization.ts
@@ -143,12 +143,12 @@ function isXArticleLink(value: string): boolean {
 
 function xArticleLink(values: string[]): string | undefined {
   const articleLinks = values.filter(isXArticleLink);
-  const first = articleLinks[0];
-  if (!first) return undefined;
-  const identity = xArticleIdentity(first);
+  const identities = new Set(articleLinks.map(xArticleIdentity).filter((value): value is string => value !== null));
+  if (identities.size !== 1) return undefined;
+  const identity = identities.values().next().value as string;
   return articleLinks.find((value) => (
     new URL(value).hostname === 'x.com' && xArticleIdentity(value) === identity
-  )) ?? first;
+  )) ?? articleLinks[0];
 }
 
 function xArticleIdentity(value: string): string | null {

--- a/src/bookmark-materialization.ts
+++ b/src/bookmark-materialization.ts
@@ -88,11 +88,12 @@ function component(
     sourceAsset?: SourceComponent['source_asset'];
   } = {},
 ): SourceComponent {
+  const hop = options.hop ?? 1;
   return {
     component_id: componentId(rootId, label),
     relation,
-    traversal_hop: options.hop ?? 1,
-    mandatory_direct: options.mandatory ?? true,
+    traversal_hop: hop,
+    mandatory_direct: options.mandatory ?? hop === 1,
     materiality: options.materiality ?? 'answer_required',
     achieved_depth: options.achievedDepth ?? (disposition === 'used'
       ? 'exact source-owned representation at materialization time'

--- a/src/bookmark-materialization.ts
+++ b/src/bookmark-materialization.ts
@@ -8,7 +8,7 @@ import {
 import type { BookmarkMediaObject, BookmarkRecord, QuotedTweetSnapshot, ThreadTweetSnapshot } from './types.js';
 import type { ExactXRefreshObservation } from './x-materialize.js';
 import {
-  bindArticleEnrichment,
+  bindXArticleEnrichment,
   bindArticleLocator,
   isXArticleLocator,
   sameSourceLocator,
@@ -374,11 +374,18 @@ export async function materializeBookmark(
   const components: SourceComponent[] = [];
   const verificationCache: MediaVerificationCache = new Map();
   const rootLinks = uniquePublicLinks(item.links ?? []);
-  const recoveredArticleLink = bindArticleEnrichment(item.tweetId, rootLinks, {
+  const recoveredArticleLink = bindXArticleEnrichment(item.tweetId, rootLinks, {
     articleText: item.articleText,
     sourceTweetId: item.articleSourceTweetId,
     sourceLocator: item.articleLocator,
   });
+  const xArticleLinks = rootLinks.filter(isXArticleLocator);
+  const requestedXArticleLocator = item.articleLocator && isXArticleLocator(item.articleLocator)
+    ? item.articleLocator
+    : undefined;
+  const unresolvedXArticleLink = recoveredArticleLink
+    ? undefined
+    : bindArticleLocator(xArticleLinks, requestedXArticleLocator) ?? xArticleLinks[0];
   const boundManifest = manifest
     ? { ...manifest, entries: manifest.entries.filter((entry) => entry.bookmarkId === item.id) }
     : null;
@@ -501,24 +508,15 @@ export async function materializeBookmark(
       'used',
       'X long-form article content recovered',
     ));
-  } else if (
-    item.articleText
-    || item.articleTitle
-    || item.articleSite
-    || (item.links ?? []).some(isXArticleLocator)
-  ) {
+  } else if (unresolvedXArticleLink) {
     components.push(component(
       rootId,
       'x-article',
       'embedded_x_article',
-      bindArticleLocator(rootLinks, item.articleLocator)
-        ?? rootLinks.find(isXArticleLocator)
-        ?? item.url,
+      unresolvedXArticleLink,
       null,
       'unresolved',
-      item.articleText
-        ? 'X long-form article content is present but source-tweet or locator identity is unbound'
-        : 'X long-form article identity exists but article content is absent',
+      'X long-form article identity exists but article content is absent or not bound to this locator',
     ));
   }
 
@@ -530,7 +528,10 @@ export async function materializeBookmark(
     locator: item.url,
     author_handle: item.authorHandle ?? null,
     posted_at: item.postedAt ?? null,
-    source_cutoff: item.threadExpandedAt ?? item.enrichedAt ?? item.syncedAt ?? null,
+    source_cutoff: item.threadExpandedAt
+      ?? (recoveredArticleLink ? item.enrichedAt : undefined)
+      ?? item.syncedAt
+      ?? null,
     achieved_depth: incomplete
       ? 'source-owned root and enumerated components with explicit unresolved depth'
       : 'source-owned root and enumerated components recovered',

--- a/src/bookmark-media.ts
+++ b/src/bookmark-media.ts
@@ -1,7 +1,7 @@
 import path from 'node:path';
 import { createHash } from 'node:crypto';
 import { createReadStream } from 'node:fs';
-import { stat, writeFile } from 'node:fs/promises';
+import { realpath, stat, writeFile } from 'node:fs/promises';
 import { ensureDir, pathExists, readJson, readJsonLines, writeJson } from './fs.js';
 import { bookmarkMediaDir, bookmarkMediaManifestPath, twitterBookmarksCachePath } from './paths.js';
 import type { BookmarkRecord } from './types.js';
@@ -45,6 +45,13 @@ export interface MediaFetchProgress {
   currentSourceUrl?: string;
 }
 
+export interface VerifiedDownloadedMediaAsset {
+  bytes: number;
+  sha256: string;
+}
+
+export type MediaVerificationCache = Map<string, VerifiedDownloadedMediaAsset | null>;
+
 interface MediaFetchTarget {
   bookmarkId: string;
   tweetId: string;
@@ -76,6 +83,56 @@ interface CachedMediaResult {
 
 const HOUR_MS = 60 * 60_000;
 const DAY_MS = 24 * HOUR_MS;
+
+function strictlyInside(parentPath: string, childPath: string): boolean {
+  const relative = path.relative(parentPath, childPath);
+  return relative !== ''
+    && relative !== '..'
+    && !relative.startsWith(`..${path.sep}`)
+    && !path.isAbsolute(relative);
+}
+
+export async function verifyDownloadedMediaEntry(
+  entry: MediaFetchEntry,
+  cache?: MediaVerificationCache,
+): Promise<VerifiedDownloadedMediaAsset | null> {
+  if (entry.status !== 'downloaded' || !entry.localPath) return null;
+
+  let verified = cache?.get(entry.localPath);
+  if (verified === undefined) {
+    try {
+      const [mediaRoot, filePath] = await Promise.all([
+        realpath(bookmarkMediaDir()),
+        realpath(entry.localPath),
+      ]);
+      if (!strictlyInside(mediaRoot, filePath)) {
+        verified = null;
+      } else {
+        const file = await stat(filePath);
+        if (!file.isFile()) {
+          verified = null;
+        } else {
+          const hash = createHash('sha256');
+          for await (const chunk of createReadStream(filePath)) hash.update(chunk);
+          const sha256 = hash.digest('hex');
+          const filename = path.basename(filePath);
+          const extension = path.extname(filename);
+          const stem = extension ? filename.slice(0, -extension.length) : filename;
+          const digestFromFilename = stem.match(/(?:^|-)([a-f0-9]{16})$/i)?.[1];
+          verified = digestFromFilename?.toLowerCase() === sha256.slice(0, 16)
+            ? { bytes: file.size, sha256 }
+            : null;
+        }
+      }
+    } catch {
+      verified = null;
+    }
+    cache?.set(entry.localPath, verified);
+  }
+
+  if (!verified || (entry.bytes !== undefined && entry.bytes !== verified.bytes)) return null;
+  return verified;
+}
 
 function mediaAssetKey(tweetId: string, sourceUrl: string, isProfileImage: boolean): string {
   return isProfileImage ? `profile::${sourceUrl}` : `${tweetId}::${sourceUrl}`;
@@ -271,35 +328,10 @@ async function loadReusableDownloadedResults(previous: MediaFetchManifest | null
 }> {
   const associationKeys = new Set<string>();
   const bySourceUrl = new Map<string, CachedMediaResult>();
-  const verifiedFiles = new Map<string, { bytes: number; digest: string } | null>();
+  const verifiedFiles: MediaVerificationCache = new Map();
   for (const entry of previous?.entries ?? []) {
-    if (entry.status !== 'downloaded' || !entry.localPath) continue;
-    try {
-      let verified = verifiedFiles.get(entry.localPath);
-      if (verified === undefined) {
-        const file = await stat(entry.localPath);
-        if (!file.isFile()) {
-          verifiedFiles.set(entry.localPath, null);
-          continue;
-        }
-        const hash = createHash('sha256');
-        for await (const chunk of createReadStream(entry.localPath)) hash.update(chunk);
-        verified = { bytes: file.size, digest: hash.digest('hex').slice(0, 16) };
-        verifiedFiles.set(entry.localPath, verified);
-      }
-      if (!verified || (entry.bytes !== undefined && verified.bytes !== entry.bytes)) continue;
-
-      const filename = path.basename(entry.localPath);
-      const extension = path.extname(filename);
-      const stem = extension ? filename.slice(0, -extension.length) : filename;
-      const digestFromFilename = entry.sourceUrl.includes('/profile_images/')
-        ? stem
-        : stem.startsWith(`${entry.tweetId}-`)
-          ? stem.slice(entry.tweetId.length + 1)
-          : '';
-      if (!/^[a-f0-9]{16}$/i.test(digestFromFilename)
-        || digestFromFilename.toLowerCase() !== verified.digest) continue;
-
+    const verified = await verifyDownloadedMediaEntry(entry, verifiedFiles);
+    if (verified) {
       associationKeys.add(mediaEntryKeyFromEntry(entry));
       if (!bySourceUrl.has(entry.sourceUrl)) {
         bySourceUrl.set(entry.sourceUrl, {
@@ -310,8 +342,6 @@ async function loadReusableDownloadedResults(previous: MediaFetchManifest | null
           fetchedAt: entry.fetchedAt,
         });
       }
-    } catch {
-      // Missing or changed files are not reusable and must be fetched again.
     }
   }
   return { associationKeys, bySourceUrl };

--- a/src/bookmark-media.ts
+++ b/src/bookmark-media.ts
@@ -108,7 +108,10 @@ function hasTargets(source: { media?: unknown[]; mediaObjects?: unknown[]; autho
 }
 
 function hasMediaCandidate(bookmark: BookmarkRecord): boolean {
-  return hasTargets(bookmark) || hasTargets(bookmark.quotedTweet);
+  return hasTargets(bookmark)
+    || hasTargets(bookmark.quotedTweet)
+    || (bookmark.threadContext ?? []).some(hasTargets)
+    || (bookmark.threadBelow ?? []).some(hasTargets);
 }
 
 function pushTarget(
@@ -199,6 +202,21 @@ function resolveMediaTargets(
       authorProfileImageUrl: bookmark.quotedTweet.authorProfileImageUrl,
       media: bookmark.quotedTweet.media,
       mediaObjects: bookmark.quotedTweet.mediaObjects,
+    }, downloadedProfileImageUrls, skipProfileImages);
+  }
+
+  for (const threadTweet of [
+    ...(bookmark.threadContext ?? []),
+    ...(bookmark.threadBelow ?? []),
+  ]) {
+    appendMediaTargets(targets, seenKeys, bookmark.id, {
+      tweetId: threadTweet.id,
+      tweetUrl: threadTweet.url,
+      authorHandle: threadTweet.authorHandle,
+      authorName: threadTweet.authorName,
+      authorProfileImageUrl: threadTweet.authorProfileImageUrl,
+      media: threadTweet.media,
+      mediaObjects: threadTweet.mediaObjects,
     }, downloadedProfileImageUrls, skipProfileImages);
   }
 

--- a/src/bookmark-media.ts
+++ b/src/bookmark-media.ts
@@ -1,5 +1,6 @@
 import path from 'node:path';
 import { createHash } from 'node:crypto';
+import { createReadStream } from 'node:fs';
 import { stat, writeFile } from 'node:fs/promises';
 import { ensureDir, pathExists, readJson, readJsonLines, writeJson } from './fs.js';
 import { bookmarkMediaDir, bookmarkMediaManifestPath, twitterBookmarksCachePath } from './paths.js';
@@ -269,17 +270,41 @@ async function loadReusableDownloadedResults(previous: MediaFetchManifest | null
 }> {
   const associationKeys = new Set<string>();
   const bySourceUrl = new Map<string, CachedMediaResult>();
+  const verifiedFiles = new Map<string, { bytes: number; digest: string } | null>();
   for (const entry of previous?.entries ?? []) {
     if (entry.status !== 'downloaded' || !entry.localPath) continue;
     try {
-      const file = await stat(entry.localPath);
-      if (!file.isFile() || (entry.bytes !== undefined && file.size !== entry.bytes)) continue;
+      let verified = verifiedFiles.get(entry.localPath);
+      if (verified === undefined) {
+        const file = await stat(entry.localPath);
+        if (!file.isFile()) {
+          verifiedFiles.set(entry.localPath, null);
+          continue;
+        }
+        const hash = createHash('sha256');
+        for await (const chunk of createReadStream(entry.localPath)) hash.update(chunk);
+        verified = { bytes: file.size, digest: hash.digest('hex').slice(0, 16) };
+        verifiedFiles.set(entry.localPath, verified);
+      }
+      if (!verified || (entry.bytes !== undefined && verified.bytes !== entry.bytes)) continue;
+
+      const filename = path.basename(entry.localPath);
+      const extension = path.extname(filename);
+      const stem = extension ? filename.slice(0, -extension.length) : filename;
+      const digestFromFilename = entry.sourceUrl.includes('/profile_images/')
+        ? stem
+        : stem.startsWith(`${entry.tweetId}-`)
+          ? stem.slice(entry.tweetId.length + 1)
+          : '';
+      if (!/^[a-f0-9]{16}$/i.test(digestFromFilename)
+        || digestFromFilename.toLowerCase() !== verified.digest) continue;
+
       associationKeys.add(mediaEntryKeyFromEntry(entry));
       if (!bySourceUrl.has(entry.sourceUrl)) {
         bySourceUrl.set(entry.sourceUrl, {
           localPath: entry.localPath,
           contentType: entry.contentType,
-          bytes: file.size,
+          bytes: verified.bytes,
           status: 'downloaded',
           fetchedAt: entry.fetchedAt,
         });

--- a/src/bookmark-media.ts
+++ b/src/bookmark-media.ts
@@ -262,7 +262,7 @@ function hasPendingMediaTarget(
 }
 
 export async function fetchBookmarkMediaBatch(
-  options: { limit?: number; maxBytes?: number; skipProfileImages?: boolean; retryFailed?: boolean; signal?: AbortSignal; onProgress?: (progress: MediaFetchProgress) => void } = {}
+  options: { limit?: number; maxBytes?: number; skipProfileImages?: boolean; retryFailed?: boolean; records?: BookmarkRecord[]; signal?: AbortSignal; onProgress?: (progress: MediaFetchProgress) => void } = {}
 ): Promise<MediaFetchManifest> {
   const limit = typeof options.limit === 'number' && !Number.isNaN(options.limit)
     ? Math.max(0, options.limit)
@@ -278,7 +278,7 @@ export async function fetchBookmarkMediaBatch(
   const previous = await loadManifest();
   const coveredAssetKeys = buildCoveredAssetKeys(previous, maxBytes, retryFailed, nowMs);
   const coveredProfileImageUrls = buildCoveredProfileImageUrls(previous, maxBytes, retryFailed, nowMs);
-  const bookmarks = await readJsonLines<BookmarkRecord>(twitterBookmarksCachePath());
+  const bookmarks = options.records ?? await readJsonLines<BookmarkRecord>(twitterBookmarksCachePath());
   const candidates = bookmarks
     .filter(hasMediaCandidate)
     .filter((bookmark) => hasPendingMediaTarget(bookmark, coveredAssetKeys, coveredProfileImageUrls, skipProfileImages))

--- a/src/bookmark-media.ts
+++ b/src/bookmark-media.ts
@@ -1,6 +1,6 @@
 import path from 'node:path';
 import { createHash } from 'node:crypto';
-import { writeFile } from 'node:fs/promises';
+import { stat, writeFile } from 'node:fs/promises';
 import { ensureDir, pathExists, readJson, readJsonLines, writeJson } from './fs.js';
 import { bookmarkMediaDir, bookmarkMediaManifestPath, twitterBookmarksCachePath } from './paths.js';
 import type { BookmarkRecord } from './types.js';
@@ -75,12 +75,26 @@ interface CachedMediaResult {
 const HOUR_MS = 60 * 60_000;
 const DAY_MS = 24 * HOUR_MS;
 
-function mediaEntryKey(tweetId: string, sourceUrl: string, isProfileImage: boolean): string {
+function mediaAssetKey(tweetId: string, sourceUrl: string, isProfileImage: boolean): string {
   return isProfileImage ? `profile::${sourceUrl}` : `${tweetId}::${sourceUrl}`;
 }
 
+function mediaAssociationKey(
+  bookmarkId: string,
+  tweetId: string,
+  sourceUrl: string,
+  isProfileImage: boolean,
+): string {
+  return isProfileImage ? mediaAssetKey(tweetId, sourceUrl, true) : `${bookmarkId}::${tweetId}::${sourceUrl}`;
+}
+
 function mediaEntryKeyFromEntry(entry: MediaFetchEntry): string {
-  return mediaEntryKey(entry.tweetId, entry.sourceUrl, entry.sourceUrl.includes('/profile_images/'));
+  return mediaAssociationKey(
+    entry.bookmarkId,
+    entry.tweetId,
+    entry.sourceUrl,
+    entry.sourceUrl.includes('/profile_images/'),
+  );
 }
 
 function sanitizeExtFromContentType(contentType?: string, sourceUrl?: string): string {
@@ -122,7 +136,7 @@ function pushTarget(
   isProfileImage: boolean,
 ): void {
   if (!sourceUrl) return;
-  const key = mediaEntryKey(base.tweetId, sourceUrl, isProfileImage);
+  const key = mediaAssetKey(base.tweetId, sourceUrl, isProfileImage);
   if (seenKeys.has(key)) return;
   seenKeys.add(key);
   targets.push({
@@ -249,20 +263,64 @@ function isCoveredEntry(entry: MediaFetchEntry, maxBytes: number, retryFailed: b
   return typeof entry.bytes === 'number' && !Number.isNaN(entry.bytes) && entry.bytes > maxBytes;
 }
 
-function buildCoveredAssetKeys(previous: MediaFetchManifest | null, maxBytes: number, retryFailed: boolean, nowMs: number): Set<string> {
+async function loadReusableDownloadedResults(previous: MediaFetchManifest | null): Promise<{
+  associationKeys: Set<string>;
+  bySourceUrl: Map<string, CachedMediaResult>;
+}> {
+  const associationKeys = new Set<string>();
+  const bySourceUrl = new Map<string, CachedMediaResult>();
+  for (const entry of previous?.entries ?? []) {
+    if (entry.status !== 'downloaded' || !entry.localPath) continue;
+    try {
+      const file = await stat(entry.localPath);
+      if (!file.isFile() || (entry.bytes !== undefined && file.size !== entry.bytes)) continue;
+      associationKeys.add(mediaEntryKeyFromEntry(entry));
+      if (!bySourceUrl.has(entry.sourceUrl)) {
+        bySourceUrl.set(entry.sourceUrl, {
+          localPath: entry.localPath,
+          contentType: entry.contentType,
+          bytes: file.size,
+          status: 'downloaded',
+          fetchedAt: entry.fetchedAt,
+        });
+      }
+    } catch {
+      // Missing or changed files are not reusable and must be fetched again.
+    }
+  }
+  return { associationKeys, bySourceUrl };
+}
+
+function buildCoveredAssetKeys(
+  previous: MediaFetchManifest | null,
+  maxBytes: number,
+  retryFailed: boolean,
+  nowMs: number,
+  verifiedDownloadedAssociations: Set<string>,
+): Set<string> {
   return new Set(
     (previous?.entries ?? [])
       .filter((entry) => !entry.sourceUrl.includes('/profile_images/'))
-      .filter((entry) => isCoveredEntry(entry, maxBytes, retryFailed, nowMs))
-      .map((entry) => `${entry.tweetId}::${entry.sourceUrl}`),
+      .filter((entry) => entry.status === 'downloaded'
+        ? verifiedDownloadedAssociations.has(mediaEntryKeyFromEntry(entry))
+        : isCoveredEntry(entry, maxBytes, retryFailed, nowMs))
+      .map(mediaEntryKeyFromEntry),
   );
 }
 
-function buildCoveredProfileImageUrls(previous: MediaFetchManifest | null, maxBytes: number, retryFailed: boolean, nowMs: number): Set<string> {
+function buildCoveredProfileImageUrls(
+  previous: MediaFetchManifest | null,
+  maxBytes: number,
+  retryFailed: boolean,
+  nowMs: number,
+  verifiedDownloadedAssociations: Set<string>,
+): Set<string> {
   return new Set(
     (previous?.entries ?? [])
       .filter((entry) => entry.sourceUrl.includes('/profile_images/'))
-      .filter((entry) => isCoveredEntry(entry, maxBytes, retryFailed, nowMs))
+      .filter((entry) => entry.status === 'downloaded'
+        ? verifiedDownloadedAssociations.has(mediaEntryKeyFromEntry(entry))
+        : isCoveredEntry(entry, maxBytes, retryFailed, nowMs))
       .map((entry) => entry.sourceUrl),
   );
 }
@@ -273,9 +331,9 @@ function hasPendingMediaTarget(
   coveredProfileImageUrls: Set<string>,
   skipProfileImages: boolean,
 ): boolean {
-  return resolveMediaTargets(bookmark, coveredProfileImageUrls, skipProfileImages).some(({ tweetId, sourceUrl, isProfileImage }) => {
+  return resolveMediaTargets(bookmark, coveredProfileImageUrls, skipProfileImages).some(({ bookmarkId, tweetId, sourceUrl, isProfileImage }) => {
     if (isProfileImage) return true;
-    return !coveredAssetKeys.has(`${tweetId}::${sourceUrl}`);
+    return !coveredAssetKeys.has(mediaAssociationKey(bookmarkId, tweetId, sourceUrl, false));
   });
 }
 
@@ -294,15 +352,28 @@ export async function fetchBookmarkMediaBatch(
   await ensureDir(mediaDir);
 
   const previous = await loadManifest();
-  const coveredAssetKeys = buildCoveredAssetKeys(previous, maxBytes, retryFailed, nowMs);
-  const coveredProfileImageUrls = buildCoveredProfileImageUrls(previous, maxBytes, retryFailed, nowMs);
+  const reusable = await loadReusableDownloadedResults(previous);
+  const coveredAssetKeys = buildCoveredAssetKeys(
+    previous,
+    maxBytes,
+    retryFailed,
+    nowMs,
+    reusable.associationKeys,
+  );
+  const coveredProfileImageUrls = buildCoveredProfileImageUrls(
+    previous,
+    maxBytes,
+    retryFailed,
+    nowMs,
+    reusable.associationKeys,
+  );
   const bookmarks = options.records ?? await readJsonLines<BookmarkRecord>(twitterBookmarksCachePath());
   const candidates = bookmarks
     .filter(hasMediaCandidate)
     .filter((bookmark) => hasPendingMediaTarget(bookmark, coveredAssetKeys, coveredProfileImageUrls, skipProfileImages))
     .slice(0, limit);
   const entriesByKey = new Map((previous?.entries ?? []).map((entry) => [mediaEntryKeyFromEntry(entry), entry]));
-  const cachedResultsBySourceUrl = new Map<string, CachedMediaResult>();
+  const cachedResultsBySourceUrl = reusable.bySourceUrl;
 
   let downloaded = 0;
   let skippedTooLarge = 0;
@@ -367,7 +438,7 @@ export async function fetchBookmarkMediaBatch(
     for (const target of mediaTargets) {
       if (options.signal?.aborted) break;
       const { bookmarkId, tweetId, tweetUrl, authorHandle, authorName, sourceUrl, isProfileImage } = target;
-      const key = mediaEntryKey(tweetId, sourceUrl, isProfileImage);
+      const key = mediaAssociationKey(bookmarkId, tweetId, sourceUrl, isProfileImage);
       if (!isProfileImage && coveredAssetKeys.has(key)) continue;
       const cachedResult = cachedResultsBySourceUrl.get(sourceUrl);
       if (cachedResult) {

--- a/src/bookmark-media.ts
+++ b/src/bookmark-media.ts
@@ -5,6 +5,7 @@ import { stat, writeFile } from 'node:fs/promises';
 import { ensureDir, pathExists, readJson, readJsonLines, writeJson } from './fs.js';
 import { bookmarkMediaDir, bookmarkMediaManifestPath, twitterBookmarksCachePath } from './paths.js';
 import type { BookmarkRecord } from './types.js';
+import { XRequestExecutor } from './x-request-policy.js';
 
 export const DEFAULT_MEDIA_MAX_BYTES = 200 * 1024 * 1024;
 
@@ -363,6 +364,7 @@ function hasPendingMediaTarget(
 }
 
 export async function fetchBookmarkMediaBatch(
+  requestExecutor: XRequestExecutor,
   options: { limit?: number; maxBytes?: number; skipProfileImages?: boolean; retryFailed?: boolean; records?: BookmarkRecord[]; signal?: AbortSignal; onProgress?: (progress: MediaFetchProgress) => void } = {}
 ): Promise<MediaFetchManifest> {
   const limit = typeof options.limit === 'number' && !Number.isNaN(options.limit)
@@ -474,9 +476,16 @@ export async function fetchBookmarkMediaBatch(
       const fetchedAt = new Date().toISOString();
 
       try {
-        const head = await fetch(sourceUrl, { method: 'HEAD' });
-        const contentLengthHeader = head.headers.get('content-length');
-        const contentType = head.headers.get('content-type') ?? undefined;
+        const head = await requestExecutor.requestHeaders(sourceUrl, {
+          method: 'HEAD',
+          signal: options.signal,
+        });
+        if (head.failureKind === 'aborted') break;
+        if (head.failureKind === 'network') {
+          throw new Error(head.errorMessage ?? head.failureKind);
+        }
+        const contentLengthHeader = head.status === 'ok' ? head.headers?.contentLength : undefined;
+        const contentType = head.status === 'ok' ? head.headers?.contentType : undefined;
         const declaredBytes = contentLengthHeader ? Number(contentLengthHeader) : undefined;
 
         if (typeof declaredBytes === 'number' && !Number.isNaN(declaredBytes) && declaredBytes > maxBytes) {
@@ -509,8 +518,12 @@ export async function fetchBookmarkMediaBatch(
           continue;
         }
 
-        const response = await fetch(sourceUrl);
-        if (!response.ok) {
+        const response = await requestExecutor.requestBytes(sourceUrl, { signal: options.signal });
+        if (response.failureKind === 'aborted') break;
+        if (response.status !== 'ok' || !response.bytes) {
+          const reason = response.httpStatus
+            ? `HTTP ${response.httpStatus}`
+            : response.errorMessage ?? response.failureKind ?? response.status;
           const entry = {
             bookmarkId,
             tweetId,
@@ -519,7 +532,7 @@ export async function fetchBookmarkMediaBatch(
             authorName,
             sourceUrl,
             status: 'failed',
-            reason: `HTTP ${response.status}`,
+            reason,
             fetchedAt,
           } satisfies MediaFetchEntry;
           upsertEntry(entry);
@@ -534,7 +547,7 @@ export async function fetchBookmarkMediaBatch(
           continue;
         }
 
-        const buffer = Buffer.from(await response.arrayBuffer());
+        const buffer = response.bytes;
         if (buffer.byteLength > maxBytes) {
           const entry = {
             bookmarkId,
@@ -543,7 +556,7 @@ export async function fetchBookmarkMediaBatch(
             authorHandle,
             authorName,
             sourceUrl,
-            contentType: response.headers.get('content-type') ?? contentType ?? undefined,
+            contentType: response.contentType ?? contentType,
             bytes: buffer.byteLength,
             status: 'skipped_too_large',
             reason: `downloaded size ${buffer.byteLength} exceeds max ${maxBytes}`,
@@ -566,7 +579,7 @@ export async function fetchBookmarkMediaBatch(
         }
 
         const digest = createHash('sha256').update(buffer).digest('hex').slice(0, 16);
-        const ext = sanitizeExtFromContentType(response.headers.get('content-type') ?? contentType ?? undefined, sourceUrl);
+        const ext = sanitizeExtFromContentType(response.contentType ?? contentType, sourceUrl);
         const filename = isProfileImage
           ? `${digest}${ext}`
           : `${tweetId}-${digest}${ext}`;
@@ -583,7 +596,7 @@ export async function fetchBookmarkMediaBatch(
           authorName,
           sourceUrl,
           localPath,
-          contentType: response.headers.get('content-type') ?? contentType ?? undefined,
+          contentType: response.contentType ?? contentType,
           bytes: buffer.byteLength,
           status: 'downloaded',
           fetchedAt,

--- a/src/bookmark-media.ts
+++ b/src/bookmark-media.ts
@@ -322,75 +322,131 @@ function isCoveredEntry(entry: MediaFetchEntry, maxBytes: number, retryFailed: b
   return typeof entry.bytes === 'number' && !Number.isNaN(entry.bytes) && entry.bytes > maxBytes;
 }
 
-async function loadReusableDownloadedResults(previous: MediaFetchManifest | null): Promise<{
-  associationKeys: Set<string>;
+async function selectMediaCandidates(
+  bookmarks: BookmarkRecord[],
+  previous: MediaFetchManifest | null,
+  limit: number,
+  maxBytes: number,
+  retryFailed: boolean,
+  nowMs: number,
+  skipProfileImages: boolean,
+): Promise<{
+  candidates: BookmarkRecord[];
+  coveredAssetKeys: Set<string>;
+  coveredProfileImageUrls: Set<string>;
   bySourceUrl: Map<string, CachedMediaResult>;
 }> {
-  const associationKeys = new Set<string>();
+  const coveredAssetKeys = buildNonDownloadedCoveredAssetKeys(previous, maxBytes, retryFailed, nowMs);
+  const coveredProfileImageUrls = buildNonDownloadedCoveredProfileImageUrls(previous, maxBytes, retryFailed, nowMs);
   const bySourceUrl = new Map<string, CachedMediaResult>();
   const verifiedFiles: MediaVerificationCache = new Map();
+  const downloadedByAssociation = new Map<string, MediaFetchEntry>();
+  const downloadedBySourceUrl = new Map<string, MediaFetchEntry[]>();
   for (const entry of previous?.entries ?? []) {
-    const verified = await verifyDownloadedMediaEntry(entry, verifiedFiles);
-    if (verified) {
-      associationKeys.add(mediaEntryKeyFromEntry(entry));
-      if (!bySourceUrl.has(entry.sourceUrl)) {
-        bySourceUrl.set(entry.sourceUrl, {
-          localPath: entry.localPath,
-          contentType: entry.contentType,
-          bytes: verified.bytes,
-          status: 'downloaded',
-          fetchedAt: entry.fetchedAt,
-        });
-      }
-    }
+    if (entry.status !== 'downloaded') continue;
+    downloadedByAssociation.set(mediaEntryKeyFromEntry(entry), entry);
+    const sourceEntries = downloadedBySourceUrl.get(entry.sourceUrl) ?? [];
+    sourceEntries.push(entry);
+    downloadedBySourceUrl.set(entry.sourceUrl, sourceEntries);
   }
-  return { associationKeys, bySourceUrl };
+
+  const admitReusable = async (entry: MediaFetchEntry): Promise<boolean> => {
+    const verified = await verifyDownloadedMediaEntry(entry, verifiedFiles);
+    if (!verified) return false;
+    if (!bySourceUrl.has(entry.sourceUrl)) {
+      bySourceUrl.set(entry.sourceUrl, {
+        localPath: entry.localPath,
+        contentType: entry.contentType,
+        bytes: verified.bytes,
+        status: 'downloaded',
+        fetchedAt: entry.fetchedAt,
+      });
+    }
+    return true;
+  };
+
+  const admitSource = async (sourceUrl: string): Promise<boolean> => {
+    if (bySourceUrl.has(sourceUrl)) return true;
+    for (const entry of downloadedBySourceUrl.get(sourceUrl) ?? []) {
+      if (await admitReusable(entry)) return true;
+    }
+    return false;
+  };
+
+  const candidates: BookmarkRecord[] = [];
+  if (limit === 0) {
+    return {
+      candidates,
+      coveredAssetKeys,
+      coveredProfileImageUrls,
+      bySourceUrl,
+    };
+  }
+  for (const bookmark of bookmarks) {
+    if (!hasMediaCandidate(bookmark)) continue;
+    let pending = false;
+    const targets = resolveMediaTargets(bookmark, coveredProfileImageUrls, skipProfileImages);
+    for (const { bookmarkId, tweetId, sourceUrl, isProfileImage } of targets) {
+      if (isProfileImage) {
+        if (await admitSource(sourceUrl)) {
+          coveredProfileImageUrls.add(sourceUrl);
+        } else {
+          pending = true;
+        }
+        continue;
+      }
+
+      const key = mediaAssociationKey(bookmarkId, tweetId, sourceUrl, false);
+      if (coveredAssetKeys.has(key)) continue;
+      const association = downloadedByAssociation.get(key);
+      if (association && await admitReusable(association)) {
+        coveredAssetKeys.add(key);
+        continue;
+      }
+      // Reusable bytes avoid HTTP, but this root/tweet association remains pending
+      // until applyCachedResult writes its own custody entry into the manifest.
+      await admitSource(sourceUrl);
+      pending = true;
+    }
+    if (pending) candidates.push(bookmark);
+    if (candidates.length >= limit) break;
+  }
+  return {
+    candidates,
+    coveredAssetKeys,
+    coveredProfileImageUrls,
+    bySourceUrl,
+  };
 }
 
-function buildCoveredAssetKeys(
+function buildNonDownloadedCoveredAssetKeys(
   previous: MediaFetchManifest | null,
   maxBytes: number,
   retryFailed: boolean,
   nowMs: number,
-  verifiedDownloadedAssociations: Set<string>,
 ): Set<string> {
   return new Set(
     (previous?.entries ?? [])
       .filter((entry) => !entry.sourceUrl.includes('/profile_images/'))
-      .filter((entry) => entry.status === 'downloaded'
-        ? verifiedDownloadedAssociations.has(mediaEntryKeyFromEntry(entry))
-        : isCoveredEntry(entry, maxBytes, retryFailed, nowMs))
+      .filter((entry) => entry.status !== 'downloaded')
+      .filter((entry) => isCoveredEntry(entry, maxBytes, retryFailed, nowMs))
       .map(mediaEntryKeyFromEntry),
   );
 }
 
-function buildCoveredProfileImageUrls(
+function buildNonDownloadedCoveredProfileImageUrls(
   previous: MediaFetchManifest | null,
   maxBytes: number,
   retryFailed: boolean,
   nowMs: number,
-  verifiedDownloadedAssociations: Set<string>,
 ): Set<string> {
   return new Set(
     (previous?.entries ?? [])
       .filter((entry) => entry.sourceUrl.includes('/profile_images/'))
-      .filter((entry) => entry.status === 'downloaded'
-        ? verifiedDownloadedAssociations.has(mediaEntryKeyFromEntry(entry))
-        : isCoveredEntry(entry, maxBytes, retryFailed, nowMs))
+      .filter((entry) => entry.status !== 'downloaded')
+      .filter((entry) => isCoveredEntry(entry, maxBytes, retryFailed, nowMs))
       .map((entry) => entry.sourceUrl),
   );
-}
-
-function hasPendingMediaTarget(
-  bookmark: BookmarkRecord,
-  coveredAssetKeys: Set<string>,
-  coveredProfileImageUrls: Set<string>,
-  skipProfileImages: boolean,
-): boolean {
-  return resolveMediaTargets(bookmark, coveredProfileImageUrls, skipProfileImages).some(({ bookmarkId, tweetId, sourceUrl, isProfileImage }) => {
-    if (isProfileImage) return true;
-    return !coveredAssetKeys.has(mediaAssociationKey(bookmarkId, tweetId, sourceUrl, false));
-  });
 }
 
 export async function fetchBookmarkMediaBatch(
@@ -409,28 +465,23 @@ export async function fetchBookmarkMediaBatch(
   await ensureDir(mediaDir);
 
   const previous = await loadManifest();
-  const reusable = await loadReusableDownloadedResults(previous);
-  const coveredAssetKeys = buildCoveredAssetKeys(
-    previous,
-    maxBytes,
-    retryFailed,
-    nowMs,
-    reusable.associationKeys,
-  );
-  const coveredProfileImageUrls = buildCoveredProfileImageUrls(
-    previous,
-    maxBytes,
-    retryFailed,
-    nowMs,
-    reusable.associationKeys,
-  );
   const bookmarks = options.records ?? await readJsonLines<BookmarkRecord>(twitterBookmarksCachePath());
-  const candidates = bookmarks
-    .filter(hasMediaCandidate)
-    .filter((bookmark) => hasPendingMediaTarget(bookmark, coveredAssetKeys, coveredProfileImageUrls, skipProfileImages))
-    .slice(0, limit);
+  const selected = await selectMediaCandidates(
+    bookmarks,
+    previous,
+    limit,
+    maxBytes,
+    retryFailed,
+    nowMs,
+    skipProfileImages,
+  );
+  const {
+    candidates,
+    coveredAssetKeys,
+    coveredProfileImageUrls,
+    bySourceUrl: cachedResultsBySourceUrl,
+  } = selected;
   const entriesByKey = new Map((previous?.entries ?? []).map((entry) => [mediaEntryKeyFromEntry(entry), entry]));
-  const cachedResultsBySourceUrl = reusable.bySourceUrl;
 
   let downloaded = 0;
   let skippedTooLarge = 0;

--- a/src/bookmark-snapshot.ts
+++ b/src/bookmark-snapshot.ts
@@ -21,7 +21,7 @@ function boundArchivedRecord(archived: BookmarkRecord): BookmarkRecord {
       : undefined;
   const articleLocator = bindArticleEnrichment(archived.tweetId, archived.links ?? [], {
     articleText: archived.articleText,
-    sourceTweetId: archived.articleSourceTweetId ?? archived.tweetId,
+    sourceTweetId: archived.articleSourceTweetId,
     sourceLocator: archived.articleLocator,
   });
 

--- a/src/bookmark-snapshot.ts
+++ b/src/bookmark-snapshot.ts
@@ -1,0 +1,100 @@
+import { getBookmarkById, type BookmarkTimelineItem } from './bookmarks-db.js';
+import type { MediaFetchManifest } from './bookmark-media.js';
+import { pathExists, readJson, readJsonLines } from './fs.js';
+import {
+  bookmarkMediaManifestPath,
+  twitterBookmarksCachePath,
+  twitterBookmarksIndexPath,
+} from './paths.js';
+import { bindArticleLocator } from './source-bindings.js';
+import type { BookmarkRecord } from './types.js';
+
+export interface CanonicalBookmarkSnapshot {
+  record: BookmarkRecord;
+  manifest: MediaFetchManifest | null;
+}
+
+function boundArchivedRecord(archived: BookmarkRecord): BookmarkRecord {
+  const quotedTweet = archived.quotedStatusId
+    && archived.quotedTweet?.id === archived.quotedStatusId
+      ? archived.quotedTweet
+      : undefined;
+  const articleLocator = archived.articleText
+    && (archived.articleSourceTweetId ?? archived.tweetId) === archived.tweetId
+      ? bindArticleLocator(archived.links ?? [], archived.articleLocator)
+      : undefined;
+
+  return {
+    ...archived,
+    quotedTweet,
+    articleTitle: archived.articleTitle ?? null,
+    articleText: articleLocator ? archived.articleText : null,
+    articleSite: archived.articleSite ?? null,
+    articleSourceTweetId: articleLocator ? archived.tweetId : null,
+    articleLocator: articleLocator ?? null,
+  };
+}
+
+export function hydrateCanonicalBookmark(
+  archived: BookmarkRecord,
+  indexed: BookmarkTimelineItem | null,
+): BookmarkRecord {
+  const record = boundArchivedRecord(archived);
+  if (!indexed || indexed.id !== archived.id || indexed.tweetId !== archived.tweetId) return record;
+
+  const indexedQuote = !record.quotedTweet
+    && archived.quotedStatusId
+    && indexed.quotedStatusId === archived.quotedStatusId
+    && indexed.quotedTweet?.id === archived.quotedStatusId
+      ? indexed.quotedTweet
+      : undefined;
+
+  const indexedArticleLocator = !record.articleText
+    && indexed.articleText
+    && indexed.articleSourceTweetId === archived.tweetId
+      ? bindArticleLocator(archived.links ?? [], indexed.articleLocator)
+      : undefined;
+
+  return {
+    ...record,
+    quotedTweet: record.quotedTweet ?? indexedQuote,
+    articleTitle: indexedArticleLocator ? indexed.articleTitle : record.articleTitle,
+    articleText: indexedArticleLocator ? indexed.articleText : record.articleText,
+    articleSite: indexedArticleLocator ? indexed.articleSite : record.articleSite,
+    articleSourceTweetId: indexedArticleLocator ? archived.tweetId : record.articleSourceTweetId,
+    articleLocator: indexedArticleLocator ?? record.articleLocator,
+    enrichedAt: indexedArticleLocator ? indexed.enrichedAt : record.enrichedAt,
+  };
+}
+
+function bindManifest(
+  bookmarkId: string,
+  manifest: MediaFetchManifest | null,
+): MediaFetchManifest | null {
+  if (!manifest) return null;
+  const entries = manifest.entries.filter((entry) => entry.bookmarkId === bookmarkId);
+  return { ...manifest, entries };
+}
+
+export async function loadBoundMediaManifest(bookmarkId: string): Promise<MediaFetchManifest | null> {
+  const manifest = await pathExists(bookmarkMediaManifestPath())
+    ? await readJson<MediaFetchManifest>(bookmarkMediaManifestPath())
+    : null;
+  return bindManifest(bookmarkId, manifest);
+}
+
+export async function loadCanonicalBookmarkSnapshot(exactId: string): Promise<CanonicalBookmarkSnapshot> {
+  const archived = (await readJsonLines<BookmarkRecord>(twitterBookmarksCachePath()))
+    .find((row) => row.tweetId === exactId || row.id === exactId);
+  if (!archived || archived.tweetId !== exactId) {
+    throw new Error(`Archived X bookmark not found: ${exactId}`);
+  }
+
+  const indexed = await pathExists(twitterBookmarksIndexPath())
+    ? await getBookmarkById(archived.id)
+    : null;
+  return {
+    record: hydrateCanonicalBookmark(archived, indexed),
+    manifest: await loadBoundMediaManifest(archived.id),
+  };
+}

--- a/src/bookmark-snapshot.ts
+++ b/src/bookmark-snapshot.ts
@@ -6,7 +6,7 @@ import {
   twitterBookmarksCachePath,
   twitterBookmarksIndexPath,
 } from './paths.js';
-import { bindArticleLocator } from './source-bindings.js';
+import { bindArticleEnrichment } from './source-bindings.js';
 import type { BookmarkRecord } from './types.js';
 
 export interface CanonicalBookmarkSnapshot {
@@ -19,10 +19,11 @@ function boundArchivedRecord(archived: BookmarkRecord): BookmarkRecord {
     && archived.quotedTweet?.id === archived.quotedStatusId
       ? archived.quotedTweet
       : undefined;
-  const articleLocator = archived.articleText
-    && (archived.articleSourceTweetId ?? archived.tweetId) === archived.tweetId
-      ? bindArticleLocator(archived.links ?? [], archived.articleLocator)
-      : undefined;
+  const articleLocator = bindArticleEnrichment(archived.tweetId, archived.links ?? [], {
+    articleText: archived.articleText,
+    sourceTweetId: archived.articleSourceTweetId ?? archived.tweetId,
+    sourceLocator: archived.articleLocator,
+  });
 
   return {
     ...archived,
@@ -50,10 +51,12 @@ export function hydrateCanonicalBookmark(
       : undefined;
 
   const indexedArticleLocator = !record.articleText
-    && indexed.articleText
-    && indexed.articleSourceTweetId === archived.tweetId
-      ? bindArticleLocator(archived.links ?? [], indexed.articleLocator)
-      : undefined;
+    ? bindArticleEnrichment(archived.tweetId, archived.links ?? [], {
+        articleText: indexed.articleText,
+        sourceTweetId: indexed.articleSourceTweetId,
+        sourceLocator: indexed.articleLocator,
+      })
+    : undefined;
 
   return {
     ...record,

--- a/src/bookmark-snapshot.ts
+++ b/src/bookmark-snapshot.ts
@@ -86,11 +86,12 @@ export async function loadBoundMediaManifest(bookmarkId: string): Promise<MediaF
   return bindManifest(bookmarkId, manifest);
 }
 
-export async function loadCanonicalBookmarkSnapshot(exactId: string): Promise<CanonicalBookmarkSnapshot> {
+/** Load by the response-owned X tweet ID accepted by `ft materialize <id>`. */
+export async function loadCanonicalBookmarkSnapshot(exactTweetId: string): Promise<CanonicalBookmarkSnapshot> {
   const archived = (await readJsonLines<BookmarkRecord>(twitterBookmarksCachePath()))
-    .find((row) => row.tweetId === exactId || row.id === exactId);
-  if (!archived || archived.tweetId !== exactId) {
-    throw new Error(`Archived X bookmark not found: ${exactId}`);
+    .find((row) => row.tweetId === exactTweetId);
+  if (!archived) {
+    throw new Error(`Archived X bookmark not found: ${exactTweetId}`);
   }
 
   const indexed = await pathExists(twitterBookmarksIndexPath())

--- a/src/bookmarks-db.ts
+++ b/src/bookmarks-db.ts
@@ -456,7 +456,7 @@ function insertRecord(db: Database, r: BookmarkRecord, preserved?: PreservedBook
 
   const rawArticleLocator = bindArticleEnrichment(r.tweetId, r.links ?? [], {
     articleText: r.articleText,
-    sourceTweetId: r.articleSourceTweetId ?? r.tweetId,
+    sourceTweetId: r.articleSourceTweetId,
     sourceLocator: r.articleLocator,
   });
   const preservedArticleLocator = preservedRootMatches

--- a/src/bookmarks-db.ts
+++ b/src/bookmarks-db.ts
@@ -6,8 +6,9 @@ import { twitterBookmarksCachePath, twitterBookmarksIndexPath } from './paths.js
 import type { BookmarkRecord, QuotedTweetSnapshot } from './types.js';
 import { classifyCorpus, formatClassificationSummary } from './bookmark-classify.js';
 import type { ClassificationSummary } from './bookmark-classify.js';
+import { bindArticleLocator, canonicalHttpLocator } from './source-bindings.js';
 
-const SCHEMA_VERSION = 6;
+const SCHEMA_VERSION = 7;
 
 export interface SearchResult {
   id: string;
@@ -48,6 +49,8 @@ export interface BookmarkTimelineItem {
   articleTitle?: string | null;
   articleText?: string | null;
   articleSite?: string | null;
+  articleSourceTweetId?: string | null;
+  articleLocator?: string | null;
   enrichedAt?: string | null;
   quotedStatusId?: string | null;
   quotedTweet?: QuotedTweetSnapshot | null;
@@ -171,6 +174,8 @@ function mapTimelineRow(row: unknown[]): BookmarkTimelineItem {
     enrichedAt: (row[29] as string) ?? null,
     quotedStatusId: (row[30] as string) ?? null,
     quotedTweet: parseQuotedTweet(row[31]),
+    articleSourceTweetId: (row[32] as string) ?? null,
+    articleLocator: (row[33] as string) ?? null,
   };
 }
 
@@ -271,7 +276,9 @@ function initSchema(db: Database): void {
     article_site TEXT,
     enriched_at TEXT,
     folder_ids TEXT,
-    folder_names TEXT
+    folder_names TEXT,
+    article_source_tweet_id TEXT,
+    article_locator TEXT
   )`);
 
   db.run(`CREATE INDEX IF NOT EXISTS idx_bookmarks_author ON bookmarks(author_handle)`);
@@ -342,6 +349,8 @@ function ensureMigrations(db: Database): void {
     ensureColumn(db, 'bookmarks', 'article_text', 'TEXT');
     ensureColumn(db, 'bookmarks', 'article_site', 'TEXT');
     ensureColumn(db, 'bookmarks', 'enriched_at', 'TEXT');
+    ensureColumn(db, 'bookmarks', 'article_source_tweet_id', 'TEXT');
+    ensureColumn(db, 'bookmarks', 'article_locator', 'TEXT');
 
     ensureColumn(db, 'bookmarks', 'folder_ids', 'TEXT');
     ensureColumn(db, 'bookmarks', 'folder_names', 'TEXT');
@@ -363,6 +372,8 @@ function ensureMigrations(db: Database): void {
 }
 
 interface PreservedBookmarkFields {
+  tweetId: string;
+  quotedStatusId: string | null;
   categories: string | null;
   primaryCategory: string | null;
   githubUrls: string | null;
@@ -373,6 +384,8 @@ interface PreservedBookmarkFields {
   articleText: string | null;
   articleSite: string | null;
   enrichedAt: string | null;
+  articleSourceTweetId: string | null;
+  articleLocator: string | null;
   folderIds: string | null;
   folderNames: string | null;
 }
@@ -389,8 +402,30 @@ function insertRecord(db: Database, r: BookmarkRecord, preserved?: PreservedBook
   const githubFromLinks = (r.links ?? []).filter((l) => /github\.com/i.test(l));
   const githubUrls = [...new Set([...githubMatches.map((m) => `https://${m}`), ...githubFromLinks])];
 
+  const preservedRootMatches = preserved?.tweetId === r.tweetId;
+  const preservedQuote = preservedRootMatches
+    && preserved?.quotedStatusId === (r.quotedStatusId ?? null)
+    && parseQuotedTweet(preserved.quotedTweetJson)?.id === r.quotedStatusId
+      ? preserved.quotedTweetJson
+      : null;
+  const rawQuote = r.quotedStatusId && r.quotedTweet?.id === r.quotedStatusId
+    ? JSON.stringify(r.quotedTweet)
+    : null;
+
+  const rawArticleLocator = r.articleText
+    && (r.articleSourceTweetId ?? r.tweetId) === r.tweetId
+      ? bindArticleLocator(r.links ?? [], r.articleLocator)
+      : undefined;
+  const preservedArticleLocator = preservedRootMatches
+    && preserved?.articleText
+    && preserved.articleSourceTweetId === r.tweetId
+      ? bindArticleLocator(r.links ?? [], preserved.articleLocator)
+      : undefined;
+  const useRawArticle = Boolean(r.articleText && rawArticleLocator);
+  const usePreservedArticle = !useRawArticle && Boolean(preservedArticleLocator);
+
   db.run(
-    `INSERT OR REPLACE INTO bookmarks VALUES (${Array(37).fill('?').join(',')})`,
+    `INSERT OR REPLACE INTO bookmarks VALUES (${Array(39).fill('?').join(',')})`,
     [
       r.id,
       r.tweetId,
@@ -422,13 +457,15 @@ function insertRecord(db: Database, r: BookmarkRecord, preserved?: PreservedBook
       preserved?.githubUrls ?? (githubUrls.length ? JSON.stringify(githubUrls) : null),
       preserved?.domains ?? null,
       preserved?.primaryDomain ?? null,
-      r.quotedTweet ? JSON.stringify(r.quotedTweet) : (preserved?.quotedTweetJson ?? null),
-      preserved?.articleTitle ?? null,
-      preserved?.articleText ?? null,
-      preserved?.articleSite ?? null,
-      preserved?.enrichedAt ?? null,
+      rawQuote ?? preservedQuote,
+      useRawArticle ? (r.articleTitle ?? null) : usePreservedArticle ? preserved?.articleTitle ?? null : null,
+      useRawArticle ? r.articleText! : usePreservedArticle ? preserved?.articleText ?? null : null,
+      useRawArticle ? (r.articleSite ?? null) : usePreservedArticle ? preserved?.articleSite ?? null : null,
+      useRawArticle ? (r.enrichedAt ?? null) : usePreservedArticle ? preserved?.enrichedAt ?? null : null,
       serializeJsonArray(r.folderIds) ?? preserved?.folderIds ?? null,
       serializeJsonArray(r.folderNames) ?? preserved?.folderNames ?? null,
+      useRawArticle ? r.tweetId : usePreservedArticle ? preserved?.articleSourceTweetId ?? null : null,
+      useRawArticle ? rawArticleLocator! : usePreservedArticle ? preservedArticleLocator! : null,
     ]
   );
 }
@@ -457,25 +494,29 @@ export async function buildIndex(options?: { force?: boolean }): Promise<{ dbPat
     const existingRows = new Map<string, PreservedBookmarkFields>();
     try {
       const rows = db.exec(
-        `SELECT id, categories, primary_category, github_urls, domains, primary_domain,
+        `SELECT id, tweet_id, quoted_status_id, categories, primary_category, github_urls, domains, primary_domain,
                 quoted_tweet_json, article_title, article_text, article_site, enriched_at,
-                folder_ids, folder_names
+                folder_ids, folder_names, article_source_tweet_id, article_locator
          FROM bookmarks`
       );
       for (const r of (rows[0]?.values ?? [])) {
         existingRows.set(r[0] as string, {
-          categories: (r[1] as string) ?? null,
-          primaryCategory: (r[2] as string) ?? null,
-          githubUrls: (r[3] as string) ?? null,
-          domains: (r[4] as string) ?? null,
-          primaryDomain: (r[5] as string) ?? null,
-          quotedTweetJson: (r[6] as string) ?? null,
-          articleTitle: (r[7] as string) ?? null,
-          articleText: (r[8] as string) ?? null,
-          articleSite: (r[9] as string) ?? null,
-          enrichedAt: (r[10] as string) ?? null,
-          folderIds: (r[11] as string) ?? null,
-          folderNames: (r[12] as string) ?? null,
+          tweetId: String(r[1]),
+          quotedStatusId: (r[2] as string) ?? null,
+          categories: (r[3] as string) ?? null,
+          primaryCategory: (r[4] as string) ?? null,
+          githubUrls: (r[5] as string) ?? null,
+          domains: (r[6] as string) ?? null,
+          primaryDomain: (r[7] as string) ?? null,
+          quotedTweetJson: (r[8] as string) ?? null,
+          articleTitle: (r[9] as string) ?? null,
+          articleText: (r[10] as string) ?? null,
+          articleSite: (r[11] as string) ?? null,
+          enrichedAt: (r[12] as string) ?? null,
+          folderIds: (r[13] as string) ?? null,
+          folderNames: (r[14] as string) ?? null,
+          articleSourceTweetId: (r[15] as string) ?? null,
+          articleLocator: (r[16] as string) ?? null,
         });
       }
     } catch { /* table may be empty */ }
@@ -664,7 +705,9 @@ export async function listBookmarks(
         b.synced_at,
         b.enriched_at,
         b.quoted_status_id,
-        b.quoted_tweet_json
+        b.quoted_tweet_json,
+        b.article_source_tweet_id,
+        b.article_locator
       FROM bookmarks b
       ${where}
       ${bookmarkSortClause(filters.sort)}
@@ -812,7 +855,9 @@ export async function getBookmarkById(id: string): Promise<BookmarkTimelineItem 
         b.synced_at,
         b.enriched_at,
         b.quoted_status_id,
-        b.quoted_tweet_json
+        b.quoted_tweet_json,
+        b.article_source_tweet_id,
+        b.article_locator
       FROM bookmarks b
       WHERE b.id = ?
       LIMIT 1`,
@@ -1160,9 +1205,11 @@ export async function updateQuotedTweets(
   ensureMigrations(db);
 
   try {
-    const stmt = db.prepare('UPDATE bookmarks SET quoted_tweet_json = ? WHERE id = ?');
+    const stmt = db.prepare(
+      'UPDATE bookmarks SET quoted_tweet_json = ? WHERE id = ? AND quoted_status_id = ?',
+    );
     for (const record of records) {
-      stmt.run([JSON.stringify(record.quotedTweet), record.id]);
+      stmt.run([JSON.stringify(record.quotedTweet), record.id, record.quotedTweet.id]);
     }
     stmt.free();
     saveDb(db, dbPath);
@@ -1194,6 +1241,8 @@ export async function updateBookmarkText(
 
 export interface ArticleUpdate {
   id: string;
+  sourceTweetId: string;
+  sourceLocator: string;
   articleTitle: string;
   articleText: string;
   articleSite?: string;
@@ -1209,11 +1258,26 @@ export async function updateArticleContent(
 
   try {
     const stmt = db.prepare(
-      'UPDATE bookmarks SET article_title = ?, article_text = ?, article_site = ?, enriched_at = ? WHERE id = ?'
+      `UPDATE bookmarks
+       SET article_title = ?, article_text = ?, article_site = ?, enriched_at = ?,
+           article_source_tweet_id = ?, article_locator = ?
+       WHERE id = ? AND tweet_id = ?`
     );
     const now = new Date().toISOString();
     for (const record of records) {
-      stmt.run([record.articleTitle, record.articleText, record.articleSite ?? null, now, record.id]);
+      if (!record.sourceTweetId || !canonicalHttpLocator(record.sourceLocator)) {
+        throw new Error(`Refusing unbound article enrichment for bookmark ${record.id}`);
+      }
+      stmt.run([
+        record.articleTitle,
+        record.articleText,
+        record.articleSite ?? null,
+        now,
+        record.sourceTweetId,
+        record.sourceLocator,
+        record.id,
+        record.sourceTweetId,
+      ]);
     }
     stmt.free();
     db.run("INSERT INTO bookmarks_fts(bookmarks_fts) VALUES('rebuild')");

--- a/src/bookmarks-db.ts
+++ b/src/bookmarks-db.ts
@@ -395,6 +395,48 @@ function serializeJsonArray(values: string[] | undefined | null): string | null 
   return JSON.stringify(values);
 }
 
+const BOOKMARK_INSERT_COLUMNS = [
+  'id',
+  'tweet_id',
+  'url',
+  'text',
+  'author_handle',
+  'author_name',
+  'author_profile_image_url',
+  'posted_at',
+  'bookmarked_at',
+  'synced_at',
+  'conversation_id',
+  'in_reply_to_status_id',
+  'quoted_status_id',
+  'language',
+  'like_count',
+  'repost_count',
+  'reply_count',
+  'quote_count',
+  'bookmark_count',
+  'view_count',
+  'media_count',
+  'link_count',
+  'links_json',
+  'tags_json',
+  'ingested_via',
+  'categories',
+  'primary_category',
+  'github_urls',
+  'domains',
+  'primary_domain',
+  'quoted_tweet_json',
+  'article_title',
+  'article_text',
+  'article_site',
+  'enriched_at',
+  'folder_ids',
+  'folder_names',
+  'article_source_tweet_id',
+  'article_locator',
+] as const;
+
 function insertRecord(db: Database, r: BookmarkRecord, preserved?: PreservedBookmarkFields): void {
   // Extract GitHub URLs (kept inline — no LLM needed for URL parsing)
   const text = r.text ?? '';
@@ -425,7 +467,8 @@ function insertRecord(db: Database, r: BookmarkRecord, preserved?: PreservedBook
   const usePreservedArticle = !useRawArticle && Boolean(preservedArticleLocator);
 
   db.run(
-    `INSERT OR REPLACE INTO bookmarks VALUES (${Array(39).fill('?').join(',')})`,
+    `INSERT OR REPLACE INTO bookmarks (${BOOKMARK_INSERT_COLUMNS.join(',')})
+     VALUES (${BOOKMARK_INSERT_COLUMNS.map(() => '?').join(',')})`,
     [
       r.id,
       r.tweetId,

--- a/src/bookmarks-db.ts
+++ b/src/bookmarks-db.ts
@@ -6,7 +6,7 @@ import { twitterBookmarksCachePath, twitterBookmarksIndexPath } from './paths.js
 import type { BookmarkRecord, QuotedTweetSnapshot } from './types.js';
 import { classifyCorpus, formatClassificationSummary } from './bookmark-classify.js';
 import type { ClassificationSummary } from './bookmark-classify.js';
-import { bindArticleLocator, canonicalHttpLocator } from './source-bindings.js';
+import { bindArticleEnrichment, canonicalHttpLocator } from './source-bindings.js';
 
 const SCHEMA_VERSION = 7;
 
@@ -454,15 +454,18 @@ function insertRecord(db: Database, r: BookmarkRecord, preserved?: PreservedBook
     ? JSON.stringify(r.quotedTweet)
     : null;
 
-  const rawArticleLocator = r.articleText
-    && (r.articleSourceTweetId ?? r.tweetId) === r.tweetId
-      ? bindArticleLocator(r.links ?? [], r.articleLocator)
-      : undefined;
+  const rawArticleLocator = bindArticleEnrichment(r.tweetId, r.links ?? [], {
+    articleText: r.articleText,
+    sourceTweetId: r.articleSourceTweetId ?? r.tweetId,
+    sourceLocator: r.articleLocator,
+  });
   const preservedArticleLocator = preservedRootMatches
-    && preserved?.articleText
-    && preserved.articleSourceTweetId === r.tweetId
-      ? bindArticleLocator(r.links ?? [], preserved.articleLocator)
-      : undefined;
+    ? bindArticleEnrichment(r.tweetId, r.links ?? [], {
+        articleText: preserved?.articleText,
+        sourceTweetId: preserved?.articleSourceTweetId,
+        sourceLocator: preserved?.articleLocator,
+      })
+    : undefined;
   const useRawArticle = Boolean(r.articleText && rawArticleLocator);
   const usePreservedArticle = !useRawArticle && Boolean(preservedArticleLocator);
 

--- a/src/bookmarks-db.ts
+++ b/src/bookmarks-db.ts
@@ -1255,6 +1255,8 @@ export async function updateQuotedTweets(
       'UPDATE bookmarks SET quoted_tweet_json = ? WHERE id = ? AND quoted_status_id = ?',
     );
     for (const record of records) {
+      // A mismatched quote identity intentionally updates zero rows: derived
+      // content must never replace the root-owned quote binding.
       stmt.run([JSON.stringify(record.quotedTweet), record.id, record.quotedTweet.id]);
     }
     stmt.free();
@@ -1314,6 +1316,8 @@ export async function updateArticleContent(
       if (!record.sourceTweetId || !canonicalHttpLocator(record.sourceLocator)) {
         throw new Error(`Refusing unbound article enrichment for bookmark ${record.id}`);
       }
+      // The tweet_id predicate intentionally rejects wrong-root enrichment by
+      // updating zero rows instead of attaching content across identities.
       stmt.run([
         record.articleTitle,
         record.articleText,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1371,10 +1371,14 @@ export function buildCli() {
 
       let manifest = snapshot.manifest;
       if (options.fetchMedia) {
+        const requestedMediaMaxBytes = Number(options.mediaMaxBytes);
+        const mediaMaxBytes = Number.isFinite(requestedMediaMaxBytes)
+          ? Math.max(0, requestedMediaMaxBytes)
+          : DEFAULT_MEDIA_MAX_BYTES;
         await fetchBookmarkMediaBatch(requestExecutor!, {
           records: [record],
           limit: 1,
-          maxBytes: Number(options.mediaMaxBytes) || DEFAULT_MEDIA_MAX_BYTES,
+          maxBytes: mediaMaxBytes,
           skipProfileImages: Boolean(options.skipProfileImages),
         });
         manifest = await loadBoundMediaManifest(record.id);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -37,6 +37,7 @@ import { canonicalLibraryDir, dataDir, ensureDataDir, isFirstRun, migrateLegacyI
 import { materializeBookmark } from './bookmark-materialization.js';
 import { loadBoundMediaManifest, loadCanonicalBookmarkSnapshot } from './bookmark-snapshot.js';
 import { refreshExactXBookmark } from './x-materialize.js';
+import { XRequestExecutor } from './x-request-policy.js';
 import { PromptCancelledError, promptText } from './prompt.js';
 import { skillWithFrontmatter, installSkill, uninstallSkill } from './skill.js';
 import { registerCompanionCommands } from './companion-cli.js';
@@ -272,7 +273,8 @@ async function runMediaFetchWithProgress(options: { limit?: number; maxBytes?: n
       console.log('\n  Interrupted. Saving media progress...\n');
     },
   });
-  const result = await runWithSpinner(spinner, () => fetchBookmarkMediaBatch({
+  const requestExecutor = new XRequestExecutor({ maxAttempts: 1 });
+  const result = await runWithSpinner(spinner, () => fetchBookmarkMediaBatch(requestExecutor, {
     limit: options.limit,
     maxBytes: options.maxBytes,
     skipProfileImages: options.skipProfileImages,
@@ -1339,6 +1341,11 @@ export function buildCli() {
       const snapshot = await loadCanonicalBookmarkSnapshot(exactId);
       let record: BookmarkRecord = snapshot.record;
       let refreshObservation = null;
+      const requestedDelayMs = Number(options.delayMs);
+      const delayMs = Number.isFinite(requestedDelayMs) ? Math.max(0, requestedDelayMs) : 300;
+      const requestExecutor = options.refresh || options.fetchMedia
+        ? new XRequestExecutor({ delayMs })
+        : undefined;
       if (options.refresh) {
         const directCookies = parseCookieOption(options.cookies);
         const cookies = resolveGapFillCookies({
@@ -1355,7 +1362,8 @@ export function buildCli() {
         const refreshed = await refreshExactXBookmark(record, {
           csrfToken: cookies.csrfToken,
           cookieHeader: cookies.cookieHeader,
-          delayMs: Number(options.delayMs) || 300,
+          delayMs,
+          requestExecutor,
         });
         record = refreshed.record;
         refreshObservation = refreshed.observation;
@@ -1363,7 +1371,7 @@ export function buildCli() {
 
       let manifest = snapshot.manifest;
       if (options.fetchMedia) {
-        await fetchBookmarkMediaBatch({
+        await fetchBookmarkMediaBatch(requestExecutor!, {
           records: [record],
           limit: 1,
           maxBytes: Number(options.mediaMaxBytes) || DEFAULT_MEDIA_MAX_BYTES,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -33,9 +33,9 @@ import { exportBookmarks } from './md-export.js';
 import { renderViz } from './bookmarks-viz.js';
 import { listBrowserIds } from './browsers.js';
 import { configureHttpProxyFromEnv } from './http-proxy.js';
-import { canonicalLibraryDir, dataDir, ensureDataDir, isFirstRun, migrateLegacyIdeasData, twitterBookmarksCachePath, twitterBookmarksIndexPath, twitterBackfillStatePath, mdDir, bookmarkMediaDir, bookmarkMediaManifestPath } from './paths.js';
-import { pathExists, readJson, readJsonLines } from './fs.js';
+import { canonicalLibraryDir, dataDir, ensureDataDir, isFirstRun, migrateLegacyIdeasData, twitterBookmarksIndexPath, twitterBackfillStatePath, mdDir, bookmarkMediaDir, bookmarkMediaManifestPath } from './paths.js';
 import { materializeBookmark } from './bookmark-materialization.js';
+import { loadBoundMediaManifest, loadCanonicalBookmarkSnapshot } from './bookmark-snapshot.js';
 import { refreshExactXBookmark } from './x-materialize.js';
 import { PromptCancelledError, promptText } from './prompt.js';
 import { skillWithFrontmatter, installSkill, uninstallSkill } from './skill.js';
@@ -1336,25 +1336,8 @@ export function buildCli() {
         throw new Error('Materialization requires one exact numeric X bookmark id.');
       }
 
-      const archived = (await readJsonLines<BookmarkRecord>(twitterBookmarksCachePath()))
-        .find((row) => row.tweetId === exactId || row.id === exactId);
-      if (!archived || archived.tweetId !== exactId) {
-        throw new Error(`Archived X bookmark not found: ${exactId}`);
-      }
-
-      const indexed = await pathExists(twitterBookmarksIndexPath())
-        ? await getBookmarkById(archived.id)
-        : null;
-      let record: BookmarkRecord = {
-        ...archived,
-        text: indexed?.text?.trim() ? indexed.text : archived.text,
-        quotedStatusId: indexed?.quotedStatusId ?? archived.quotedStatusId,
-        quotedTweet: indexed?.quotedTweet ?? archived.quotedTweet,
-        articleTitle: indexed?.articleTitle ?? archived.articleTitle,
-        articleText: indexed?.articleText ?? archived.articleText,
-        articleSite: indexed?.articleSite ?? archived.articleSite,
-        enrichedAt: indexed?.enrichedAt ?? archived.enrichedAt,
-      };
+      const snapshot = await loadCanonicalBookmarkSnapshot(exactId);
+      let record: BookmarkRecord = snapshot.record;
       let refreshObservation = null;
       if (options.refresh) {
         const directCookies = parseCookieOption(options.cookies);
@@ -1378,6 +1361,7 @@ export function buildCli() {
         refreshObservation = refreshed.observation;
       }
 
+      let manifest = snapshot.manifest;
       if (options.fetchMedia) {
         await fetchBookmarkMediaBatch({
           records: [record],
@@ -1385,11 +1369,9 @@ export function buildCli() {
           maxBytes: Number(options.mediaMaxBytes) || DEFAULT_MEDIA_MAX_BYTES,
           skipProfileImages: Boolean(options.skipProfileImages),
         });
+        manifest = await loadBoundMediaManifest(record.id);
       }
 
-      const manifest = await pathExists(bookmarkMediaManifestPath())
-        ? await readJson<MediaFetchManifest>(bookmarkMediaManifestPath())
-        : null;
       const result = await materializeBookmark(record, manifest, refreshObservation);
       if (options.json) {
         printJson(result);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1342,7 +1342,19 @@ export function buildCli() {
         throw new Error(`Archived X bookmark not found: ${exactId}`);
       }
 
-      let record = archived;
+      const indexed = await pathExists(twitterBookmarksIndexPath())
+        ? await getBookmarkById(archived.id)
+        : null;
+      let record: BookmarkRecord = {
+        ...archived,
+        text: indexed?.text?.trim() ? indexed.text : archived.text,
+        quotedStatusId: indexed?.quotedStatusId ?? archived.quotedStatusId,
+        quotedTweet: indexed?.quotedTweet ?? archived.quotedTweet,
+        articleTitle: indexed?.articleTitle ?? archived.articleTitle,
+        articleText: indexed?.articleText ?? archived.articleText,
+        articleSite: indexed?.articleSite ?? archived.articleSite,
+        enrichedAt: indexed?.enrichedAt ?? archived.enrichedAt,
+      };
       let refreshObservation = null;
       if (options.refresh) {
         const directCookies = parseCookieOption(options.cookies);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,9 +3,9 @@ import { Command, InvalidArgumentError, Option } from 'commander';
 import { syncTwitterBookmarks } from './bookmarks.js';
 import { getBookmarkStatusView, formatBookmarkStatus } from './bookmarks-service.js';
 import { runTwitterOAuthFlow } from './xauth.js';
-import { syncBookmarksGraphQL, syncGaps, syncBookmarkFolders } from './graphql-bookmarks.js';
+import { resolveGapFillCookies, syncBookmarksGraphQL, syncGaps, syncBookmarkFolders } from './graphql-bookmarks.js';
 import type { SyncProgress, GapFillProgress, FolderSyncProgress } from './graphql-bookmarks.js';
-import type { BookmarkFolder, QuotedTweetSnapshot } from './types.js';
+import type { BookmarkFolder, BookmarkRecord, QuotedTweetSnapshot } from './types.js';
 import { DEFAULT_MEDIA_MAX_BYTES, fetchBookmarkMediaBatch } from './bookmark-media.js';
 import type { MediaFetchManifest, MediaFetchProgress } from './bookmark-media.js';
 import {
@@ -33,7 +33,10 @@ import { exportBookmarks } from './md-export.js';
 import { renderViz } from './bookmarks-viz.js';
 import { listBrowserIds } from './browsers.js';
 import { configureHttpProxyFromEnv } from './http-proxy.js';
-import { canonicalLibraryDir, dataDir, ensureDataDir, isFirstRun, migrateLegacyIdeasData, twitterBookmarksIndexPath, twitterBackfillStatePath, mdDir, bookmarkMediaDir, bookmarkMediaManifestPath } from './paths.js';
+import { canonicalLibraryDir, dataDir, ensureDataDir, isFirstRun, migrateLegacyIdeasData, twitterBookmarksCachePath, twitterBookmarksIndexPath, twitterBackfillStatePath, mdDir, bookmarkMediaDir, bookmarkMediaManifestPath } from './paths.js';
+import { pathExists, readJson, readJsonLines } from './fs.js';
+import { materializeBookmark } from './bookmark-materialization.js';
+import { refreshExactXBookmark } from './x-materialize.js';
 import { PromptCancelledError, promptText } from './prompt.js';
 import { skillWithFrontmatter, installSkill, uninstallSkill } from './skill.js';
 import { registerCompanionCommands } from './companion-cli.js';
@@ -1307,6 +1310,84 @@ export function buildCli() {
       if (item.links.length) console.log(`links: ${item.links.join(', ')}`);
       if (item.categories) console.log(`categories: ${item.categories}`);
       if (item.domains) console.log(`domains: ${item.domains}`);
+    }));
+
+  // ── materialize ─────────────────────────────────────────────────────────
+
+  program
+    .command('materialize')
+    .description('Materialize one exact archived X bookmark and its source-owned components')
+    .argument('<id>', 'Exact numeric X bookmark id')
+    .option('--refresh', 'Refresh only this exact root and its bounded thread context', false)
+    .option('--fetch-media', 'Fetch only this exact root and enumerated component media', false)
+    .option('--media-max-bytes <n>', 'Per-asset byte limit for requested media', (v: string) => Number(v), DEFAULT_MEDIA_MAX_BYTES)
+    .option('--skip-profile-images', 'Skip author profile images during requested media fetch', false)
+    .option('--delay-ms <n>', 'Delay between exact X requests in ms', (v: string) => Number(v), 300)
+    .option('--browser <name>', 'Browser to read the existing X session from')
+    .option('--cookies <values...>', 'Pass ct0 and auth_token directly (skips browser extraction)')
+    .option('--chrome-user-data-dir <path>', 'Chrome-family user-data directory')
+    .option('--chrome-profile-directory <name>', 'Chrome-family profile name')
+    .option('--firefox-profile-dir <path>', 'Firefox profile directory')
+    .option('--json', 'JSON output')
+    .action(safe(async (id: string, options) => {
+      if (!requireData()) return;
+      const exactId = String(id);
+      if (!/^\d{5,25}$/.test(exactId)) {
+        throw new Error('Materialization requires one exact numeric X bookmark id.');
+      }
+
+      const archived = (await readJsonLines<BookmarkRecord>(twitterBookmarksCachePath()))
+        .find((row) => row.tweetId === exactId || row.id === exactId);
+      if (!archived || archived.tweetId !== exactId) {
+        throw new Error(`Archived X bookmark not found: ${exactId}`);
+      }
+
+      let record = archived;
+      let refreshObservation = null;
+      if (options.refresh) {
+        const directCookies = parseCookieOption(options.cookies);
+        const cookies = resolveGapFillCookies({
+          browser: options.browser ? String(options.browser) : undefined,
+          chromeUserDataDir: options.chromeUserDataDir ? String(options.chromeUserDataDir) : undefined,
+          chromeProfileDirectory: options.chromeProfileDirectory ? String(options.chromeProfileDirectory) : undefined,
+          firefoxProfileDir: options.firefoxProfileDir ? String(options.firefoxProfileDir) : undefined,
+          csrfToken: directCookies.csrfToken,
+          cookieHeader: directCookies.cookieHeader,
+        });
+        if (!cookies.csrfToken) {
+          throw new Error('Exact X refresh requires an authenticated browser session or --cookies <ct0> [auth_token].');
+        }
+        const refreshed = await refreshExactXBookmark(record, {
+          csrfToken: cookies.csrfToken,
+          cookieHeader: cookies.cookieHeader,
+          delayMs: Number(options.delayMs) || 300,
+        });
+        record = refreshed.record;
+        refreshObservation = refreshed.observation;
+      }
+
+      if (options.fetchMedia) {
+        await fetchBookmarkMediaBatch({
+          records: [record],
+          limit: 1,
+          maxBytes: Number(options.mediaMaxBytes) || DEFAULT_MEDIA_MAX_BYTES,
+          skipProfileImages: Boolean(options.skipProfileImages),
+        });
+      }
+
+      const manifest = await pathExists(bookmarkMediaManifestPath())
+        ? await readJson<MediaFetchManifest>(bookmarkMediaManifestPath())
+        : null;
+      const result = await materializeBookmark(record, manifest, refreshObservation);
+      if (options.json) {
+        printJson(result);
+        return;
+      }
+      console.log(`${result.source_id} · ${result.locator}`);
+      console.log(`${result.components.length} components · ${result.achieved_depth}`);
+      for (const row of result.components) {
+        console.log(`  ${row.disposition.padEnd(11)} ${row.relation} · ${row.source_locator}`);
+      }
     }));
 
   // ── stats ───────────────────────────────────────────────────────────────

--- a/src/graphql-bookmarks.ts
+++ b/src/graphql-bookmarks.ts
@@ -1513,7 +1513,9 @@ export function parseTweetResultByRestId(json: any, tweetId: string): QuotedTwee
   const userResult = tweet?.core?.user_results?.result;
   const handle = userResult?.core?.screen_name ?? userResult?.legacy?.screen_name;
   const mediaEntities: any[] = legacy?.extended_entities?.media ?? legacy?.entities?.media ?? [];
-  const resolvedId = String(legacy.id_str ?? tweet?.rest_id ?? tweetId);
+  const responseId = legacy.id_str ?? tweet?.rest_id;
+  if (responseId === undefined || responseId === null || String(responseId).length === 0) return null;
+  const resolvedId = String(responseId);
 
   return {
     id: resolvedId,
@@ -1698,7 +1700,7 @@ export async function fetchTweetByIdViaGraphQL(
       }
       const snapshot = parseTweetResultByRestId(json, tweetId);
       const article = parseTweetArticleByRestId(json);
-      if (!snapshot) return { snapshot: null, article, status: article ? 'ok' : 'empty', source: 'graphql' };
+      if (!snapshot) return { snapshot: null, article: null, status: 'error', source: 'graphql' };
       if (snapshot.id !== tweetId) {
         return { snapshot: null, article: null, status: 'error', source: 'graphql' };
       }

--- a/src/graphql-bookmarks.ts
+++ b/src/graphql-bookmarks.ts
@@ -9,13 +9,14 @@ import { exportBookmarksForSyncSeed, updateQuotedTweets, updateBookmarkText, upd
 import type { ArticleUpdate } from './bookmarks-db.js';
 import { fetchArticle, resolveTcoLink } from './bookmark-enrich.js';
 import type { ArticleContent } from './bookmark-enrich.js';
-import { bindArticleEnrichment, bindArticleLocator, xArticleIdentity } from './source-bindings.js';
+import { bindArticleEnrichment, bindArticleLocator, isXArticleLocator, xArticleIdentity } from './source-bindings.js';
 import { XRequestExecutor } from './x-request-policy.js';
 import {
   compareThreadTweetsChronologically,
   expandVisibleUrlEntities,
   extractExpandedLinks,
   parseTweetDetailResponse,
+  reduceExactDecimalIdentity,
   tweetUrlEntities,
 } from './tweet-snapshots.js';
 
@@ -1520,13 +1521,26 @@ export function parseTweetResultByRestId(json: any, tweetId: string): QuotedTwee
   const userResult = tweet?.core?.user_results?.result;
   const handle = userResult?.core?.screen_name ?? userResult?.legacy?.screen_name;
   const mediaEntities: any[] = legacy?.extended_entities?.media ?? legacy?.entities?.media ?? [];
-  const responseId = legacy.id_str ?? tweet?.rest_id;
-  if (responseId === undefined || responseId === null || String(responseId).length === 0) return null;
-  const resolvedId = String(responseId);
+  const focalIdentity = reduceExactDecimalIdentity(legacy.id_str, tweet?.rest_id);
+  if (focalIdentity.status !== 'ok' || focalIdentity.id !== tweetId) return null;
+  const resolvedId = focalIdentity.id;
+  const quotedStatusResult = tweet?.quoted_status_result;
+  const quotedResult = quotedStatusResult?.result;
+  const quotedTweet = quotedResult?.tweet ?? quotedResult;
+  const quoteIdentity = reduceExactDecimalIdentity(
+    legacy.quoted_status_id_str,
+    quotedTweet?.legacy?.id_str,
+    quotedTweet?.rest_id,
+  );
+  if (quoteIdentity.status === 'invalid') return null;
+  const quotedStatusId = quoteIdentity.status === 'ok' ? quoteIdentity.id : undefined;
+  const quotedStatusIdentityUnresolved = Boolean(quotedStatusResult && !quotedStatusId);
 
   return {
     id: resolvedId,
     text,
+    ...(quotedStatusId ? { quotedStatusId } : {}),
+    ...(quotedStatusIdentityUnresolved ? { quotedStatusIdentityUnresolved: true } : {}),
     authorHandle: handle,
     authorName: userResult?.core?.name ?? userResult?.legacy?.name,
     authorProfileImageUrl:
@@ -1618,10 +1632,14 @@ function focalArticleCandidates(tweet: any): any[] {
 }
 
 function articleCandidateLocator(candidate: any, sourceLinks: string[]): string | undefined {
-  const candidateId = candidate?.rest_id ?? candidate?.article_id ?? candidate?.id;
-  if (candidateId !== undefined && candidateId !== null && String(candidateId).length > 0) {
-    const requested = `https://x.com/i/article/${String(candidateId)}`;
-    return bindArticleLocator(sourceLinks, requested) ?? requested;
+  const identity = reduceExactDecimalIdentity(candidate?.rest_id, candidate?.article_id, candidate?.id);
+  if (identity.status === 'invalid') return undefined;
+  if (identity.status === 'ok') {
+    const requested = `https://x.com/i/article/${identity.id}`;
+    const focalArticleLinks = sourceLinks.filter(isXArticleLocator);
+    return focalArticleLinks.length > 0
+      ? bindArticleLocator(focalArticleLinks, requested)
+      : requested;
   }
   return bindArticleLocator(sourceLinks);
 }
@@ -1630,9 +1648,9 @@ export function parseTweetArticleByRestId(json: any, requestedTweetId?: string):
   const result = json?.data?.tweetResult?.result;
   if (!result) return null;
   const tweet = result.tweet ?? result;
-  const responseTweetId = tweet?.legacy?.id_str ?? tweet?.rest_id;
-  if (responseTweetId === undefined || responseTweetId === null) return null;
-  const sourceTweetId = String(responseTweetId);
+  const focalIdentity = reduceExactDecimalIdentity(tweet?.legacy?.id_str, tweet?.rest_id);
+  if (focalIdentity.status !== 'ok') return null;
+  const sourceTweetId = focalIdentity.id;
   if (requestedTweetId && sourceTweetId !== requestedTweetId) return null;
   const sourceLinks = extractExpandedLinks(tweetUrlEntities(tweet, tweet?.legacy));
 
@@ -2026,16 +2044,6 @@ function isLinkOnlyBookmark(record: BookmarkRecord): boolean {
   return textWithoutUrls(record.text ?? '').length < LINK_ONLY_THRESHOLD;
 }
 
-function isXArticleUrl(value: string): boolean {
-  try {
-    const url = new URL(value);
-    const host = url.hostname.toLowerCase();
-    return (host === 'x.com' || host === 'twitter.com') && url.pathname.startsWith('/i/article/');
-  } catch {
-    return false;
-  }
-}
-
 async function readEnrichedBookmarkIds(records: BookmarkRecord[]): Promise<Set<string>> {
   const enrichedIds = new Set<string>();
   const recordsById = new Map(records.map((record) => [record.id, record]));
@@ -2102,7 +2110,7 @@ export async function syncGaps(options: SyncGapsOptions = {}): Promise<GapFillRe
   // Gap 3a: X Article bookmarks can look short ("x.com/i/article/…") even
   // when the useful body exists in the authenticated TweetResult payload.
   const needsXArticle = records.filter((r) =>
-    !enrichedIds.has(r.id) && isLinkOnlyBookmark(r) && (r.links ?? []).some(isXArticleUrl)
+    !enrichedIds.has(r.id) && isLinkOnlyBookmark(r) && (r.links ?? []).some(isXArticleLocator)
   );
   const xArticleIds = new Set(needsXArticle.map((r) => r.tweetId));
 
@@ -2291,7 +2299,7 @@ export async function syncGaps(options: SyncGapsOptions = {}): Promise<GapFillRe
   // Filter to link-only bookmarks not yet enriched
   const needsEnrichment = records.filter((r) => {
     if (enrichedIds.has(r.id)) return false;
-    if ((r.links ?? []).some(isXArticleUrl)) return false;
+    if ((r.links ?? []).some(isXArticleLocator)) return false;
     return isLinkOnlyBookmark(r);
   });
 

--- a/src/graphql-bookmarks.ts
+++ b/src/graphql-bookmarks.ts
@@ -1738,18 +1738,22 @@ export async function fetchTweetDetailViaGraphQL(
   httpStatus?: number;
   enumerationComplete: boolean;
   remainingCursor?: string;
+  remainingCursors?: string[];
   parserGap: boolean;
 }> {
   const maxPages = options.maxPages ?? 3;
   const delayMs = options.delayMs ?? 300;
   const tweets: ThreadTweetSnapshot[] = [];
-  let cursor: string | undefined;
+  const pendingCursors: Array<string | undefined> = [undefined];
+  const processedCursors = new Set<string>();
   let sawRecognizedTimeline = false;
   let sawTweetResult = false;
   let sawUnavailableTweet = false;
   let sawUnparseableTweet = false;
 
-  for (let page = 0; page < maxPages; page++) {
+  for (let page = 0; page < maxPages && pendingCursors.length > 0; page++) {
+    const cursor = pendingCursors.shift();
+    if (cursor) processedCursors.add(cursor);
     let response: Response;
     try {
       response = await fetch(buildTweetDetailUrl(tweetId, cursor), {
@@ -1770,29 +1774,41 @@ export async function fetchTweetDetailViaGraphQL(
     sawUnavailableTweet ||= parsed.sawUnavailableTweet;
     sawUnparseableTweet ||= parsed.sawUnparseableTweet;
     tweets.push(...parsed.tweets);
-    if (!parsed.nextCursor) {
-      cursor = undefined;
-      break;
+    for (const nextCursor of parsed.continuationCursors) {
+      if (processedCursors.has(nextCursor)) {
+        sawUnparseableTweet = true;
+        continue;
+      }
+      if (!pendingCursors.includes(nextCursor)) pendingCursors.push(nextCursor);
     }
-    if (parsed.nextCursor === cursor) break;
-    cursor = parsed.nextCursor;
-    if (page < maxPages - 1) await new Promise((resolve) => setTimeout(resolve, delayMs));
+    if (page < maxPages - 1 && pendingCursors.length > 0) {
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+    }
   }
 
   const byId = new Map<string, ThreadTweetSnapshot>();
   for (const tweet of tweets) if (!byId.has(tweet.id)) byId.set(tweet.id, tweet);
   const parserGap = sawUnavailableTweet || sawUnparseableTweet;
-  const enumerationComplete = !cursor && !parserGap;
+  const remainingCursors = pendingCursors.filter((value): value is string => Boolean(value));
+  const enumerationComplete = pendingCursors.length === 0 && !parserGap;
   if (byId.size === 0) {
     if (sawUnavailableTweet && !sawUnparseableTweet) return { tweets: [], status: 'not_found', enumerationComplete: false, parserGap };
-    if (sawRecognizedTimeline && !sawTweetResult) return { tweets: [], status: 'empty', enumerationComplete, parserGap };
+    if (sawRecognizedTimeline && !sawTweetResult) return {
+      tweets: [],
+      status: 'empty',
+      enumerationComplete: false,
+      ...(remainingCursors[0] ? { remainingCursor: remainingCursors[0] } : {}),
+      ...(remainingCursors.length > 0 ? { remainingCursors } : {}),
+      parserGap,
+    };
     return { tweets: [], status: 'error', enumerationComplete: false, parserGap: true };
   }
   return {
     tweets: Array.from(byId.values()).sort(compareThreadTweetsChronologically),
     status: 'ok',
     enumerationComplete,
-    ...(cursor ? { remainingCursor: cursor } : {}),
+    ...(remainingCursors[0] ? { remainingCursor: remainingCursors[0] } : {}),
+    ...(remainingCursors.length > 0 ? { remainingCursors } : {}),
     parserGap,
   };
 }

--- a/src/graphql-bookmarks.ts
+++ b/src/graphql-bookmarks.ts
@@ -1881,13 +1881,19 @@ async function fetchTweetViaSyndication(tweetId: string): Promise<TweetFetchResu
     if (response.ok) {
       const data = await response.json() as any;
       if (!data?.text) return { snapshot: null, status: 'empty', source: 'syndication' };
+      const responseTweetId = data.id_str === undefined || data.id_str === null
+        ? null
+        : String(data.id_str);
+      if (responseTweetId !== tweetId) {
+        return { snapshot: null, status: 'error', source: 'syndication' };
+      }
       const handle = data.user?.screen_name;
       const mediaEntities: any[] = data.mediaDetails ?? [];
       return {
         status: 'ok',
         source: 'syndication',
         snapshot: {
-          id: String(data.id_str ?? tweetId),
+          id: responseTweetId,
           text: data.text,
           authorHandle: handle,
           authorName: data.user?.name,
@@ -1900,7 +1906,7 @@ async function fetchTweetViaSyndication(tweetId: string): Promise<TweetFetchResu
             width: m.original_info?.width,
             height: m.original_info?.height,
           })),
-          url: `https://x.com/${handle ?? '_'}/status/${data.id_str ?? tweetId}`,
+          url: `https://x.com/${handle ?? '_'}/status/${responseTweetId}`,
         },
       };
     }
@@ -2130,11 +2136,23 @@ export async function syncGaps(options: SyncGapsOptions = {}): Promise<GapFillRe
     let resultSource: TweetFetchSource | undefined;
     try {
       const result = await fetcher(tweetId);
-      snapshot = result.snapshot;
-      article = result.article;
+      const identityMismatch = Boolean(
+        (result.snapshot && result.snapshot.id !== tweetId)
+        || (result.article && result.article.sourceTweetId !== tweetId),
+      );
+      snapshot = identityMismatch ? null : result.snapshot;
+      article = identityMismatch ? null : result.article;
       resultStatus = result.status;
       resultSource = result.source;
-      if (!snapshot && !article) {
+      if (identityMismatch) {
+        resultStatus = 'error';
+        failed++;
+        failures.push({
+          tweetId,
+          reason: 'fetched content did not bind to the requested tweet identity',
+          url: `https://x.com/_/status/${tweetId}`,
+        });
+      } else if (!snapshot && !article) {
         failed++;
         failures.push({
           tweetId,

--- a/src/graphql-bookmarks.ts
+++ b/src/graphql-bookmarks.ts
@@ -1768,7 +1768,13 @@ export async function fetchTweetDetailViaGraphQL(
     if (response.status >= 500) return { tweets, status: 'server_error', httpStatus: response.status, enumerationComplete: false, parserGap: false };
     if (!response.ok) return { tweets, status: 'error', httpStatus: response.status, enumerationComplete: false, parserGap: false };
 
-    const parsed = parseTweetDetailResponse(await response.json());
+    let json: unknown;
+    try {
+      json = await response.json();
+    } catch {
+      return { tweets, status: 'error', httpStatus: response.status, enumerationComplete: false, parserGap: true };
+    }
+    const parsed = parseTweetDetailResponse(json);
     sawRecognizedTimeline ||= parsed.recognizedTimeline;
     sawTweetResult ||= parsed.sawTweetResult;
     sawUnavailableTweet ||= parsed.sawUnavailableTweet;

--- a/src/graphql-bookmarks.ts
+++ b/src/graphql-bookmarks.ts
@@ -4,11 +4,18 @@ import { loadChromeSessionConfig } from './config.js';
 import { extractChromeXCookies } from './chrome-cookies.js';
 import { extractFirefoxXCookies } from './firefox-cookies.js';
 import { parseTimestampMs } from './date-utils.js';
-import type { BookmarkBackfillState, BookmarkCacheMeta, BookmarkFolder, BookmarkRecord, QuotedTweetSnapshot } from './types.js';
+import type { BookmarkBackfillState, BookmarkCacheMeta, BookmarkFolder, BookmarkRecord, QuotedTweetSnapshot, ThreadTweetSnapshot } from './types.js';
 import { exportBookmarksForSyncSeed, updateQuotedTweets, updateBookmarkText, updateArticleContent } from './bookmarks-db.js';
 import type { ArticleUpdate } from './bookmarks-db.js';
 import { fetchArticle, resolveTcoLink } from './bookmark-enrich.js';
 import type { ArticleContent } from './bookmark-enrich.js';
+import {
+  compareThreadTweetsChronologically,
+  expandVisibleUrlEntities,
+  extractExpandedLinks,
+  parseTweetDetailResponse,
+  tweetUrlEntities,
+} from './tweet-snapshots.js';
 
 const CHROME_UA = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.0.0 Safari/537.36';
 
@@ -25,6 +32,8 @@ const BOOKMARKS_OPERATION = 'Bookmarks';
 // working against Karpathy's 2039805659525644595 note_tweet on 2026-04-15.
 const TWEET_RESULT_BY_REST_ID_QUERY_ID = 'fHLDP3qFEjnTqhWBVvsREg';
 const TWEET_RESULT_BY_REST_ID_OPERATION = 'TweetResultByRestId';
+const TWEET_DETAIL_QUERY_ID = '-0WTL1e9Pij-JWAF5ztCCA';
+const TWEET_DETAIL_OPERATION = 'TweetDetail';
 
 // ──────────────────────────────────────────────────────────────────────────
 // Folder endpoints — READ ONLY. We never POST/PUT/DELETE to X.
@@ -1436,6 +1445,41 @@ const TWEET_RESULT_FIELD_TOGGLES = {
   withAuxiliaryUserLabels: false,
 };
 
+const TWEET_DETAIL_FEATURES = {
+  rweb_video_screen_enabled: false,
+  payments_enabled: false,
+  profile_label_improvements_pcf_label_in_post_enabled: true,
+  rweb_tipjar_consumption_enabled: true,
+  verified_phone_label_enabled: false,
+  creator_subscriptions_tweet_preview_api_enabled: true,
+  responsive_web_graphql_timeline_navigation_enabled: true,
+  responsive_web_graphql_skip_user_profile_image_extensions_enabled: false,
+  premium_content_api_read_enabled: false,
+  communities_web_enable_tweet_community_results_fetch: true,
+  c9s_tweet_anatomy_moderator_badge_enabled: true,
+  responsive_web_grok_analyze_button_fetch_trends_enabled: false,
+  responsive_web_grok_analyze_post_followups_enabled: true,
+  responsive_web_jetfuel_frame: false,
+  responsive_web_grok_share_attachment_enabled: true,
+  articles_preview_enabled: true,
+  responsive_web_edit_tweet_api_enabled: true,
+  graphql_is_translatable_rweb_tweet_is_translatable_enabled: true,
+  view_counts_everywhere_api_enabled: true,
+  longform_notetweets_consumption_enabled: true,
+  responsive_web_twitter_article_tweet_consumption_enabled: true,
+  tweet_awards_web_tipping_enabled: false,
+  responsive_web_grok_show_grok_translated_post: false,
+  responsive_web_grok_analysis_button_from_backend: false,
+  creator_subscriptions_quote_tweet_preview_enabled: false,
+  freedom_of_speech_not_reach_fetch_enabled: true,
+  standardized_nudges_misinfo: true,
+  tweet_with_visibility_results_prefer_gql_limited_actions_policy_enabled: true,
+  longform_notetweets_rich_text_read_enabled: true,
+  longform_notetweets_inline_media_enabled: true,
+  responsive_web_grok_image_annotation_enabled: true,
+  responsive_web_enhance_cards_enabled: false,
+};
+
 export type TweetFetchSource = 'graphql' | 'syndication';
 
 export interface TweetFetchResult {
@@ -1461,8 +1505,9 @@ export function parseTweetResultByRestId(json: any, tweetId: string): QuotedTwee
   const legacy = tweet?.legacy;
   if (!legacy) return null;
 
+  const urlEntities = tweetUrlEntities(tweet, legacy);
   const noteText = tweet?.note_tweet?.note_tweet_results?.result?.text;
-  const text = noteText ?? legacy.full_text ?? legacy.text ?? '';
+  const text = expandVisibleUrlEntities(noteText ?? legacy.full_text ?? legacy.text ?? '', urlEntities);
   if (!text) return null;
 
   const userResult = tweet?.core?.user_results?.result;
@@ -1485,7 +1530,16 @@ export function parseTweetResultByRestId(json: any, tweetId: string): QuotedTwee
       expandedUrl: m.expanded_url,
       width: m.original_info?.width,
       height: m.original_info?.height,
+      altText: m.ext_alt_text,
+      videoVariants: Array.isArray(m.video_info?.variants)
+        ? m.video_info.variants
+            .filter((v: any) => v.content_type === 'video/mp4')
+            .map((v: any) => ({ bitrate: v.bitrate, url: v.url }))
+        : undefined,
     })),
+    links: extractExpandedLinks(urlEntities),
+    conversationId: legacy.conversation_id_str,
+    inReplyToStatusId: legacy.in_reply_to_status_id_str,
     url: `https://x.com/${handle ?? '_'}/status/${resolvedId}`,
   };
 }
@@ -1591,6 +1645,27 @@ function buildTweetResultByRestIdUrl(tweetId: string): string {
   return `https://x.com/i/api/graphql/${TWEET_RESULT_BY_REST_ID_QUERY_ID}/${TWEET_RESULT_BY_REST_ID_OPERATION}?${params}`;
 }
 
+function buildTweetDetailUrl(tweetId: string, cursor?: string): string {
+  const variables: Record<string, unknown> = {
+    focalTweetId: tweetId,
+    with_rux_injections: false,
+    includePromotedContent: false,
+    withCommunity: true,
+    withQuickPromoteEligibilityTweetFields: true,
+    withBirdwatchNotes: true,
+    withVoice: true,
+    withV2Timeline: true,
+    rankingMode: 'Relevance',
+    count: 40,
+  };
+  if (cursor) variables.cursor = cursor;
+  const params = new URLSearchParams({
+    variables: JSON.stringify(variables),
+    features: JSON.stringify(TWEET_DETAIL_FEATURES),
+  });
+  return `https://x.com/i/api/graphql/${TWEET_DETAIL_QUERY_ID}/${TWEET_DETAIL_OPERATION}?${params}`;
+}
+
 export async function fetchTweetByIdViaGraphQL(
   tweetId: string,
   csrfToken: string,
@@ -1645,6 +1720,60 @@ export async function fetchTweetByIdViaGraphQL(
     return { snapshot: null, status: 'error', httpStatus: response.status, source: 'graphql' };
   }
   return { snapshot: null, status: 'rate_limited', source: 'graphql' };
+}
+
+export async function fetchTweetDetailViaGraphQL(
+  tweetId: string,
+  csrfToken: string,
+  cookieHeader?: string,
+  options: { maxPages?: number; delayMs?: number } = {},
+): Promise<{ tweets: ThreadTweetSnapshot[]; status: TweetFetchResult['status']; httpStatus?: number }> {
+  const maxPages = options.maxPages ?? 3;
+  const delayMs = options.delayMs ?? 300;
+  const tweets: ThreadTweetSnapshot[] = [];
+  let cursor: string | undefined;
+  let sawRecognizedTimeline = false;
+  let sawTweetResult = false;
+  let sawUnavailableTweet = false;
+  let sawUnparseableTweet = false;
+
+  for (let page = 0; page < maxPages; page++) {
+    let response: Response;
+    try {
+      response = await fetch(buildTweetDetailUrl(tweetId, cursor), {
+        headers: buildHeaders(csrfToken, cookieHeader),
+      });
+    } catch {
+      return { tweets, status: 'error' };
+    }
+    if (response.status === 429) return { tweets, status: 'rate_limited', httpStatus: 429 };
+    if (response.status === 404) return { tweets, status: 'not_found', httpStatus: 404 };
+    if (response.status === 401 || response.status === 403) return { tweets, status: 'forbidden', httpStatus: response.status };
+    if (response.status >= 500) return { tweets, status: 'server_error', httpStatus: response.status };
+    if (!response.ok) return { tweets, status: 'error', httpStatus: response.status };
+
+    const parsed = parseTweetDetailResponse(await response.json());
+    sawRecognizedTimeline ||= parsed.recognizedTimeline;
+    sawTweetResult ||= parsed.sawTweetResult;
+    sawUnavailableTweet ||= parsed.sawUnavailableTweet;
+    sawUnparseableTweet ||= parsed.sawUnparseableTweet;
+    tweets.push(...parsed.tweets);
+    if (!parsed.nextCursor || parsed.nextCursor === cursor) break;
+    cursor = parsed.nextCursor;
+    if (page < maxPages - 1) await new Promise((resolve) => setTimeout(resolve, delayMs));
+  }
+
+  const byId = new Map<string, ThreadTweetSnapshot>();
+  for (const tweet of tweets) if (!byId.has(tweet.id)) byId.set(tweet.id, tweet);
+  if (byId.size === 0) {
+    if (sawUnavailableTweet && !sawUnparseableTweet) return { tweets: [], status: 'not_found' };
+    if (sawRecognizedTimeline && !sawTweetResult) return { tweets: [], status: 'empty' };
+    return { tweets: [], status: 'error' };
+  }
+  return {
+    tweets: Array.from(byId.values()).sort(compareThreadTweetsChronologically),
+    status: 'ok',
+  };
 }
 
 async function fetchTweetViaSyndication(tweetId: string): Promise<TweetFetchResult> {
@@ -1764,7 +1893,7 @@ export interface SyncGapsOptions {
   tweetFetcher?: TweetFetcher;
 }
 
-function resolveGapFillCookies(options: SyncGapsOptions): { csrfToken?: string; cookieHeader?: string } {
+export function resolveGapFillCookies(options: SyncGapsOptions): { csrfToken?: string; cookieHeader?: string } {
   if (options.csrfToken) {
     return { csrfToken: options.csrfToken, cookieHeader: options.cookieHeader };
   }

--- a/src/graphql-bookmarks.ts
+++ b/src/graphql-bookmarks.ts
@@ -1699,6 +1699,9 @@ export async function fetchTweetByIdViaGraphQL(
       const snapshot = parseTweetResultByRestId(json, tweetId);
       const article = parseTweetArticleByRestId(json);
       if (!snapshot) return { snapshot: null, article, status: article ? 'ok' : 'empty', source: 'graphql' };
+      if (snapshot.id !== tweetId) {
+        return { snapshot: null, article: null, status: 'error', source: 'graphql' };
+      }
       return { snapshot, article, status: 'ok', source: 'graphql' };
     }
 
@@ -1727,7 +1730,14 @@ export async function fetchTweetDetailViaGraphQL(
   csrfToken: string,
   cookieHeader?: string,
   options: { maxPages?: number; delayMs?: number } = {},
-): Promise<{ tweets: ThreadTweetSnapshot[]; status: TweetFetchResult['status']; httpStatus?: number }> {
+): Promise<{
+  tweets: ThreadTweetSnapshot[];
+  status: TweetFetchResult['status'];
+  httpStatus?: number;
+  enumerationComplete: boolean;
+  remainingCursor?: string;
+  parserGap: boolean;
+}> {
   const maxPages = options.maxPages ?? 3;
   const delayMs = options.delayMs ?? 300;
   const tweets: ThreadTweetSnapshot[] = [];
@@ -1744,13 +1754,13 @@ export async function fetchTweetDetailViaGraphQL(
         headers: buildHeaders(csrfToken, cookieHeader),
       });
     } catch {
-      return { tweets, status: 'error' };
+      return { tweets, status: 'error', enumerationComplete: false, parserGap: true };
     }
-    if (response.status === 429) return { tweets, status: 'rate_limited', httpStatus: 429 };
-    if (response.status === 404) return { tweets, status: 'not_found', httpStatus: 404 };
-    if (response.status === 401 || response.status === 403) return { tweets, status: 'forbidden', httpStatus: response.status };
-    if (response.status >= 500) return { tweets, status: 'server_error', httpStatus: response.status };
-    if (!response.ok) return { tweets, status: 'error', httpStatus: response.status };
+    if (response.status === 429) return { tweets, status: 'rate_limited', httpStatus: 429, enumerationComplete: false, parserGap: false };
+    if (response.status === 404) return { tweets, status: 'not_found', httpStatus: 404, enumerationComplete: false, parserGap: false };
+    if (response.status === 401 || response.status === 403) return { tweets, status: 'forbidden', httpStatus: response.status, enumerationComplete: false, parserGap: false };
+    if (response.status >= 500) return { tweets, status: 'server_error', httpStatus: response.status, enumerationComplete: false, parserGap: false };
+    if (!response.ok) return { tweets, status: 'error', httpStatus: response.status, enumerationComplete: false, parserGap: false };
 
     const parsed = parseTweetDetailResponse(await response.json());
     sawRecognizedTimeline ||= parsed.recognizedTimeline;
@@ -1758,21 +1768,30 @@ export async function fetchTweetDetailViaGraphQL(
     sawUnavailableTweet ||= parsed.sawUnavailableTweet;
     sawUnparseableTweet ||= parsed.sawUnparseableTweet;
     tweets.push(...parsed.tweets);
-    if (!parsed.nextCursor || parsed.nextCursor === cursor) break;
+    if (!parsed.nextCursor) {
+      cursor = undefined;
+      break;
+    }
+    if (parsed.nextCursor === cursor) break;
     cursor = parsed.nextCursor;
     if (page < maxPages - 1) await new Promise((resolve) => setTimeout(resolve, delayMs));
   }
 
   const byId = new Map<string, ThreadTweetSnapshot>();
   for (const tweet of tweets) if (!byId.has(tweet.id)) byId.set(tweet.id, tweet);
+  const parserGap = sawUnavailableTweet || sawUnparseableTweet;
+  const enumerationComplete = !cursor && !parserGap;
   if (byId.size === 0) {
-    if (sawUnavailableTweet && !sawUnparseableTweet) return { tweets: [], status: 'not_found' };
-    if (sawRecognizedTimeline && !sawTweetResult) return { tweets: [], status: 'empty' };
-    return { tweets: [], status: 'error' };
+    if (sawUnavailableTweet && !sawUnparseableTweet) return { tweets: [], status: 'not_found', enumerationComplete: false, parserGap };
+    if (sawRecognizedTimeline && !sawTweetResult) return { tweets: [], status: 'empty', enumerationComplete, parserGap };
+    return { tweets: [], status: 'error', enumerationComplete: false, parserGap: true };
   }
   return {
     tweets: Array.from(byId.values()).sort(compareThreadTweetsChronologically),
     status: 'ok',
+    enumerationComplete,
+    ...(cursor ? { remainingCursor: cursor } : {}),
+    parserGap,
   };
 }
 

--- a/src/graphql-bookmarks.ts
+++ b/src/graphql-bookmarks.ts
@@ -1590,7 +1590,7 @@ function articleFromCandidate(candidate: any): ArticleContent | null {
       : '';
 
   let text = '';
-  for (const key of ['articleBody', 'plain_text', 'plainText', 'body', 'text', 'description', 'preview_text', 'summary_text']) {
+  for (const key of ['articleBody', 'plain_text', 'plainText', 'body']) {
     if (typeof candidate[key] === 'string' && candidate[key].length > text.length) {
       text = candidate[key];
     }

--- a/src/graphql-bookmarks.ts
+++ b/src/graphql-bookmarks.ts
@@ -1487,7 +1487,7 @@ export type TweetFetchSource = 'graphql' | 'syndication';
 export interface TweetFetchResult {
   snapshot: QuotedTweetSnapshot | null;
   article?: TweetArticleContent | null;
-  status: 'ok' | 'empty' | 'not_found' | 'forbidden' | 'rate_limited' | 'server_error' | 'error';
+  status: 'ok' | 'empty' | 'graphql_error' | 'not_found' | 'forbidden' | 'rate_limited' | 'server_error' | 'error';
   httpStatus?: number;
   /**
    * Which backend produced this result. `'graphql'` is authoritative for
@@ -1690,7 +1690,7 @@ export async function fetchTweetByIdViaGraphQL(
   options: { executor?: XRequestExecutor; delayMs?: number } = {},
 ): Promise<TweetFetchResult> {
   const executor = options.executor ?? new XRequestExecutor({ delayMs: options.delayMs });
-  const response = await executor.requestJson(buildTweetResultByRestIdUrl(tweetId), {
+  const response = await executor.requestGraphqlJson(buildTweetResultByRestIdUrl(tweetId), {
     headers: buildHeaders(csrfToken, cookieHeader),
   });
   if (response.status !== 'ok') {
@@ -1793,11 +1793,13 @@ export async function fetchTweetDetailViaGraphQL(
 
   for (let page = 0; page < maxPages && pendingCursors.length > 0; page++) {
     const cursor = pendingCursors.shift();
-    const response = await executor.requestJson(buildTweetDetailUrl(tweetId, cursor), {
+    const response = await executor.requestGraphqlJson(buildTweetDetailUrl(tweetId, cursor), {
       headers: buildHeaders(csrfToken, cookieHeader),
     });
     if (response.status !== 'ok') {
-      if (response.status === 'error' && response.httpStatus && response.httpStatus >= 200 && response.httpStatus < 300) {
+      if (response.status === 'graphql_error') {
+        parserGaps.add('graphql_errors');
+      } else if (response.status === 'error' && response.httpStatus && response.httpStatus >= 200 && response.httpStatus < 300) {
         parserGaps.add('malformed_json');
       }
       return failedTweetDetailResult(

--- a/src/graphql-bookmarks.ts
+++ b/src/graphql-bookmarks.ts
@@ -9,7 +9,7 @@ import { exportBookmarksForSyncSeed, updateQuotedTweets, updateBookmarkText, upd
 import type { ArticleUpdate } from './bookmarks-db.js';
 import { fetchArticle, resolveTcoLink } from './bookmark-enrich.js';
 import type { ArticleContent } from './bookmark-enrich.js';
-import { bindArticleLocator, xArticleIdentity } from './source-bindings.js';
+import { bindArticleEnrichment, bindArticleLocator, xArticleIdentity } from './source-bindings.js';
 import { XRequestExecutor } from './x-request-policy.js';
 import {
   compareThreadTweetsChronologically,
@@ -1793,7 +1793,6 @@ export async function fetchTweetDetailViaGraphQL(
 
   for (let page = 0; page < maxPages && pendingCursors.length > 0; page++) {
     const cursor = pendingCursors.shift();
-    if (cursor) processedCursors.add(cursor);
     const response = await executor.requestJson(buildTweetDetailUrl(tweetId, cursor), {
       headers: buildHeaders(csrfToken, cookieHeader),
     });
@@ -1805,7 +1804,7 @@ export async function fetchTweetDetailViaGraphQL(
         tweetId,
         response.status,
         tweets,
-        pendingCursors,
+        cursor ? [cursor, ...pendingCursors] : pendingCursors,
         processedCursors,
         parserGaps,
         response.httpStatus,
@@ -1818,6 +1817,7 @@ export async function fetchTweetDetailViaGraphQL(
     sawUnavailableTweet ||= parsed.sawUnavailableTweet;
     for (const gap of parsed.parserGaps) parserGaps.add(gap);
     tweets.push(...parsed.tweets);
+    if (cursor) processedCursors.add(cursor);
     for (const nextCursor of parsed.continuationCursors) {
       if (processedCursors.has(nextCursor)) {
         parserGaps.add('repeated_cursor');
@@ -2034,20 +2034,31 @@ function isXArticleUrl(value: string): boolean {
   }
 }
 
-async function readEnrichedBookmarkIds(): Promise<Set<string>> {
+async function readEnrichedBookmarkIds(records: BookmarkRecord[]): Promise<Set<string>> {
   const enrichedIds = new Set<string>();
+  const recordsById = new Map(records.map((record) => [record.id, record]));
   try {
     const { openDb } = await import('./db.js');
     const { twitterBookmarksIndexPath } = await import('./paths.js');
     const db = await openDb(twitterBookmarksIndexPath());
     try {
       const rows = db.exec(
-        `SELECT id FROM bookmarks
+        `SELECT id, tweet_id, article_source_tweet_id, article_locator, article_text FROM bookmarks
          WHERE enriched_at IS NOT NULL
            AND article_source_tweet_id = tweet_id
            AND article_locator IS NOT NULL`,
       );
-      for (const row of rows[0]?.values ?? []) enrichedIds.add(row[0] as string);
+      for (const row of rows[0]?.values ?? []) {
+        const id = String(row[0]);
+        const record = recordsById.get(id);
+        if (!record || String(row[1]) !== record.tweetId) continue;
+        const locator = bindArticleEnrichment(record.tweetId, record.links ?? [], {
+          articleText: row[4] == null ? null : String(row[4]),
+          sourceTweetId: row[2] == null ? null : String(row[2]),
+          sourceLocator: row[3] == null ? null : String(row[3]),
+        });
+        if (locator) enrichedIds.add(id);
+      }
     } finally { db.close(); }
   } catch { /* DB may not exist yet */ }
   return enrichedIds;
@@ -2073,7 +2084,7 @@ export async function syncGaps(options: SyncGapsOptions = {}): Promise<GapFillRe
       }
       return fetchTweetViaSyndication(tweetId);
     });
-  const enrichedIds = await readEnrichedBookmarkIds();
+  const enrichedIds = await readEnrichedBookmarkIds(records);
 
   // Gap 1: missing quoted tweets. Skip records where a previous gap-fill run
   // already tried and failed — otherwise dead tweets get re-fetched forever.
@@ -2286,19 +2297,24 @@ export async function syncGaps(options: SyncGapsOptions = {}): Promise<GapFillRe
   for (let i = 0; i < articleTotal; i++) {
     const record = needsEnrichment[i];
     // Find the first non-twitter link
+    let sourceLocator: string | null = null;
     let targetUrl: string | null = null;
     for (const link of record.links ?? []) {
       const resolved = link.includes('t.co/') ? await resolveTcoLink(link) : link;
-      if (resolved) { targetUrl = resolved; break; }
+      if (resolved) {
+        sourceLocator = link;
+        targetUrl = resolved;
+        break;
+      }
     }
 
-    if (targetUrl) {
+    if (sourceLocator && targetUrl) {
       const article = await fetchArticle(targetUrl);
       if (article && article.text.length >= 50) {
         articleDbUpdates.push({
           id: record.id,
           sourceTweetId: record.tweetId,
-          sourceLocator: targetUrl,
+          sourceLocator,
           articleTitle: article.title,
           articleText: article.text,
           articleSite: article.siteName,

--- a/src/graphql-bookmarks.ts
+++ b/src/graphql-bookmarks.ts
@@ -18,6 +18,7 @@ import {
   parseTweetDetailResponse,
   reduceExactDecimalIdentity,
   tweetUrlEntities,
+  uniqueStrings,
 } from './tweet-snapshots.js';
 
 const CHROME_UA = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.0.0 Safari/537.36';
@@ -1484,10 +1485,13 @@ const TWEET_DETAIL_FEATURES = {
 };
 
 export type TweetFetchSource = 'graphql' | 'syndication';
+export type TweetArticleEvidenceStatus = 'absent' | 'resolved' | 'unresolved' | 'invalid';
 
 export interface TweetFetchResult {
   snapshot: QuotedTweetSnapshot | null;
   article?: TweetArticleContent | null;
+  /** Whether the focal response contained no article, one bound article, or unusable article evidence. */
+  articleStatus?: TweetArticleEvidenceStatus;
   status: 'ok' | 'empty' | 'graphql_error' | 'not_found' | 'forbidden' | 'rate_limited' | 'server_error' | 'error';
   httpStatus?: number;
   /**
@@ -1515,12 +1519,20 @@ export function parseTweetResultByRestId(json: any, tweetId: string): QuotedTwee
 
   const urlEntities = tweetUrlEntities(tweet, legacy);
   const noteText = tweet?.note_tweet?.note_tweet_results?.result?.text;
-  const text = expandVisibleUrlEntities(noteText ?? legacy.full_text ?? legacy.text ?? '', urlEntities);
-  if (!text) return null;
+  const responseText = noteText ?? legacy.full_text ?? legacy.text;
+  if (typeof responseText !== 'string') return null;
+  const text = expandVisibleUrlEntities(responseText, urlEntities);
+  const rawMediaEntities = legacy?.extended_entities?.media ?? legacy?.entities?.media;
+  const mediaEntities: any[] = Array.isArray(rawMediaEntities)
+    ? rawMediaEntities.filter((media: any) => media && typeof media === 'object')
+    : [];
+  const media = mediaEntities
+    .map((item: any) => item.media_url_https ?? item.media_url)
+    .filter((url: any): url is string => typeof url === 'string' && url.length > 0);
+  if (!text && media.length === 0) return null;
 
   const userResult = tweet?.core?.user_results?.result;
   const handle = userResult?.core?.screen_name ?? userResult?.legacy?.screen_name;
-  const mediaEntities: any[] = legacy?.extended_entities?.media ?? legacy?.entities?.media ?? [];
   const focalIdentity = reduceExactDecimalIdentity(legacy.id_str, tweet?.rest_id);
   if (focalIdentity.status !== 'ok' || focalIdentity.id !== tweetId) return null;
   const resolvedId = focalIdentity.id;
@@ -1546,7 +1558,7 @@ export function parseTweetResultByRestId(json: any, tweetId: string): QuotedTwee
     authorProfileImageUrl:
       userResult?.avatar?.image_url ?? userResult?.legacy?.profile_image_url_https,
     postedAt: legacy.created_at ?? null,
-    media: mediaEntities.map((m: any) => m.media_url_https ?? m.media_url).filter(Boolean),
+    media,
     mediaObjects: mediaEntities.map((m: any) => ({
       type: m.type,
       url: m.media_url_https ?? m.media_url,
@@ -1623,46 +1635,184 @@ function articleFromCandidate(candidate: any): ArticleContent | null {
   return { title, text, siteName };
 }
 
-function focalArticleCandidates(tweet: any): any[] {
-  return [
-    tweet?.article_results?.result,
-    tweet?.article?.article_results?.result,
-    tweet?.article?.result,
-  ].filter((value) => value && typeof value === 'object');
+type FocalArticleSlot =
+  | { status: 'absent' | 'unresolved' | 'invalid' }
+  | { status: 'candidate'; candidate: Record<string, unknown> };
+
+interface FocalArticleObservation {
+  status: 'resolved' | 'unresolved' | 'invalid';
+  identity?: string;
+  article?: ArticleContent;
+  sourceLocator?: string;
 }
 
-function articleCandidateLocator(candidate: any, sourceLinks: string[]): string | undefined {
+interface TweetArticleEvidence {
+  status: TweetArticleEvidenceStatus;
+  article: TweetArticleContent | null;
+}
+
+function hasOwn(value: object, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(value, key);
+}
+
+function resultSlot(container: unknown): FocalArticleSlot {
+  if (container === undefined || container === null) return { status: 'absent' };
+  if (typeof container !== 'object') return { status: 'invalid' };
+  if (!hasOwn(container, 'result')) return { status: 'unresolved' };
+  const candidate = (container as { result?: unknown }).result;
+  if (candidate === undefined || candidate === null) return { status: 'absent' };
+  if (typeof candidate !== 'object') return { status: 'invalid' };
+  return { status: 'candidate', candidate: candidate as Record<string, unknown> };
+}
+
+/** Enumerate only direct focal article envelopes; never descend into quotes or other entities. */
+function focalArticleSlots(tweet: any): FocalArticleSlot[] {
+  const slots: FocalArticleSlot[] = [];
+  if (hasOwn(tweet, 'article_results')) slots.push(resultSlot(tweet.article_results));
+
+  if (hasOwn(tweet, 'article')) {
+    const article = tweet.article;
+    if (article === undefined || article === null) {
+      slots.push({ status: 'absent' });
+    } else if (typeof article !== 'object') {
+      slots.push({ status: 'invalid' });
+    } else {
+      let recognized = false;
+      if (hasOwn(article, 'article_results')) {
+        slots.push(resultSlot(article.article_results));
+        recognized = true;
+      }
+      if (hasOwn(article, 'result')) {
+        const candidate = article.result;
+        slots.push(candidate === undefined || candidate === null
+          ? { status: 'absent' }
+          : typeof candidate === 'object'
+            ? { status: 'candidate', candidate: candidate as Record<string, unknown> }
+            : { status: 'invalid' });
+        recognized = true;
+      }
+      if (!recognized) slots.push({ status: 'unresolved' });
+    }
+  }
+  return slots;
+}
+
+function articleCandidateLocator(candidate: any, sourceLinks: string[]): {
+  status: 'ok' | 'unresolved' | 'invalid';
+  identity?: string;
+  locator?: string;
+} {
   const identity = reduceExactDecimalIdentity(candidate?.rest_id, candidate?.article_id, candidate?.id);
-  if (identity.status === 'invalid') return undefined;
+  if (identity.status === 'invalid') return { status: 'invalid' };
+  const focalArticleLinks = sourceLinks.filter(isXArticleLocator);
   if (identity.status === 'ok') {
     const requested = `https://x.com/i/article/${identity.id}`;
-    const focalArticleLinks = sourceLinks.filter(isXArticleLocator);
-    return focalArticleLinks.length > 0
+    const locator = focalArticleLinks.length > 0
       ? bindArticleLocator(focalArticleLinks, requested)
       : requested;
+    return locator
+      ? { status: 'ok', identity: identity.id, locator }
+      : { status: 'unresolved', identity: identity.id };
   }
-  return bindArticleLocator(sourceLinks);
+  const locator = bindArticleLocator(focalArticleLinks);
+  const locatorIdentity = locator ? xArticleIdentity(locator) : null;
+  return locator && locatorIdentity
+    ? { status: 'ok', identity: locatorIdentity, locator }
+    : { status: 'unresolved' };
+}
+
+function observeFocalArticleCandidate(
+  candidate: Record<string, unknown>,
+  sourceLinks: string[],
+): FocalArticleObservation {
+  const locator = articleCandidateLocator(candidate, sourceLinks);
+  if (locator.status === 'invalid') return { status: 'invalid' };
+  const article = articleFromCandidate(candidate);
+  if (!article || locator.status !== 'ok' || !locator.identity || !locator.locator) {
+    return { status: 'unresolved', identity: locator.identity };
+  }
+  return {
+    status: 'resolved',
+    identity: locator.identity,
+    article,
+    sourceLocator: locator.locator,
+  };
+}
+
+function agreedOptional(values: Array<string | undefined>): string | undefined {
+  const nonempty = uniqueStrings(values.filter((value): value is string => Boolean(value?.trim())));
+  return nonempty.length === 1 ? nonempty[0] : undefined;
+}
+
+function reduceFocalArticleEvidence(tweet: any, sourceTweetId: string): TweetArticleEvidence {
+  const sourceLinks = extractExpandedLinks(tweetUrlEntities(tweet, tweet?.legacy));
+  const slots = focalArticleSlots(tweet);
+  if (slots.some((slot) => slot.status === 'invalid')) {
+    return { status: 'invalid', article: null };
+  }
+
+  const observations: FocalArticleObservation[] = slots.flatMap((slot) => {
+    if (slot.status === 'candidate') return [observeFocalArticleCandidate(slot.candidate, sourceLinks)];
+    if (slot.status === 'unresolved') return [{ status: 'unresolved' as const }];
+    return [];
+  });
+  if (observations.some((observation) => observation.status === 'invalid')) {
+    return { status: 'invalid', article: null };
+  }
+  if (observations.length === 0) {
+    return sourceLinks.some(isXArticleLocator)
+      ? { status: 'unresolved', article: null }
+      : { status: 'absent', article: null };
+  }
+
+  const identities = uniqueStrings(
+    observations
+      .map((observation) => observation.identity)
+      .filter((value): value is string => Boolean(value)),
+  );
+  if (identities.length > 1) return { status: 'invalid', article: null };
+  if (observations.some((observation) => !observation.identity)) {
+    return { status: 'unresolved', article: null };
+  }
+
+  const resolved = observations.filter((observation) => observation.status === 'resolved');
+  if (resolved.length === 0 || identities.length !== 1) {
+    return { status: 'unresolved', article: null };
+  }
+  const bodies = uniqueStrings(
+    resolved.map((observation) => observation.article!.text),
+  );
+  if (bodies.length !== 1) return { status: 'invalid', article: null };
+
+  const sourceLocator = resolved[0].sourceLocator;
+  if (!sourceLocator || resolved.some((observation) => observation.sourceLocator !== sourceLocator)) {
+    return { status: 'invalid', article: null };
+  }
+  return {
+    status: 'resolved',
+    article: {
+      sourceTweetId,
+      sourceLocator,
+      title: agreedOptional(resolved.map((observation) => observation.article!.title)) ?? '',
+      text: bodies[0],
+      siteName: agreedOptional(resolved.map((observation) => observation.article!.siteName)),
+    },
+  };
+}
+
+function parseTweetArticleEvidenceByRestId(json: any, requestedTweetId?: string): TweetArticleEvidence {
+  const result = json?.data?.tweetResult?.result;
+  if (!result) return { status: 'invalid', article: null };
+  const tweet = result.tweet ?? result;
+  const focalIdentity = reduceExactDecimalIdentity(tweet?.legacy?.id_str, tweet?.rest_id);
+  if (focalIdentity.status !== 'ok' || (requestedTweetId && focalIdentity.id !== requestedTweetId)) {
+    return { status: 'invalid', article: null };
+  }
+  return reduceFocalArticleEvidence(tweet, focalIdentity.id);
 }
 
 export function parseTweetArticleByRestId(json: any, requestedTweetId?: string): TweetArticleContent | null {
-  const result = json?.data?.tweetResult?.result;
-  if (!result) return null;
-  const tweet = result.tweet ?? result;
-  const focalIdentity = reduceExactDecimalIdentity(tweet?.legacy?.id_str, tweet?.rest_id);
-  if (focalIdentity.status !== 'ok') return null;
-  const sourceTweetId = focalIdentity.id;
-  if (requestedTweetId && sourceTweetId !== requestedTweetId) return null;
-  const sourceLinks = extractExpandedLinks(tweetUrlEntities(tweet, tweet?.legacy));
-
-  for (const candidate of focalArticleCandidates(tweet)) {
-    const article = articleFromCandidate(candidate);
-    const sourceLocator = articleCandidateLocator(candidate, sourceLinks);
-    if (article && sourceLocator && xArticleIdentity(sourceLocator)) {
-      return { ...article, sourceTweetId, sourceLocator };
-    }
-  }
-
-  return null;
+  return parseTweetArticleEvidenceByRestId(json, requestedTweetId).article;
 }
 
 function buildTweetResultByRestIdUrl(tweetId: string): string {
@@ -1729,11 +1879,23 @@ export async function fetchTweetByIdViaGraphQL(
     return { snapshot: null, status: 'not_found', source: 'graphql' };
   }
   const snapshot = parseTweetResultByRestId(json, tweetId);
-  const article = parseTweetArticleByRestId(json, tweetId);
+  const articleEvidence = parseTweetArticleEvidenceByRestId(json, tweetId);
   if (!snapshot || snapshot.id !== tweetId) {
-    return { snapshot: null, article: null, status: 'error', source: 'graphql' };
+    return {
+      snapshot: null,
+      article: null,
+      articleStatus: 'invalid',
+      status: 'error',
+      source: 'graphql',
+    };
   }
-  return { snapshot, article, status: 'ok', source: 'graphql' };
+  return {
+    snapshot,
+    article: articleEvidence.article,
+    articleStatus: articleEvidence.status,
+    status: 'ok',
+    source: 'graphql',
+  };
 }
 
 export type TweetDetailTermination =

--- a/src/graphql-bookmarks.ts
+++ b/src/graphql-bookmarks.ts
@@ -9,6 +9,8 @@ import { exportBookmarksForSyncSeed, updateQuotedTweets, updateBookmarkText, upd
 import type { ArticleUpdate } from './bookmarks-db.js';
 import { fetchArticle, resolveTcoLink } from './bookmark-enrich.js';
 import type { ArticleContent } from './bookmark-enrich.js';
+import { bindArticleLocator, xArticleIdentity } from './source-bindings.js';
+import { XRequestExecutor } from './x-request-policy.js';
 import {
   compareThreadTweetsChronologically,
   expandVisibleUrlEntities,
@@ -1484,7 +1486,7 @@ export type TweetFetchSource = 'graphql' | 'syndication';
 
 export interface TweetFetchResult {
   snapshot: QuotedTweetSnapshot | null;
-  article?: ArticleContent | null;
+  article?: TweetArticleContent | null;
   status: 'ok' | 'empty' | 'not_found' | 'forbidden' | 'rate_limited' | 'server_error' | 'error';
   httpStatus?: number;
   /**
@@ -1494,6 +1496,11 @@ export interface TweetFetchResult {
    * treated as settling Gap 2.
    */
   source?: TweetFetchSource;
+}
+
+export interface TweetArticleContent extends ArticleContent {
+  sourceTweetId: string;
+  sourceLocator: string;
 }
 
 export function parseTweetResultByRestId(json: any, tweetId: string): QuotedTweetSnapshot | null {
@@ -1544,23 +1551,6 @@ export function parseTweetResultByRestId(json: any, tweetId: string): QuotedTwee
     inReplyToStatusId: legacy.in_reply_to_status_id_str,
     url: `https://x.com/${handle ?? '_'}/status/${resolvedId}`,
   };
-}
-
-function unwrapGraphqlResult(value: any): any {
-  return value?.result?.tweet ?? value?.result ?? value?.tweet ?? value;
-}
-
-function collectArticleCandidates(value: any, depth = 0): any[] {
-  if (!value || typeof value !== 'object' || depth > 8) return [];
-  const candidates: any[] = [];
-  for (const [key, child] of Object.entries(value)) {
-    if (!child || typeof child !== 'object') continue;
-    if (key.toLowerCase().includes('article')) {
-      candidates.push(unwrapGraphqlResult(child));
-    }
-    candidates.push(...collectArticleCandidates(child, depth + 1));
-  }
-  return candidates;
 }
 
 function blockText(block: any): string {
@@ -1619,14 +1609,39 @@ function articleFromCandidate(candidate: any): ArticleContent | null {
   return { title, text, siteName };
 }
 
-export function parseTweetArticleByRestId(json: any): ArticleContent | null {
+function focalArticleCandidates(tweet: any): any[] {
+  return [
+    tweet?.article_results?.result,
+    tweet?.article?.article_results?.result,
+    tweet?.article?.result,
+  ].filter((value) => value && typeof value === 'object');
+}
+
+function articleCandidateLocator(candidate: any, sourceLinks: string[]): string | undefined {
+  const candidateId = candidate?.rest_id ?? candidate?.article_id ?? candidate?.id;
+  if (candidateId !== undefined && candidateId !== null && String(candidateId).length > 0) {
+    const requested = `https://x.com/i/article/${String(candidateId)}`;
+    return bindArticleLocator(sourceLinks, requested) ?? requested;
+  }
+  return bindArticleLocator(sourceLinks);
+}
+
+export function parseTweetArticleByRestId(json: any, requestedTweetId?: string): TweetArticleContent | null {
   const result = json?.data?.tweetResult?.result;
   if (!result) return null;
   const tweet = result.tweet ?? result;
+  const responseTweetId = tweet?.legacy?.id_str ?? tweet?.rest_id;
+  if (responseTweetId === undefined || responseTweetId === null) return null;
+  const sourceTweetId = String(responseTweetId);
+  if (requestedTweetId && sourceTweetId !== requestedTweetId) return null;
+  const sourceLinks = extractExpandedLinks(tweetUrlEntities(tweet, tweet?.legacy));
 
-  for (const candidate of collectArticleCandidates(tweet)) {
+  for (const candidate of focalArticleCandidates(tweet)) {
     const article = articleFromCandidate(candidate);
-    if (article) return article;
+    const sourceLocator = articleCandidateLocator(candidate, sourceLinks);
+    if (article && sourceLocator && xArticleIdentity(sourceLocator)) {
+      return { ...article, sourceTweetId, sourceLocator };
+    }
   }
 
   return null;
@@ -1672,150 +1687,186 @@ export async function fetchTweetByIdViaGraphQL(
   tweetId: string,
   csrfToken: string,
   cookieHeader?: string,
+  options: { executor?: XRequestExecutor; delayMs?: number } = {},
 ): Promise<TweetFetchResult> {
-  for (let attempt = 0; attempt < 4; attempt++) {
-    let response: Response;
-    try {
-      response = await fetch(buildTweetResultByRestIdUrl(tweetId), {
-        headers: buildHeaders(csrfToken, cookieHeader),
-      });
-    } catch {
-      await new Promise((r) => setTimeout(r, 2000 * (attempt + 1)));
-      continue;
-    }
-
-    if (response.ok) {
-      let json: any;
-      try {
-        json = await response.json();
-      } catch {
-        return { snapshot: null, status: 'error', source: 'graphql' };
-      }
-      // Tombstoned / deleted tweets come back with a result.__typename like
-      // TweetTombstone or TweetUnavailable and no legacy block.
-      const result = json?.data?.tweetResult?.result;
-      const typename = result?.__typename;
-      if (!result || typename === 'TweetTombstone' || typename === 'TweetUnavailable') {
-        return { snapshot: null, status: 'not_found', source: 'graphql' };
-      }
-      const snapshot = parseTweetResultByRestId(json, tweetId);
-      const article = parseTweetArticleByRestId(json);
-      if (!snapshot) return { snapshot: null, article: null, status: 'error', source: 'graphql' };
-      if (snapshot.id !== tweetId) {
-        return { snapshot: null, article: null, status: 'error', source: 'graphql' };
-      }
-      return { snapshot, article, status: 'ok', source: 'graphql' };
-    }
-
-    if (response.status === 429) {
-      await new Promise((r) => setTimeout(r, Math.min(15 * Math.pow(2, attempt), 120) * 1000));
-      continue;
-    }
-    if (response.status >= 500) {
-      await new Promise((r) => setTimeout(r, 5000 * (attempt + 1)));
-      continue;
-    }
-    if (response.status === 404) {
-      return { snapshot: null, status: 'not_found', httpStatus: 404, source: 'graphql' };
-    }
-    if (response.status === 401 || response.status === 403) {
-      return { snapshot: null, status: 'forbidden', httpStatus: response.status, source: 'graphql' };
-    }
-    // Other 4xx (400 usually means X rotated feature flags / queryId) — don't retry.
-    return { snapshot: null, status: 'error', httpStatus: response.status, source: 'graphql' };
+  const executor = options.executor ?? new XRequestExecutor({ delayMs: options.delayMs });
+  const response = await executor.requestJson(buildTweetResultByRestIdUrl(tweetId), {
+    headers: buildHeaders(csrfToken, cookieHeader),
+  });
+  if (response.status !== 'ok') {
+    return {
+      snapshot: null,
+      status: response.status,
+      ...(response.httpStatus ? { httpStatus: response.httpStatus } : {}),
+      source: 'graphql',
+    };
   }
-  return { snapshot: null, status: 'rate_limited', source: 'graphql' };
+
+  const json = response.json as any;
+  // Tombstoned / deleted tweets come back with a result.__typename like
+  // TweetTombstone or TweetUnavailable and no legacy block.
+  const result = json?.data?.tweetResult?.result;
+  const typename = result?.__typename;
+  if (!result || typename === 'TweetTombstone' || typename === 'TweetUnavailable') {
+    return { snapshot: null, status: 'not_found', source: 'graphql' };
+  }
+  const snapshot = parseTweetResultByRestId(json, tweetId);
+  const article = parseTweetArticleByRestId(json, tweetId);
+  if (!snapshot || snapshot.id !== tweetId) {
+    return { snapshot: null, article: null, status: 'error', source: 'graphql' };
+  }
+  return { snapshot, article, status: 'ok', source: 'graphql' };
+}
+
+export type TweetDetailTermination =
+  | 'exhausted'
+  | 'empty'
+  | 'missing_focal'
+  | 'parser_gap'
+  | 'limit'
+  | 'unavailable'
+  | 'error';
+
+export interface TweetDetailFetchResult {
+  tweets: ThreadTweetSnapshot[];
+  status: TweetFetchResult['status'];
+  httpStatus?: number;
+  focalTweetId: string;
+  focalBound: boolean;
+  pendingCursors: string[];
+  processedCursors: string[];
+  enumerationTermination: TweetDetailTermination;
+  enumerationComplete: boolean;
+  remainingCursor?: string;
+  remainingCursors?: string[];
+  parserGap: boolean;
+  parserGaps: string[];
+}
+
+function failedTweetDetailResult(
+  tweetId: string,
+  status: TweetFetchResult['status'],
+  tweets: ThreadTweetSnapshot[],
+  pendingCursors: Array<string | undefined>,
+  processedCursors: Set<string>,
+  parserGaps: Set<string>,
+  httpStatus?: number,
+): TweetDetailFetchResult {
+  const remainingCursors = pendingCursors.filter((value): value is string => Boolean(value));
+  const byId = new Map<string, ThreadTweetSnapshot>();
+  for (const tweet of tweets) if (!byId.has(tweet.id)) byId.set(tweet.id, tweet);
+  const enumerationTermination: TweetDetailTermination = status === 'not_found' || status === 'forbidden'
+    ? 'unavailable'
+    : 'error';
+  return {
+    tweets: Array.from(byId.values()).sort(compareThreadTweetsChronologically),
+    status,
+    ...(httpStatus ? { httpStatus } : {}),
+    focalTweetId: tweetId,
+    focalBound: byId.has(tweetId),
+    pendingCursors: remainingCursors,
+    processedCursors: [...processedCursors],
+    enumerationTermination,
+    enumerationComplete: false,
+    ...(remainingCursors[0] ? { remainingCursor: remainingCursors[0] } : {}),
+    ...(remainingCursors.length ? { remainingCursors } : {}),
+    parserGap: parserGaps.size > 0,
+    parserGaps: [...parserGaps].sort(),
+  };
 }
 
 export async function fetchTweetDetailViaGraphQL(
   tweetId: string,
   csrfToken: string,
   cookieHeader?: string,
-  options: { maxPages?: number; delayMs?: number } = {},
-): Promise<{
-  tweets: ThreadTweetSnapshot[];
-  status: TweetFetchResult['status'];
-  httpStatus?: number;
-  enumerationComplete: boolean;
-  remainingCursor?: string;
-  remainingCursors?: string[];
-  parserGap: boolean;
-}> {
+  options: { maxPages?: number; delayMs?: number; executor?: XRequestExecutor } = {},
+): Promise<TweetDetailFetchResult> {
   const maxPages = options.maxPages ?? 3;
-  const delayMs = options.delayMs ?? 300;
+  const executor = options.executor ?? new XRequestExecutor({ delayMs: options.delayMs ?? 300 });
   const tweets: ThreadTweetSnapshot[] = [];
   const pendingCursors: Array<string | undefined> = [undefined];
   const processedCursors = new Set<string>();
+  const parserGaps = new Set<string>();
   let sawRecognizedTimeline = false;
   let sawTweetResult = false;
   let sawUnavailableTweet = false;
-  let sawUnparseableTweet = false;
 
   for (let page = 0; page < maxPages && pendingCursors.length > 0; page++) {
     const cursor = pendingCursors.shift();
     if (cursor) processedCursors.add(cursor);
-    let response: Response;
-    try {
-      response = await fetch(buildTweetDetailUrl(tweetId, cursor), {
-        headers: buildHeaders(csrfToken, cookieHeader),
-      });
-    } catch {
-      return { tweets, status: 'error', enumerationComplete: false, parserGap: true };
+    const response = await executor.requestJson(buildTweetDetailUrl(tweetId, cursor), {
+      headers: buildHeaders(csrfToken, cookieHeader),
+    });
+    if (response.status !== 'ok') {
+      if (response.status === 'error' && response.httpStatus && response.httpStatus >= 200 && response.httpStatus < 300) {
+        parserGaps.add('malformed_json');
+      }
+      return failedTweetDetailResult(
+        tweetId,
+        response.status,
+        tweets,
+        pendingCursors,
+        processedCursors,
+        parserGaps,
+        response.httpStatus,
+      );
     }
-    if (response.status === 429) return { tweets, status: 'rate_limited', httpStatus: 429, enumerationComplete: false, parserGap: false };
-    if (response.status === 404) return { tweets, status: 'not_found', httpStatus: 404, enumerationComplete: false, parserGap: false };
-    if (response.status === 401 || response.status === 403) return { tweets, status: 'forbidden', httpStatus: response.status, enumerationComplete: false, parserGap: false };
-    if (response.status >= 500) return { tweets, status: 'server_error', httpStatus: response.status, enumerationComplete: false, parserGap: false };
-    if (!response.ok) return { tweets, status: 'error', httpStatus: response.status, enumerationComplete: false, parserGap: false };
 
-    let json: unknown;
-    try {
-      json = await response.json();
-    } catch {
-      return { tweets, status: 'error', httpStatus: response.status, enumerationComplete: false, parserGap: true };
-    }
-    const parsed = parseTweetDetailResponse(json);
+    const parsed = parseTweetDetailResponse(response.json);
     sawRecognizedTimeline ||= parsed.recognizedTimeline;
     sawTweetResult ||= parsed.sawTweetResult;
     sawUnavailableTweet ||= parsed.sawUnavailableTweet;
-    sawUnparseableTweet ||= parsed.sawUnparseableTweet;
+    for (const gap of parsed.parserGaps) parserGaps.add(gap);
     tweets.push(...parsed.tweets);
     for (const nextCursor of parsed.continuationCursors) {
       if (processedCursors.has(nextCursor)) {
-        sawUnparseableTweet = true;
+        parserGaps.add('repeated_cursor');
         continue;
       }
       if (!pendingCursors.includes(nextCursor)) pendingCursors.push(nextCursor);
-    }
-    if (page < maxPages - 1 && pendingCursors.length > 0) {
-      await new Promise((resolve) => setTimeout(resolve, delayMs));
     }
   }
 
   const byId = new Map<string, ThreadTweetSnapshot>();
   for (const tweet of tweets) if (!byId.has(tweet.id)) byId.set(tweet.id, tweet);
-  const parserGap = sawUnavailableTweet || sawUnparseableTweet;
   const remainingCursors = pendingCursors.filter((value): value is string => Boolean(value));
-  const enumerationComplete = pendingCursors.length === 0 && !parserGap;
-  if (byId.size === 0) {
-    if (sawUnavailableTweet && !sawUnparseableTweet) return { tweets: [], status: 'not_found', enumerationComplete: false, parserGap };
-    if (sawRecognizedTimeline && !sawTweetResult) return {
-      tweets: [],
-      status: 'empty',
-      enumerationComplete: false,
-      ...(remainingCursors[0] ? { remainingCursor: remainingCursors[0] } : {}),
-      ...(remainingCursors.length > 0 ? { remainingCursors } : {}),
-      parserGap,
-    };
-    return { tweets: [], status: 'error', enumerationComplete: false, parserGap: true };
+  const focalBound = byId.has(tweetId);
+  let status: TweetFetchResult['status'] = 'ok';
+  let enumerationTermination: TweetDetailTermination;
+  if (byId.size === 0 && sawUnavailableTweet && parserGaps.size === 1 && parserGaps.has('unavailable_tweet')) {
+    status = 'not_found';
+    enumerationTermination = 'unavailable';
+  } else if (byId.size === 0 && sawRecognizedTimeline && !sawTweetResult) {
+    status = 'empty';
+    enumerationTermination = 'empty';
+  } else if (byId.size === 0) {
+    status = 'error';
+    enumerationTermination = 'error';
+    parserGaps.add('no_parseable_tweets');
+  } else if (parserGaps.size > 0) {
+    enumerationTermination = 'parser_gap';
+  } else if (remainingCursors.length > 0 || pendingCursors.length > 0) {
+    enumerationTermination = 'limit';
+  } else if (!focalBound) {
+    enumerationTermination = 'missing_focal';
+  } else {
+    enumerationTermination = 'exhausted';
   }
+  const parserGap = parserGaps.size > 0;
+  const enumerationComplete = enumerationTermination === 'exhausted';
   return {
     tweets: Array.from(byId.values()).sort(compareThreadTweetsChronologically),
-    status: 'ok',
+    status,
+    focalTweetId: tweetId,
+    focalBound,
+    pendingCursors: remainingCursors,
+    processedCursors: [...processedCursors],
+    enumerationTermination,
     enumerationComplete,
     ...(remainingCursors[0] ? { remainingCursor: remainingCursors[0] } : {}),
     ...(remainingCursors.length > 0 ? { remainingCursors } : {}),
     parserGap,
+    parserGaps: [...parserGaps].sort(),
   };
 }
 
@@ -1984,7 +2035,12 @@ async function readEnrichedBookmarkIds(): Promise<Set<string>> {
     const { twitterBookmarksIndexPath } = await import('./paths.js');
     const db = await openDb(twitterBookmarksIndexPath());
     try {
-      const rows = db.exec('SELECT id FROM bookmarks WHERE enriched_at IS NOT NULL');
+      const rows = db.exec(
+        `SELECT id FROM bookmarks
+         WHERE enriched_at IS NOT NULL
+           AND article_source_tweet_id = tweet_id
+           AND article_locator IS NOT NULL`,
+      );
       for (const row of rows[0]?.values ?? []) enrichedIds.add(row[0] as string);
     } finally { db.close(); }
   } catch { /* DB may not exist yet */ }
@@ -2069,7 +2125,7 @@ export async function syncGaps(options: SyncGapsOptions = {}): Promise<GapFillRe
     const tweetId = allFetchIds[i];
     const now = new Date().toISOString();
     let snapshot: QuotedTweetSnapshot | null = null;
-    let article: ArticleContent | null | undefined;
+    let article: TweetArticleContent | null | undefined;
     let resultStatus: TweetFetchResult['status'] = 'error';
     let resultSource: TweetFetchSource | undefined;
     try {
@@ -2133,16 +2189,32 @@ export async function syncGaps(options: SyncGapsOptions = {}): Promise<GapFillRe
     }
 
     if (article) {
+      let acceptedArticle = false;
       for (const record of recordsByXArticleTweetId.get(tweetId) ?? []) {
         if (enrichedIds.has(record.id)) continue;
+        const sourceLocator = article.sourceTweetId === tweetId
+          ? bindArticleLocator(record.links ?? [], article.sourceLocator)
+          : undefined;
+        if (!sourceLocator) continue;
         articleDbUpdates.push({
           id: record.id,
+          sourceTweetId: tweetId,
+          sourceLocator,
           articleTitle: article.title,
           articleText: article.text,
           articleSite: article.siteName,
         });
         enrichedIds.add(record.id);
         articlesEnriched++;
+        acceptedArticle = true;
+      }
+      if (!acceptedArticle && recordsByXArticleTweetId.has(tweetId)) {
+        failed++;
+        failures.push({
+          tweetId,
+          reason: 'X Article body did not bind to the fetched focal tweet and archived article locator',
+          url: `https://x.com/_/status/${tweetId}`,
+        });
       }
     } else if (recordsByXArticleTweetId.has(tweetId) && snapshot) {
       failed++;
@@ -2207,6 +2279,8 @@ export async function syncGaps(options: SyncGapsOptions = {}): Promise<GapFillRe
       if (article && article.text.length >= 50) {
         articleDbUpdates.push({
           id: record.id,
+          sourceTweetId: record.tweetId,
+          sourceLocator: targetUrl,
           articleTitle: article.title,
           articleText: article.text,
           articleSite: article.siteName,

--- a/src/skill.ts
+++ b/src/skill.ts
@@ -123,6 +123,7 @@ ft list --after/--before DATE  # Date range (YYYY-MM-DD)
 ft stats                       # Collection overview
 ft viz                         # Terminal dashboard
 ft show <id>                   # Full detail for one bookmark
+ft materialize <id> --json     # Exact root/component depth and explicit source gaps
 ft seeds search <query> --create
 ft repos add <path>
 ft possible run --seed <id> --repos <paths...>
@@ -152,6 +153,8 @@ Combine filters: \`ft list --category tool --domain ai --limit 10\`
 - Start with Library pages for durable project knowledge, then search bookmarks for source material
 - Don't dump raw output; summarize and connect findings to the user's current work
 - Cross-reference multiple queries to build a complete picture
+- After selecting a bookmark for research, use \`ft materialize <id> --json\`; use \`--refresh\` and \`--fetch-media\` only when current exact-source depth is required
+- Treat unresolved outbound pages, PDFs, media interpretation, or thread completeness as visible source-depth gaps; never infer them from the root post
 - Look for recurring authors, topic clusters, and connections between bookmarks
 - Ground roadmap work in actual bookmark-backed seeds
 - Lead roadmap reports with the plotted grid and concrete next actions, not just prose

--- a/src/source-bindings.ts
+++ b/src/source-bindings.ts
@@ -64,3 +64,16 @@ export function bindArticleLocator(
   if (identities.size !== 1) return undefined;
   return preferredLocator(articleLinks);
 }
+
+export function bindArticleEnrichment(
+  rootTweetId: string,
+  sourceLinks: string[],
+  enrichment: {
+    articleText?: string | null;
+    sourceTweetId?: string | null;
+    sourceLocator?: string | null;
+  },
+): string | undefined {
+  if (!enrichment.articleText?.trim() || enrichment.sourceTweetId !== rootTweetId) return undefined;
+  return bindArticleLocator(sourceLinks, enrichment.sourceLocator);
+}

--- a/src/source-bindings.ts
+++ b/src/source-bindings.ts
@@ -79,3 +79,16 @@ export function bindArticleEnrichment(
     || !enrichment.sourceLocator) return undefined;
   return bindArticleLocator(sourceLinks, enrichment.sourceLocator);
 }
+
+export function bindXArticleEnrichment(
+  rootTweetId: string,
+  sourceLinks: string[],
+  enrichment: {
+    articleText?: string | null;
+    sourceTweetId?: string | null;
+    sourceLocator?: string | null;
+  },
+): string | undefined {
+  const locator = bindArticleEnrichment(rootTweetId, sourceLinks, enrichment);
+  return locator && isXArticleLocator(locator) ? locator : undefined;
+}

--- a/src/source-bindings.ts
+++ b/src/source-bindings.ts
@@ -74,6 +74,8 @@ export function bindArticleEnrichment(
     sourceLocator?: string | null;
   },
 ): string | undefined {
-  if (!enrichment.articleText?.trim() || enrichment.sourceTweetId !== rootTweetId) return undefined;
+  if (!enrichment.articleText?.trim()
+    || enrichment.sourceTweetId !== rootTweetId
+    || !enrichment.sourceLocator) return undefined;
   return bindArticleLocator(sourceLinks, enrichment.sourceLocator);
 }

--- a/src/source-bindings.ts
+++ b/src/source-bindings.ts
@@ -1,0 +1,66 @@
+export function canonicalHttpLocator(value: string): string | null {
+  try {
+    const parsed = new URL(value);
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return null;
+    parsed.hash = '';
+    parsed.hostname = parsed.hostname.toLowerCase();
+    if ((parsed.protocol === 'https:' && parsed.port === '443') || (parsed.protocol === 'http:' && parsed.port === '80')) {
+      parsed.port = '';
+    }
+    if (parsed.pathname.length > 1) parsed.pathname = parsed.pathname.replace(/\/+$/, '');
+    return parsed.toString();
+  } catch {
+    return null;
+  }
+}
+
+export function xArticleIdentity(value: string): string | null {
+  try {
+    const parsed = new URL(value);
+    const host = parsed.hostname.toLowerCase();
+    const match = parsed.pathname.match(/^\/i\/article\/([^/]+)\/?$/);
+    if ((host !== 'x.com' && host !== 'twitter.com') || !match) return null;
+    return match[1];
+  } catch {
+    return null;
+  }
+}
+
+export function isXArticleLocator(value: string): boolean {
+  return xArticleIdentity(value) !== null;
+}
+
+export function sameSourceLocator(left: string, right: string): boolean {
+  const leftArticle = xArticleIdentity(left);
+  const rightArticle = xArticleIdentity(right);
+  if (leftArticle || rightArticle) return leftArticle !== null && leftArticle === rightArticle;
+  const leftCanonical = canonicalHttpLocator(left);
+  return leftCanonical !== null && leftCanonical === canonicalHttpLocator(right);
+}
+
+function preferredLocator(values: string[]): string | undefined {
+  return values.find((value) => {
+    try {
+      const parsed = new URL(value);
+      return parsed.protocol === 'https:' && parsed.hostname.toLowerCase() === 'x.com';
+    } catch {
+      return false;
+    }
+  }) ?? values[0];
+}
+
+export function bindArticleLocator(
+  sourceLinks: string[],
+  requestedLocator?: string | null,
+): string | undefined {
+  const candidates = sourceLinks.filter((value) => canonicalHttpLocator(value) !== null);
+  if (requestedLocator) {
+    const matches = candidates.filter((value) => sameSourceLocator(value, requestedLocator));
+    return preferredLocator(matches);
+  }
+
+  const articleLinks = candidates.filter(isXArticleLocator);
+  const identities = new Set(articleLinks.map(xArticleIdentity).filter((value): value is string => value !== null));
+  if (identities.size !== 1) return undefined;
+  return preferredLocator(articleLinks);
+}

--- a/src/tweet-snapshots.ts
+++ b/src/tweet-snapshots.ts
@@ -1,0 +1,293 @@
+import { parseTimestampMs } from './date-utils.js';
+import type { ThreadTweetSnapshot } from './types.js';
+
+export function parseSnowflake(value?: string | null): bigint | null {
+  if (!value || !/^\d+$/.test(value)) return null;
+  try {
+    return BigInt(value);
+  } catch {
+    return null;
+  }
+}
+
+export function uniqueStrings(values: string[]): string[] {
+  return [...new Set(values)];
+}
+
+function urlEntityKey(entity: any): string {
+  return String(entity?.url ?? entity?.expanded_url ?? entity?.expandedUrl ?? entity?.display_url ?? entity?.displayUrl ?? '');
+}
+
+export function tweetUrlEntities(tweet: any, legacy: any): any[] {
+  const entities = [
+    ...(Array.isArray(legacy?.entities?.urls) ? legacy.entities.urls : []),
+    ...(Array.isArray(tweet?.note_tweet?.note_tweet_results?.result?.entity_set?.urls)
+      ? tweet.note_tweet.note_tweet_results.result.entity_set.urls
+      : []),
+  ];
+  const seen = new Set<string>();
+  return entities.filter((entity) => {
+    const key = urlEntityKey(entity);
+    if (!key || seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+export function syndicationUrlEntities(data: any): any[] {
+  return Array.isArray(data?.entities?.urls) ? data.entities.urls : [];
+}
+
+export function extractExpandedLinks(urlEntities: any[]): string[] {
+  return uniqueStrings(
+    urlEntities
+      .map((entity) => entity?.expanded_url ?? entity?.expandedUrl ?? entity?.url)
+      .filter((url): url is string => typeof url === 'string' && url.length > 0 && !url.includes('t.co/')),
+  );
+}
+
+function urlEntityReplacement(entity: any): string | undefined {
+  const expanded = entity?.expanded_url ?? entity?.expandedUrl;
+  if (typeof expanded === 'string' && expanded.length > 0 && !expanded.includes('t.co/')) return expanded;
+  const display = entity?.display_url ?? entity?.displayUrl;
+  if (typeof display === 'string' && display.length > 0 && !display.includes('t.co/')) return display;
+  return undefined;
+}
+
+export function expandVisibleUrlEntities(text: string, urlEntities: any[]): string {
+  let expanded = text;
+  for (const entity of urlEntities) {
+    if (typeof entity?.url !== 'string') continue;
+    const replacement = urlEntityReplacement(entity);
+    if (!replacement) continue;
+    expanded = expanded.split(entity.url).join(replacement);
+  }
+  return expanded;
+}
+
+export function compareThreadTweetsChronologically(a: ThreadTweetSnapshot, b: ThreadTweetSnapshot): number {
+  const aId = parseSnowflake(a.id);
+  const bId = parseSnowflake(b.id);
+  if (aId != null && bId != null && aId !== bId) return aId < bId ? -1 : 1;
+  const aTime = parseTimestampMs(a.postedAt);
+  const bTime = parseTimestampMs(b.postedAt);
+  if (aTime != null && bTime != null && aTime !== bTime) return aTime - bTime;
+  return a.id.localeCompare(b.id);
+}
+
+function parseThreadTweetResult(
+  value: any,
+  fallbackId?: string,
+  metadata: Partial<ThreadTweetSnapshot> = {},
+): ThreadTweetSnapshot | null {
+  const tweet = value?.tweet ?? value;
+  const legacy = tweet?.legacy;
+  if (!legacy) return null;
+
+  const urlEntities = tweetUrlEntities(tweet, legacy);
+  const noteText = tweet?.note_tweet?.note_tweet_results?.result?.text;
+  const text = expandVisibleUrlEntities(noteText ?? legacy.full_text ?? legacy.text ?? '', urlEntities);
+  const resolvedId = String(legacy.id_str ?? tweet?.rest_id ?? fallbackId ?? '');
+  if (!resolvedId || !text) return null;
+
+  const userResult = tweet?.core?.user_results?.result;
+  const handle = userResult?.core?.screen_name ?? userResult?.legacy?.screen_name;
+  const mediaEntities: any[] = legacy?.extended_entities?.media ?? legacy?.entities?.media ?? [];
+
+  return {
+    id: resolvedId,
+    text,
+    authorHandle: handle,
+    authorName: userResult?.core?.name ?? userResult?.legacy?.name,
+    authorProfileImageUrl:
+      userResult?.avatar?.image_url ?? userResult?.legacy?.profile_image_url_https,
+    postedAt: legacy.created_at ?? null,
+    media: mediaEntities.map((m: any) => m.media_url_https ?? m.media_url).filter(Boolean),
+    mediaObjects: mediaEntities.map((m: any) => ({
+      type: m.type,
+      url: m.media_url_https ?? m.media_url,
+      expandedUrl: m.expanded_url,
+      width: m.original_info?.width,
+      height: m.original_info?.height,
+      altText: m.ext_alt_text,
+      videoVariants: Array.isArray(m.video_info?.variants)
+        ? m.video_info.variants
+            .filter((v: any) => v.content_type === 'video/mp4')
+            .map((v: any) => ({ bitrate: v.bitrate, url: v.url }))
+        : undefined,
+    })),
+    links: extractExpandedLinks(urlEntities),
+    conversationId: legacy.conversation_id_str,
+    inReplyToStatusId: legacy.in_reply_to_status_id_str,
+    ...metadata,
+    url: `https://x.com/${handle ?? '_'}/status/${resolvedId}`,
+  };
+}
+
+export function parseThreadTweetResultByRestId(json: any, tweetId: string): ThreadTweetSnapshot | null {
+  const result = json?.data?.tweetResult?.result;
+  if (!result) return null;
+  return parseThreadTweetResult(result, tweetId);
+}
+
+function sameHandle(a?: string, b?: string): boolean {
+  if (!a || !b) return false;
+  return a.toLowerCase() === b.toLowerCase();
+}
+
+function conversationSection(content: any): string | undefined {
+  return content?.clientEventInfo?.details?.conversationDetails?.conversationSection;
+}
+
+function isUnavailableTweetResult(result: any): boolean {
+  const typename = result?.__typename ?? result?.tweet?.__typename;
+  return typename === 'TweetTombstone' || typename === 'TweetUnavailable';
+}
+
+interface CollectThreadResult {
+  nextCursor?: string;
+  sawTweetResult: boolean;
+  sawUnavailableTweet: boolean;
+  sawUnparseableTweet: boolean;
+}
+
+function emptyCollectThreadResult(): CollectThreadResult {
+  return {
+    sawTweetResult: false,
+    sawUnavailableTweet: false,
+    sawUnparseableTweet: false,
+  };
+}
+
+function mergeCollectThreadResult(target: CollectThreadResult, source: CollectThreadResult): void {
+  target.nextCursor = source.nextCursor ?? target.nextCursor;
+  target.sawTweetResult = target.sawTweetResult || source.sawTweetResult;
+  target.sawUnavailableTweet = target.sawUnavailableTweet || source.sawUnavailableTweet;
+  target.sawUnparseableTweet = target.sawUnparseableTweet || source.sawUnparseableTweet;
+}
+
+function parseResultInto(
+  result: any,
+  tweets: ThreadTweetSnapshot[],
+  fallbackId?: string,
+  metadata: Partial<ThreadTweetSnapshot> = {},
+): Pick<CollectThreadResult, 'sawTweetResult' | 'sawUnavailableTweet' | 'sawUnparseableTweet'> {
+  if (!result) {
+    return { sawTweetResult: false, sawUnavailableTweet: false, sawUnparseableTweet: false };
+  }
+
+  if (isUnavailableTweetResult(result)) {
+    return { sawTweetResult: true, sawUnavailableTweet: true, sawUnparseableTweet: false };
+  }
+
+  const snapshot = parseThreadTweetResult(result, fallbackId, metadata);
+  if (!snapshot) {
+    return { sawTweetResult: true, sawUnavailableTweet: false, sawUnparseableTweet: true };
+  }
+
+  tweets.push(snapshot);
+  return { sawTweetResult: true, sawUnavailableTweet: false, sawUnparseableTweet: false };
+}
+
+function collectThreadEntries(entries: any[], out: ThreadTweetSnapshot[]): CollectThreadResult {
+  const result = emptyCollectThreadResult();
+  for (const entry of entries) {
+    if (entry?.entryId?.startsWith('cursor-bottom')) {
+      result.nextCursor = entry?.content?.value;
+      continue;
+    }
+
+    const direct = entry?.content?.itemContent?.tweet_results?.result;
+    const directParsed = parseResultInto(direct, out);
+    result.sawTweetResult = result.sawTweetResult || directParsed.sawTweetResult;
+    result.sawUnavailableTweet = result.sawUnavailableTweet || directParsed.sawUnavailableTweet;
+    result.sawUnparseableTweet = result.sawUnparseableTweet || directParsed.sawUnparseableTweet;
+
+    const moduleItems = entry?.content?.items;
+    if (Array.isArray(moduleItems)) {
+      const moduleSnapshots: ThreadTweetSnapshot[] = [];
+      for (let index = 0; index < moduleItems.length; index++) {
+        const item = moduleItems[index];
+        const itemResult = item?.item?.itemContent?.tweet_results?.result;
+        const parsed = parseResultInto(itemResult, moduleSnapshots, undefined, {
+          conversationEntryId: entry.entryId,
+          conversationDisplayType: entry?.content?.displayType,
+          conversationSection: conversationSection(entry.content),
+          conversationItemIndex: index,
+        });
+        result.sawTweetResult = result.sawTweetResult || parsed.sawTweetResult;
+        result.sawUnavailableTweet = result.sawUnavailableTweet || parsed.sawUnavailableTweet;
+        result.sawUnparseableTweet = result.sawUnparseableTweet || parsed.sawUnparseableTweet;
+      }
+      const rootId = moduleSnapshots[0]?.id;
+      for (const snapshot of moduleSnapshots) {
+        if (rootId) snapshot.conversationRootId = rootId;
+        out.push(snapshot);
+      }
+    }
+  }
+  return result;
+}
+
+export interface TweetDetailParseResult {
+  tweets: ThreadTweetSnapshot[];
+  nextCursor?: string;
+  recognizedTimeline: boolean;
+  sawTweetResult: boolean;
+  sawUnavailableTweet: boolean;
+  sawUnparseableTweet: boolean;
+}
+
+export function parseTweetDetailResponse(json: any): TweetDetailParseResult {
+  const instructionsValue = json?.data?.threaded_conversation_with_injections_v2?.instructions;
+  const recognizedTimeline = Array.isArray(instructionsValue);
+  const instructions = recognizedTimeline ? instructionsValue : [];
+  const tweets: ThreadTweetSnapshot[] = [];
+  const collectResult = emptyCollectThreadResult();
+
+  for (const instruction of instructions) {
+    if (instruction?.type === 'TimelineAddEntries' && Array.isArray(instruction.entries)) {
+      mergeCollectThreadResult(collectResult, collectThreadEntries(instruction.entries, tweets));
+    }
+    if (instruction?.type === 'TimelinePinEntry' && instruction.entry) {
+      mergeCollectThreadResult(collectResult, collectThreadEntries([instruction.entry], tweets));
+    }
+  }
+
+  const byId = new Map<string, ThreadTweetSnapshot>();
+  for (const tweet of tweets) {
+    if (!byId.has(tweet.id)) byId.set(tweet.id, tweet);
+  }
+  return {
+    tweets: Array.from(byId.values()).sort(compareThreadTweetsChronologically),
+    nextCursor: collectResult.nextCursor,
+    recognizedTimeline,
+    sawTweetResult: collectResult.sawTweetResult,
+    sawUnavailableTweet: collectResult.sawUnavailableTweet,
+    sawUnparseableTweet: collectResult.sawUnparseableTweet,
+  };
+}
+
+export function extractSameAuthorThreadBelow(
+  tweets: ThreadTweetSnapshot[],
+  focalTweetId: string,
+  focalAuthorHandle?: string,
+): ThreadTweetSnapshot[] {
+  const focal = tweets.find((tweet) => tweet.id === focalTweetId);
+  const authorHandle = focalAuthorHandle ?? focal?.authorHandle;
+  if (!authorHandle) return [];
+
+  const chainIds = new Set<string>([focalTweetId]);
+  const below: ThreadTweetSnapshot[] = [];
+  const sorted = tweets
+    .filter((tweet) => tweet.id !== focalTweetId && sameHandle(tweet.authorHandle, authorHandle))
+    .sort(compareThreadTweetsChronologically);
+
+  for (const tweet of sorted) {
+    if (!tweet.inReplyToStatusId || !chainIds.has(tweet.inReplyToStatusId)) continue;
+    below.push({ ...tweet, threadRole: 'post-thread' });
+    chainIds.add(tweet.id);
+  }
+
+  return below;
+}

--- a/src/tweet-snapshots.ts
+++ b/src/tweet-snapshots.ts
@@ -274,6 +274,7 @@ export interface TweetDetailParseResult {
   sawTweetResult: boolean;
   sawUnavailableTweet: boolean;
   sawUnparseableTweet: boolean;
+  parserGaps: string[];
 }
 
 export function parseTweetDetailResponse(json: any): TweetDetailParseResult {
@@ -282,15 +283,22 @@ export function parseTweetDetailResponse(json: any): TweetDetailParseResult {
   const instructions = recognizedTimeline ? instructionsValue : [];
   const tweets: ThreadTweetSnapshot[] = [];
   const collectResult = emptyCollectThreadResult();
+  const parserGaps = new Set<string>();
 
   for (const instruction of instructions) {
-    if (Array.isArray(instruction?.entries)) {
+    if (instruction?.type === 'TimelineAddEntries' && Array.isArray(instruction?.entries)) {
       mergeCollectThreadResult(collectResult, collectThreadEntries(instruction.entries, tweets));
-    }
-    if (instruction?.entry) {
+    } else if (instruction?.type === 'TimelineReplaceEntry' && instruction?.entry) {
       mergeCollectThreadResult(collectResult, collectThreadEntries([instruction.entry], tweets));
+    } else if (Array.isArray(instruction?.entries) || instruction?.entry) {
+      collectResult.sawUnparseableTweet = true;
+      parserGaps.add('unknown_instruction');
     }
   }
+
+  if (!recognizedTimeline) parserGaps.add('malformed_timeline');
+  if (collectResult.sawUnavailableTweet) parserGaps.add('unavailable_tweet');
+  if (collectResult.sawUnparseableTweet && parserGaps.size === 0) parserGaps.add('unparseable_entry');
 
   const byId = new Map<string, ThreadTweetSnapshot>();
   for (const tweet of tweets) {
@@ -304,6 +312,7 @@ export function parseTweetDetailResponse(json: any): TweetDetailParseResult {
     sawTweetResult: collectResult.sawTweetResult,
     sawUnavailableTweet: collectResult.sawUnavailableTweet,
     sawUnparseableTweet: collectResult.sawUnparseableTweet,
+    parserGaps: [...parserGaps].sort(),
   };
 }
 

--- a/src/tweet-snapshots.ts
+++ b/src/tweet-snapshots.ts
@@ -275,7 +275,7 @@ export function parseTweetDetailResponse(json: any): TweetDetailParseResult {
   const collectResult = emptyCollectThreadResult();
 
   for (const instruction of instructions) {
-    if (instruction?.type === 'TimelineAddEntries' && Array.isArray(instruction.entries)) {
+    if (Array.isArray(instruction?.entries)) {
       mergeCollectThreadResult(collectResult, collectThreadEntries(instruction.entries, tweets));
     }
     if (instruction?.entry) {

--- a/src/tweet-snapshots.ts
+++ b/src/tweet-snapshots.ts
@@ -146,6 +146,7 @@ function isUnavailableTweetResult(result: any): boolean {
 
 interface CollectThreadResult {
   nextCursor?: string;
+  continuationCursors: string[];
   sawTweetResult: boolean;
   sawUnavailableTweet: boolean;
   sawUnparseableTweet: boolean;
@@ -153,6 +154,7 @@ interface CollectThreadResult {
 
 function emptyCollectThreadResult(): CollectThreadResult {
   return {
+    continuationCursors: [],
     sawTweetResult: false,
     sawUnavailableTweet: false,
     sawUnparseableTweet: false,
@@ -161,6 +163,9 @@ function emptyCollectThreadResult(): CollectThreadResult {
 
 function mergeCollectThreadResult(target: CollectThreadResult, source: CollectThreadResult): void {
   target.nextCursor = source.nextCursor ?? target.nextCursor;
+  for (const cursor of source.continuationCursors) {
+    if (!target.continuationCursors.includes(cursor)) target.continuationCursors.push(cursor);
+  }
   target.sawTweetResult = target.sawTweetResult || source.sawTweetResult;
   target.sawUnavailableTweet = target.sawUnavailableTweet || source.sawUnavailableTweet;
   target.sawUnparseableTweet = target.sawUnparseableTweet || source.sawUnparseableTweet;
@@ -222,6 +227,9 @@ function collectThreadEntries(entries: any[], out: ThreadTweetSnapshot[]): Colle
     const cursor = continuationCursor(entry);
     if (cursor.recognized) {
       result.nextCursor = cursor.cursor ?? result.nextCursor;
+      if (cursor.cursor && !result.continuationCursors.includes(cursor.cursor)) {
+        result.continuationCursors.push(cursor.cursor);
+      }
       result.sawUnparseableTweet ||= cursor.parserGap;
       continue;
     }
@@ -261,6 +269,7 @@ function collectThreadEntries(entries: any[], out: ThreadTweetSnapshot[]): Colle
 export interface TweetDetailParseResult {
   tweets: ThreadTweetSnapshot[];
   nextCursor?: string;
+  continuationCursors: string[];
   recognizedTimeline: boolean;
   sawTweetResult: boolean;
   sawUnavailableTweet: boolean;
@@ -290,6 +299,7 @@ export function parseTweetDetailResponse(json: any): TweetDetailParseResult {
   return {
     tweets: Array.from(byId.values()).sort(compareThreadTweetsChronologically),
     nextCursor: collectResult.nextCursor,
+    continuationCursors: collectResult.continuationCursors,
     recognizedTimeline,
     sawTweetResult: collectResult.sawTweetResult,
     sawUnavailableTweet: collectResult.sawUnavailableTweet,

--- a/src/tweet-snapshots.ts
+++ b/src/tweet-snapshots.ts
@@ -195,16 +195,17 @@ function continuationCursor(entry: any): {
   parserGap: boolean;
 } {
   const entryId = typeof entry?.entryId === 'string' ? entry.entryId : '';
-  if (entryId.startsWith('cursor-top')) {
+  const cursorMarker = entryId.toLowerCase();
+  if (!cursorMarker.includes('cursor')) {
+    return { recognized: false, parserGap: false };
+  }
+  if (cursorMarker.includes('cursor-top')) {
     return { recognized: true, parserGap: false };
   }
-  const supported = entryId.startsWith('cursor-bottom')
-    || entryId.startsWith('cursor-showmorethreads');
+  const supported = cursorMarker.includes('cursor-bottom')
+    || cursorMarker.includes('cursor-showmorethreads');
   if (!supported) {
-    return {
-      recognized: entryId.startsWith('cursor-'),
-      parserGap: entryId.startsWith('cursor-'),
-    };
+    return { recognized: true, parserGap: true };
   }
   const value = entry?.content?.value
     ?? entry?.content?.itemContent?.value
@@ -277,7 +278,7 @@ export function parseTweetDetailResponse(json: any): TweetDetailParseResult {
     if (instruction?.type === 'TimelineAddEntries' && Array.isArray(instruction.entries)) {
       mergeCollectThreadResult(collectResult, collectThreadEntries(instruction.entries, tweets));
     }
-    if (instruction?.type === 'TimelinePinEntry' && instruction.entry) {
+    if (instruction?.entry) {
       mergeCollectThreadResult(collectResult, collectThreadEntries([instruction.entry], tweets));
     }
   }

--- a/src/tweet-snapshots.ts
+++ b/src/tweet-snapshots.ts
@@ -189,11 +189,39 @@ function parseResultInto(
   return { sawTweetResult: true, sawUnavailableTweet: false, sawUnparseableTweet: false };
 }
 
+function continuationCursor(entry: any): {
+  recognized: boolean;
+  cursor?: string;
+  parserGap: boolean;
+} {
+  const entryId = typeof entry?.entryId === 'string' ? entry.entryId : '';
+  if (entryId.startsWith('cursor-top')) {
+    return { recognized: true, parserGap: false };
+  }
+  const supported = entryId.startsWith('cursor-bottom')
+    || entryId.startsWith('cursor-showmorethreads');
+  if (!supported) {
+    return {
+      recognized: entryId.startsWith('cursor-'),
+      parserGap: entryId.startsWith('cursor-'),
+    };
+  }
+  const value = entry?.content?.value
+    ?? entry?.content?.itemContent?.value
+    ?? entry?.content?.operation?.cursor?.value;
+  if (typeof value !== 'string' || value.length === 0) {
+    return { recognized: true, parserGap: true };
+  }
+  return { recognized: true, cursor: value, parserGap: false };
+}
+
 function collectThreadEntries(entries: any[], out: ThreadTweetSnapshot[]): CollectThreadResult {
   const result = emptyCollectThreadResult();
   for (const entry of entries) {
-    if (entry?.entryId?.startsWith('cursor-bottom')) {
-      result.nextCursor = entry?.content?.value;
+    const cursor = continuationCursor(entry);
+    if (cursor.recognized) {
+      result.nextCursor = cursor.cursor ?? result.nextCursor;
+      result.sawUnparseableTweet ||= cursor.parserGap;
       continue;
     }
 

--- a/src/tweet-snapshots.ts
+++ b/src/tweet-snapshots.ts
@@ -103,14 +103,23 @@ function parseThreadTweetResult(
 
   const urlEntities = tweetUrlEntities(tweet, legacy);
   const noteText = tweet?.note_tweet?.note_tweet_results?.result?.text;
-  const text = expandVisibleUrlEntities(noteText ?? legacy.full_text ?? legacy.text ?? '', urlEntities);
+  const responseText = noteText ?? legacy.full_text ?? legacy.text;
+  if (typeof responseText !== 'string') return null;
+  const text = expandVisibleUrlEntities(responseText, urlEntities);
+  const rawMediaEntities = legacy?.extended_entities?.media ?? legacy?.entities?.media;
+  const mediaEntities: any[] = Array.isArray(rawMediaEntities)
+    ? rawMediaEntities.filter((media: any) => media && typeof media === 'object')
+    : [];
+  const media = mediaEntities
+    .map((item: any) => item.media_url_https ?? item.media_url)
+    .filter((url: any): url is string => typeof url === 'string' && url.length > 0);
+  if (!text && media.length === 0) return null;
   const identity = reduceExactDecimalIdentity(legacy.id_str, tweet?.rest_id);
-  if (identity.status !== 'ok' || (expectedId && identity.id !== expectedId) || !text) return null;
+  if (identity.status !== 'ok' || (expectedId && identity.id !== expectedId)) return null;
   const resolvedId = identity.id;
 
   const userResult = tweet?.core?.user_results?.result;
   const handle = userResult?.core?.screen_name ?? userResult?.legacy?.screen_name;
-  const mediaEntities: any[] = legacy?.extended_entities?.media ?? legacy?.entities?.media ?? [];
 
   return {
     id: resolvedId,
@@ -120,7 +129,7 @@ function parseThreadTweetResult(
     authorProfileImageUrl:
       userResult?.avatar?.image_url ?? userResult?.legacy?.profile_image_url_https,
     postedAt: legacy.created_at ?? null,
-    media: mediaEntities.map((m: any) => m.media_url_https ?? m.media_url).filter(Boolean),
+    media,
     mediaObjects: mediaEntities.map((m: any) => ({
       type: m.type,
       url: m.media_url_https ?? m.media_url,

--- a/src/tweet-snapshots.ts
+++ b/src/tweet-snapshots.ts
@@ -235,10 +235,14 @@ function collectThreadEntries(entries: any[], out: ThreadTweetSnapshot[]): Colle
     }
 
     const direct = entry?.content?.itemContent?.tweet_results?.result;
+    const hasDirectTweetEnvelope = entry?.content?.itemContent?.tweet_results !== undefined;
     const directParsed = parseResultInto(direct, out);
     result.sawTweetResult = result.sawTweetResult || directParsed.sawTweetResult;
     result.sawUnavailableTweet = result.sawUnavailableTweet || directParsed.sawUnavailableTweet;
     result.sawUnparseableTweet = result.sawUnparseableTweet || directParsed.sawUnparseableTweet;
+    if (hasDirectTweetEnvelope && direct === undefined) {
+      result.sawUnparseableTweet = true;
+    }
 
     const moduleItems = entry?.content?.items;
     if (Array.isArray(moduleItems)) {
@@ -261,6 +265,9 @@ function collectThreadEntries(entries: any[], out: ThreadTweetSnapshot[]): Colle
         if (rootId) snapshot.conversationRootId = rootId;
         out.push(snapshot);
       }
+    }
+    if (!hasDirectTweetEnvelope && !Array.isArray(moduleItems)) {
+      result.sawUnparseableTweet = true;
     }
   }
   return result;

--- a/src/tweet-snapshots.ts
+++ b/src/tweet-snapshots.ts
@@ -14,6 +14,23 @@ export function uniqueStrings(values: string[]): string[] {
   return [...new Set(values)];
 }
 
+export type ExactDecimalIdentity =
+  | { status: 'ok'; id: string }
+  | { status: 'absent' | 'invalid' };
+
+/** Accept response-owned decimal-string aliases only when every present value agrees. */
+export function reduceExactDecimalIdentity(...values: unknown[]): ExactDecimalIdentity {
+  const present = values.filter((value) => value !== undefined && value !== null);
+  if (present.length === 0) return { status: 'absent' };
+  if (present.some((value) => typeof value !== 'string' || !/^\d+$/.test(value))) {
+    return { status: 'invalid' };
+  }
+  const identities = uniqueStrings(present as string[]);
+  return identities.length === 1
+    ? { status: 'ok', id: identities[0] }
+    : { status: 'invalid' };
+}
+
 function urlEntityKey(entity: any): string {
   return String(entity?.url ?? entity?.expanded_url ?? entity?.expandedUrl ?? entity?.display_url ?? entity?.displayUrl ?? '');
 }
@@ -77,7 +94,7 @@ export function compareThreadTweetsChronologically(a: ThreadTweetSnapshot, b: Th
 
 function parseThreadTweetResult(
   value: any,
-  fallbackId?: string,
+  expectedId?: string,
   metadata: Partial<ThreadTweetSnapshot> = {},
 ): ThreadTweetSnapshot | null {
   const tweet = value?.tweet ?? value;
@@ -87,8 +104,9 @@ function parseThreadTweetResult(
   const urlEntities = tweetUrlEntities(tweet, legacy);
   const noteText = tweet?.note_tweet?.note_tweet_results?.result?.text;
   const text = expandVisibleUrlEntities(noteText ?? legacy.full_text ?? legacy.text ?? '', urlEntities);
-  const resolvedId = String(legacy.id_str ?? tweet?.rest_id ?? fallbackId ?? '');
-  if (!resolvedId || !text) return null;
+  const identity = reduceExactDecimalIdentity(legacy.id_str, tweet?.rest_id);
+  if (identity.status !== 'ok' || (expectedId && identity.id !== expectedId) || !text) return null;
+  const resolvedId = identity.id;
 
   const userResult = tweet?.core?.user_results?.result;
   const handle = userResult?.core?.screen_name ?? userResult?.legacy?.screen_name;

--- a/src/tweet-snapshots.ts
+++ b/src/tweet-snapshots.ts
@@ -240,7 +240,7 @@ function collectThreadEntries(entries: any[], out: ThreadTweetSnapshot[]): Colle
     result.sawTweetResult = result.sawTweetResult || directParsed.sawTweetResult;
     result.sawUnavailableTweet = result.sawUnavailableTweet || directParsed.sawUnavailableTweet;
     result.sawUnparseableTweet = result.sawUnparseableTweet || directParsed.sawUnparseableTweet;
-    if (hasDirectTweetEnvelope && direct === undefined) {
+    if (hasDirectTweetEnvelope && direct == null) {
       result.sawUnparseableTweet = true;
     }
 
@@ -250,6 +250,7 @@ function collectThreadEntries(entries: any[], out: ThreadTweetSnapshot[]): Colle
       for (let index = 0; index < moduleItems.length; index++) {
         const item = moduleItems[index];
         const itemResult = item?.item?.itemContent?.tweet_results?.result;
+        const hasItemTweetEnvelope = item?.item?.itemContent?.tweet_results !== undefined;
         const parsed = parseResultInto(itemResult, moduleSnapshots, undefined, {
           conversationEntryId: entry.entryId,
           conversationDisplayType: entry?.content?.displayType,
@@ -259,6 +260,9 @@ function collectThreadEntries(entries: any[], out: ThreadTweetSnapshot[]): Colle
         result.sawTweetResult = result.sawTweetResult || parsed.sawTweetResult;
         result.sawUnavailableTweet = result.sawUnavailableTweet || parsed.sawUnavailableTweet;
         result.sawUnparseableTweet = result.sawUnparseableTweet || parsed.sawUnparseableTweet;
+        if (!hasItemTweetEnvelope || itemResult == null) {
+          result.sawUnparseableTweet = true;
+        }
       }
       const rootId = moduleSnapshots[0]?.id;
       for (const snapshot of moduleSnapshots) {
@@ -297,7 +301,11 @@ export function parseTweetDetailResponse(json: any): TweetDetailParseResult {
       mergeCollectThreadResult(collectResult, collectThreadEntries(instruction.entries, tweets));
     } else if (instruction?.type === 'TimelineReplaceEntry' && instruction?.entry) {
       mergeCollectThreadResult(collectResult, collectThreadEntries([instruction.entry], tweets));
-    } else if (Array.isArray(instruction?.entries) || instruction?.entry) {
+    } else if (instruction?.type === 'TimelineTerminateTimeline'
+      && instruction?.entries === undefined
+      && instruction?.entry === undefined) {
+      // Known content-free termination marker. Queue state remains authoritative.
+    } else {
       collectResult.sawUnparseableTweet = true;
       parserGaps.add('unknown_instruction');
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -43,6 +43,10 @@ export interface BookmarkEngagementSnapshot {
 export interface QuotedTweetSnapshot {
   id: string;
   text: string;
+  /** Exact quote identity owned by this tweet's response, when present. */
+  quotedStatusId?: string;
+  /** The response identifies a quote relationship but exposes no exact quote ID. */
+  quotedStatusIdentityUnresolved?: boolean;
   authorHandle?: string;
   authorName?: string;
   authorProfileImageUrl?: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -106,6 +106,10 @@ export interface BookmarkRecord {
   articleTitle?: string | null;
   articleText?: string | null;
   articleSite?: string | null;
+  /** Tweet whose payload supplied articleText. Required for derived enrichment. */
+  articleSourceTweetId?: string | null;
+  /** Exact outbound locator whose body is stored in articleText. */
+  articleLocator?: string | null;
   enrichedAt?: string | null;
   language?: string;
   sourceApp?: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,6 +49,30 @@ export interface QuotedTweetSnapshot {
   postedAt?: string | null;
   media?: string[];
   mediaObjects?: BookmarkMediaObject[];
+  links?: string[];
+  conversationId?: string;
+  inReplyToStatusId?: string;
+  url: string;
+}
+
+export interface ThreadTweetSnapshot {
+  id: string;
+  text: string;
+  authorHandle?: string;
+  authorName?: string;
+  authorProfileImageUrl?: string;
+  postedAt?: string | null;
+  media?: string[];
+  mediaObjects?: BookmarkMediaObject[];
+  links?: string[];
+  conversationId?: string;
+  inReplyToStatusId?: string;
+  threadRole?: 'post-thread';
+  conversationEntryId?: string;
+  conversationDisplayType?: string;
+  conversationSection?: string;
+  conversationRootId?: string;
+  conversationItemIndex?: number;
   url: string;
 }
 
@@ -71,6 +95,14 @@ export interface BookmarkRecord {
   inReplyToUserId?: string;
   quotedStatusId?: string;
   quotedTweet?: QuotedTweetSnapshot;
+  /** Query-local parent posts above this root, oldest first. */
+  threadContext?: ThreadTweetSnapshot[];
+  /** Query-local same-author continuations below this root. */
+  threadBelow?: ThreadTweetSnapshot[];
+  /** Exact time the query-local thread traversal completed. */
+  threadExpandedAt?: string;
+  /** Exact time a permanent query-local thread traversal failure was observed. */
+  threadExpansionFailedAt?: string | null;
   articleTitle?: string | null;
   articleText?: string | null;
   articleSite?: string | null;

--- a/src/x-materialize.ts
+++ b/src/x-materialize.ts
@@ -2,9 +2,15 @@ import {
   fetchTweetByIdViaGraphQL,
   fetchTweetDetailViaGraphQL,
   type TweetFetchResult,
+  type TweetDetailFetchResult,
+  type TweetDetailTermination,
 } from './graphql-bookmarks.js';
 import { extractSameAuthorThreadBelow } from './tweet-snapshots.js';
+import { isXArticleLocator, sameSourceLocator } from './source-bindings.js';
 import type { BookmarkRecord, ThreadTweetSnapshot } from './types.js';
+import { XRequestExecutor } from './x-request-policy.js';
+
+export type ParentTraversalTermination = 'root' | 'cycle' | 'limit' | 'unavailable' | 'error';
 
 export interface ExactXRefreshObservation {
   status: 'complete' | 'partial' | 'unavailable';
@@ -15,6 +21,9 @@ export interface ExactXRefreshObservation {
   quote_status: TweetFetchResult['status'];
   article_status: 'ok' | 'not_applicable' | 'unresolved';
   parent_limit_reached: boolean;
+  parent_termination: ParentTraversalTermination;
+  continuation_termination: TweetDetailTermination;
+  continuation_focal_bound: boolean;
 }
 
 export interface ExactXRefreshResult {
@@ -29,27 +38,25 @@ export interface ExactXRefreshOptions {
   maxParents?: number;
   maxPages?: number;
   now?: string;
+  requestExecutor?: XRequestExecutor;
 }
 
 function hasXArticleIdentity(record: BookmarkRecord): boolean {
   return Boolean(
     record.articleTitle
     || record.articleSite
-    || record.links?.some((value) => {
-      try {
-        const parsed = new URL(value);
-        return (parsed.hostname === 'x.com' || parsed.hostname === 'twitter.com')
-          && parsed.pathname.startsWith('/i/article/');
-      } catch {
-        return false;
-      }
-    }),
+    || record.links?.some(isXArticleLocator),
   );
 }
 
 function refreshedRoot(record: BookmarkRecord, result: TweetFetchResult): BookmarkRecord {
   const snapshot = result.snapshot;
   if (!snapshot) return record;
+  const links = snapshot.links ?? record.links ?? [];
+  const articleLinks = result.article
+    && !links.some((value) => sameSourceLocator(value, result.article!.sourceLocator))
+      ? [...links, result.article.sourceLocator]
+      : links;
   return {
     ...record,
     id: record.id,
@@ -64,11 +71,70 @@ function refreshedRoot(record: BookmarkRecord, result: TweetFetchResult): Bookma
     inReplyToStatusId: snapshot.inReplyToStatusId ?? record.inReplyToStatusId,
     media: snapshot.media ?? record.media,
     mediaObjects: snapshot.mediaObjects ?? record.mediaObjects,
-    links: snapshot.links ?? record.links,
-    articleTitle: result.article?.title ?? record.articleTitle,
+    links: articleLinks,
+    articleTitle: result.article?.title ?? null,
     articleText: result.article?.text ?? null,
-    articleSite: result.article?.siteName ?? record.articleSite,
+    articleSite: result.article?.siteName ?? null,
+    articleSourceTweetId: result.article?.sourceTweetId ?? null,
+    articleLocator: result.article?.sourceLocator ?? null,
   };
+}
+
+interface ParentTraversalResult {
+  context: ThreadTweetSnapshot[];
+  status: TweetFetchResult['status'];
+  termination: ParentTraversalTermination;
+}
+
+async function traverseParents(
+  record: BookmarkRecord,
+  options: ExactXRefreshOptions,
+  executor: XRequestExecutor,
+  maxParents: number,
+): Promise<ParentTraversalResult> {
+  const context: ThreadTweetSnapshot[] = [];
+  const seen = new Set<string>([record.tweetId]);
+  let nextParent = record.inReplyToStatusId;
+  while (nextParent) {
+    if (seen.has(nextParent)) {
+      return { context, status: 'error', termination: 'cycle' };
+    }
+    if (context.length >= maxParents) {
+      return { context, status: 'error', termination: 'limit' };
+    }
+    seen.add(nextParent);
+    const parent = await fetchTweetByIdViaGraphQL(
+      nextParent,
+      options.csrfToken,
+      options.cookieHeader,
+      { executor },
+    );
+    if (parent.status !== 'ok' || !parent.snapshot) {
+      const termination: ParentTraversalTermination = parent.status === 'not_found'
+        || parent.status === 'forbidden'
+        || parent.status === 'empty'
+        ? 'unavailable'
+        : 'error';
+      return { context, status: parent.status, termination };
+    }
+    const snapshot = parent.snapshot as ThreadTweetSnapshot;
+    context.unshift(snapshot);
+    nextParent = snapshot.inReplyToStatusId;
+  }
+  return { context, status: 'ok', termination: 'root' };
+}
+
+function refreshComplete(state: {
+  parents: ParentTraversalResult;
+  detail: TweetDetailFetchResult;
+  quoteStatus: TweetFetchResult['status'];
+  articleStatus: ExactXRefreshObservation['article_status'];
+}): boolean {
+  return state.parents.termination === 'root'
+    && state.detail.enumerationTermination === 'exhausted'
+    && state.detail.focalBound
+    && state.quoteStatus === 'ok'
+    && state.articleStatus !== 'unresolved';
 }
 
 export async function refreshExactXBookmark(
@@ -77,18 +143,12 @@ export async function refreshExactXBookmark(
 ): Promise<ExactXRefreshResult> {
   const delayMs = options.delayMs ?? 300;
   const maxParents = options.maxParents ?? 25;
-  let requestCount = 0;
-  const waitForNextRequest = async (): Promise<void> => {
-    if (requestCount > 0 && delayMs > 0) {
-      await new Promise((resolve) => setTimeout(resolve, delayMs));
-    }
-    requestCount += 1;
-  };
-  await waitForNextRequest();
+  const executor = options.requestExecutor ?? new XRequestExecutor({ delayMs });
   const root = await fetchTweetByIdViaGraphQL(
     archived.tweetId,
     options.csrfToken,
     options.cookieHeader,
+    { executor },
   );
   if (root.status !== 'ok' || !root.snapshot) {
     return {
@@ -102,55 +162,37 @@ export async function refreshExactXBookmark(
         quote_status: archived.quotedStatusId ? 'empty' : 'ok',
         article_status: archived.articleText ? 'unresolved' : 'not_applicable',
         parent_limit_reached: false,
+        parent_termination: 'error',
+        continuation_termination: 'error',
+        continuation_focal_bound: false,
       },
     };
   }
 
   const record = refreshedRoot(archived, root);
-  const context: ThreadTweetSnapshot[] = [];
-  const seen = new Set<string>();
-  let parentStatus: TweetFetchResult['status'] = 'ok';
-  let nextParent = record.inReplyToStatusId;
-  while (nextParent && !seen.has(nextParent) && context.length < maxParents) {
-    seen.add(nextParent);
-    await waitForNextRequest();
-    const parent = await fetchTweetByIdViaGraphQL(
-      nextParent,
-      options.csrfToken,
-      options.cookieHeader,
-    );
-    if (parent.status !== 'ok' || !parent.snapshot) {
-      parentStatus = parent.status;
-      break;
-    }
-    const snapshot = parent.snapshot as ThreadTweetSnapshot;
-    context.unshift(snapshot);
-    nextParent = snapshot.inReplyToStatusId;
-  }
-  const parentLimitReached = Boolean(nextParent && context.length >= maxParents);
-  if (parentLimitReached) parentStatus = 'error';
+  const parents = await traverseParents(record, options, executor, maxParents);
 
-  await waitForNextRequest();
   const detail = await fetchTweetDetailViaGraphQL(
     archived.tweetId,
     options.csrfToken,
     options.cookieHeader,
-    { maxPages: options.maxPages ?? 3, delayMs },
+    { maxPages: options.maxPages ?? 3, executor },
   );
   const continuationStatus = detail.status;
-  const continuationHasFocal = detail.status === 'ok'
-    && detail.tweets.some((tweet) => tweet.id === record.tweetId);
+  const continuationHasFocal = detail.status === 'ok' && detail.focalBound;
   const below = continuationHasFocal
     ? extractSameAuthorThreadBelow(detail.tweets, record.tweetId, record.authorHandle)
     : [];
   let quoteStatus: TweetFetchResult['status'] = 'ok';
-  let quotedTweet = record.quotedTweet;
+  let quotedTweet = record.quotedStatusId && record.quotedTweet?.id === record.quotedStatusId
+    ? record.quotedTweet
+    : undefined;
   if (record.quotedStatusId) {
-    await waitForNextRequest();
     const quoted = await fetchTweetByIdViaGraphQL(
       record.quotedStatusId,
       options.csrfToken,
       options.cookieHeader,
+      { executor },
     );
     quoteStatus = quoted.status;
     if (quoted.status === 'ok' && quoted.snapshot) quotedTweet = quoted.snapshot;
@@ -160,17 +202,12 @@ export async function refreshExactXBookmark(
     : archived.articleText || hasXArticleIdentity(record)
       ? 'unresolved'
       : 'not_applicable';
-  const complete = parentStatus === 'ok'
-    && continuationStatus === 'ok'
-    && detail.enumerationComplete
-    && continuationHasFocal
-    && quoteStatus === 'ok'
-    && articleStatus !== 'unresolved';
+  const complete = refreshComplete({ parents, detail, quoteStatus, articleStatus });
 
   return {
     record: {
       ...record,
-      threadContext: context,
+      threadContext: parents.context,
       threadBelow: below,
       quotedTweet,
       threadExpandedAt: complete ? options.now ?? new Date().toISOString() : undefined,
@@ -178,12 +215,15 @@ export async function refreshExactXBookmark(
     observation: {
       status: complete ? 'complete' : 'partial',
       root_status: root.status,
-      parent_status: parentStatus,
+      parent_status: parents.status,
       continuation_status: continuationStatus,
       continuation_enumeration_complete: detail.enumerationComplete,
       quote_status: quoteStatus,
       article_status: articleStatus,
-      parent_limit_reached: parentLimitReached,
+      parent_limit_reached: parents.termination === 'limit',
+      parent_termination: parents.termination,
+      continuation_termination: detail.enumerationTermination,
+      continuation_focal_bound: detail.focalBound,
     },
   };
 }

--- a/src/x-materialize.ts
+++ b/src/x-materialize.ts
@@ -112,7 +112,7 @@ export async function refreshExactXBookmark(
     options.cookieHeader,
     { maxPages: options.maxPages ?? 3, delayMs },
   );
-  const continuationStatus = detail.status === 'empty' ? 'ok' : detail.status;
+  const continuationStatus = detail.status;
   const below = detail.status === 'ok'
     ? extractSameAuthorThreadBelow(detail.tweets, record.tweetId, record.authorHandle)
     : [];

--- a/src/x-materialize.ts
+++ b/src/x-materialize.ts
@@ -56,8 +56,10 @@ function reduceArticleCurrentness(
   record: BookmarkRecord,
   currentLinks: string[],
   liveArticle: TweetFetchResult['article'],
+  liveArticleStatus: TweetFetchResult['articleStatus'],
 ): ArticleCurrentnessReduction {
-  const liveLocator = liveArticle
+  const articleEvidenceStatus = liveArticleStatus ?? (liveArticle ? 'resolved' : 'absent');
+  const liveLocator = articleEvidenceStatus === 'resolved' && liveArticle
     ? bindXArticleEnrichment(record.tweetId, currentLinks, {
         articleText: liveArticle.text,
         sourceTweetId: liveArticle.sourceTweetId,
@@ -98,7 +100,9 @@ function reduceArticleCurrentness(
         articleSourceTweetId: retainOrdinaryEnrichment ? record.tweetId : null,
         articleLocator: retainOrdinaryEnrichment ? reaffirmedLocator ?? null : null,
       },
-      status: liveArticle || currentArticleLinks.length > 0 ? 'unresolved' : 'not_applicable',
+      status: articleEvidenceStatus !== 'absent' || currentArticleLinks.length > 0
+        ? 'unresolved'
+        : 'not_applicable',
     };
   }
   const locatorContradicted = Boolean(
@@ -124,7 +128,7 @@ function reduceArticleCurrentness(
   }
 
   const unresolved = Boolean(
-    liveArticle
+    articleEvidenceStatus !== 'absent'
     || record.articleText
     || record.articleTitle
     || record.articleSite
@@ -150,8 +154,8 @@ function refreshedRoot(
   const snapshot = result.snapshot;
   if (!snapshot) return { record, articleStatus: 'unresolved' };
   const links = snapshot.links ?? record.links ?? [];
-  const liveArticleLocator = result.article
-    && result.article.sourceTweetId === record.tweetId
+  const liveArticleLocator = result.articleStatus === 'resolved'
+    && result.article?.sourceTweetId === record.tweetId
     && result.article.text.trim()
       ? result.article.sourceLocator
       : undefined;
@@ -159,7 +163,7 @@ function refreshedRoot(
     && !links.some((value) => sameSourceLocator(value, liveArticleLocator))
       ? [...links, liveArticleLocator]
       : links;
-  const article = reduceArticleCurrentness(record, articleLinks, result.article);
+  const article = reduceArticleCurrentness(record, articleLinks, result.article, result.articleStatus);
   const liveQuotedStatusId = snapshot.quotedStatusId;
   const quotedStatusId = liveQuotedStatusId ?? record.quotedStatusId;
   const quotedTweet = quotedStatusId && record.quotedTweet?.id === quotedStatusId

--- a/src/x-materialize.ts
+++ b/src/x-materialize.ts
@@ -129,7 +129,9 @@ export async function refreshExactXBookmark(
     { maxPages: options.maxPages ?? 3, delayMs },
   );
   const continuationStatus = detail.status;
-  const below = detail.status === 'ok'
+  const continuationHasFocal = detail.status === 'ok'
+    && detail.tweets.some((tweet) => tweet.id === record.tweetId);
+  const below = continuationHasFocal
     ? extractSameAuthorThreadBelow(detail.tweets, record.tweetId, record.authorHandle)
     : [];
   let quoteStatus: TweetFetchResult['status'] = 'ok';
@@ -151,6 +153,7 @@ export async function refreshExactXBookmark(
   const complete = parentStatus === 'ok'
     && continuationStatus === 'ok'
     && detail.enumerationComplete
+    && continuationHasFocal
     && quoteStatus === 'ok'
     && articleStatus !== 'unresolved';
 

--- a/src/x-materialize.ts
+++ b/src/x-materialize.ts
@@ -11,7 +11,9 @@ export interface ExactXRefreshObservation {
   root_status: TweetFetchResult['status'];
   parent_status: TweetFetchResult['status'];
   continuation_status: TweetFetchResult['status'];
+  continuation_enumeration_complete: boolean;
   quote_status: TweetFetchResult['status'];
+  article_status: 'ok' | 'not_applicable' | 'unresolved';
   parent_limit_reached: boolean;
 }
 
@@ -48,7 +50,7 @@ function refreshedRoot(record: BookmarkRecord, result: TweetFetchResult): Bookma
     mediaObjects: snapshot.mediaObjects ?? record.mediaObjects,
     links: snapshot.links ?? record.links,
     articleTitle: result.article?.title ?? record.articleTitle,
-    articleText: result.article?.text ?? record.articleText,
+    articleText: result.article?.text ?? null,
     articleSite: result.article?.siteName ?? record.articleSite,
   };
 }
@@ -72,7 +74,9 @@ export async function refreshExactXBookmark(
         root_status: root.status,
         parent_status: 'empty',
         continuation_status: 'empty',
+        continuation_enumeration_complete: false,
         quote_status: archived.quotedStatusId ? 'empty' : 'ok',
+        article_status: archived.articleText ? 'unresolved' : 'not_applicable',
         parent_limit_reached: false,
       },
     };
@@ -123,7 +127,16 @@ export async function refreshExactXBookmark(
     quoteStatus = quoted.status;
     if (quoted.status === 'ok' && quoted.snapshot) quotedTweet = quoted.snapshot;
   }
-  const complete = parentStatus === 'ok' && continuationStatus === 'ok' && quoteStatus === 'ok';
+  const articleStatus = root.article
+    ? 'ok'
+    : archived.articleText
+      ? 'unresolved'
+      : 'not_applicable';
+  const complete = parentStatus === 'ok'
+    && continuationStatus === 'ok'
+    && detail.enumerationComplete
+    && quoteStatus === 'ok'
+    && articleStatus !== 'unresolved';
 
   return {
     record: {
@@ -131,14 +144,16 @@ export async function refreshExactXBookmark(
       threadContext: context,
       threadBelow: below,
       quotedTweet,
-      ...(complete ? { threadExpandedAt: options.now ?? new Date().toISOString() } : {}),
+      threadExpandedAt: complete ? options.now ?? new Date().toISOString() : undefined,
     },
     observation: {
       status: complete ? 'complete' : 'partial',
       root_status: root.status,
       parent_status: parentStatus,
       continuation_status: continuationStatus,
+      continuation_enumeration_complete: detail.enumerationComplete,
       quote_status: quoteStatus,
+      article_status: articleStatus,
       parent_limit_reached: parentLimitReached,
     },
   };

--- a/src/x-materialize.ts
+++ b/src/x-materialize.ts
@@ -6,7 +6,12 @@ import {
   type TweetDetailTermination,
 } from './graphql-bookmarks.js';
 import { extractSameAuthorThreadBelow } from './tweet-snapshots.js';
-import { bindArticleEnrichment, isXArticleLocator, sameSourceLocator } from './source-bindings.js';
+import {
+  bindArticleEnrichment,
+  bindXArticleEnrichment,
+  isXArticleLocator,
+  sameSourceLocator,
+} from './source-bindings.js';
 import type { BookmarkRecord, ThreadTweetSnapshot } from './types.js';
 import { XRequestExecutor } from './x-request-policy.js';
 
@@ -53,7 +58,7 @@ function reduceArticleCurrentness(
   liveArticle: TweetFetchResult['article'],
 ): ArticleCurrentnessReduction {
   const liveLocator = liveArticle
-    ? bindArticleEnrichment(record.tweetId, currentLinks, {
+    ? bindXArticleEnrichment(record.tweetId, currentLinks, {
         articleText: liveArticle.text,
         sourceTweetId: liveArticle.sourceTweetId,
         sourceLocator: liveArticle.sourceLocator,
@@ -83,6 +88,19 @@ function reduceArticleCurrentness(
     sourceLocator: record.articleLocator,
   });
   const currentArticleLinks = currentLinks.filter(isXArticleLocator);
+  if (archivedLocator && !isXArticleLocator(archivedLocator)) {
+    const retainOrdinaryEnrichment = Boolean(reaffirmedLocator);
+    return {
+      fields: {
+        articleTitle: retainOrdinaryEnrichment ? record.articleTitle ?? null : null,
+        articleText: retainOrdinaryEnrichment ? record.articleText ?? null : null,
+        articleSite: retainOrdinaryEnrichment ? record.articleSite ?? null : null,
+        articleSourceTweetId: retainOrdinaryEnrichment ? record.tweetId : null,
+        articleLocator: retainOrdinaryEnrichment ? reaffirmedLocator ?? null : null,
+      },
+      status: liveArticle || currentArticleLinks.length > 0 ? 'unresolved' : 'not_applicable',
+    };
+  }
   const locatorContradicted = Boolean(
     archivedLocator
     && isXArticleLocator(archivedLocator)
@@ -142,6 +160,11 @@ function refreshedRoot(
       ? [...links, liveArticleLocator]
       : links;
   const article = reduceArticleCurrentness(record, articleLinks, result.article);
+  const liveQuotedStatusId = snapshot.quotedStatusId;
+  const quotedStatusId = liveQuotedStatusId ?? record.quotedStatusId;
+  const quotedTweet = quotedStatusId && record.quotedTweet?.id === quotedStatusId
+    ? record.quotedTweet
+    : undefined;
   return {
     record: {
       ...record,
@@ -155,6 +178,8 @@ function refreshedRoot(
       postedAt: snapshot.postedAt ?? record.postedAt,
       conversationId: snapshot.conversationId ?? record.conversationId,
       inReplyToStatusId: snapshot.inReplyToStatusId ?? record.inReplyToStatusId,
+      quotedStatusId,
+      quotedTweet,
       media: snapshot.media ?? record.media,
       mediaObjects: snapshot.mediaObjects ?? record.mediaObjects,
       links: article.fields.articleLocator
@@ -272,6 +297,7 @@ export async function refreshExactXBookmark(
     ? extractSameAuthorThreadBelow(detail.tweets, record.tweetId, record.authorHandle)
     : [];
   let quoteStatus: TweetFetchResult['status'] = 'ok';
+  const quoteIdentityUnresolved = Boolean(root.snapshot.quotedStatusIdentityUnresolved);
   let quotedTweet = record.quotedStatusId && record.quotedTweet?.id === record.quotedStatusId
     ? record.quotedTweet
     : undefined;
@@ -285,6 +311,7 @@ export async function refreshExactXBookmark(
     quoteStatus = quoted.status;
     if (quoted.status === 'ok' && quoted.snapshot) quotedTweet = quoted.snapshot;
   }
+  if (quoteIdentityUnresolved && quoteStatus === 'ok') quoteStatus = 'empty';
   const articleStatus = refreshed.articleStatus;
   const complete = refreshComplete({ parents, detail, quoteStatus, articleStatus });
 

--- a/src/x-materialize.ts
+++ b/src/x-materialize.ts
@@ -6,7 +6,7 @@ import {
   type TweetDetailTermination,
 } from './graphql-bookmarks.js';
 import { extractSameAuthorThreadBelow } from './tweet-snapshots.js';
-import { isXArticleLocator, sameSourceLocator } from './source-bindings.js';
+import { bindArticleEnrichment, isXArticleLocator, sameSourceLocator } from './source-bindings.js';
 import type { BookmarkRecord, ThreadTweetSnapshot } from './types.js';
 import { XRequestExecutor } from './x-request-policy.js';
 
@@ -41,42 +41,129 @@ export interface ExactXRefreshOptions {
   requestExecutor?: XRequestExecutor;
 }
 
-function hasXArticleIdentity(record: BookmarkRecord): boolean {
-  return Boolean(
-    record.articleTitle
-    || record.articleSite
-    || record.links?.some(isXArticleLocator),
-  );
+interface ArticleCurrentnessReduction {
+  fields: Pick<BookmarkRecord,
+    'articleTitle' | 'articleText' | 'articleSite' | 'articleSourceTweetId' | 'articleLocator'>;
+  status: ExactXRefreshObservation['article_status'];
 }
 
-function refreshedRoot(record: BookmarkRecord, result: TweetFetchResult): BookmarkRecord {
-  const snapshot = result.snapshot;
-  if (!snapshot) return record;
-  const links = snapshot.links ?? record.links ?? [];
-  const articleLinks = result.article
-    && !links.some((value) => sameSourceLocator(value, result.article!.sourceLocator))
-      ? [...links, result.article.sourceLocator]
-      : links;
+function reduceArticleCurrentness(
+  record: BookmarkRecord,
+  currentLinks: string[],
+  liveArticle: TweetFetchResult['article'],
+): ArticleCurrentnessReduction {
+  const liveLocator = liveArticle
+    ? bindArticleEnrichment(record.tweetId, currentLinks, {
+        articleText: liveArticle.text,
+        sourceTweetId: liveArticle.sourceTweetId,
+        sourceLocator: liveArticle.sourceLocator,
+      })
+    : undefined;
+  if (liveArticle && liveLocator) {
+    return {
+      fields: {
+        articleTitle: liveArticle.title,
+        articleText: liveArticle.text,
+        articleSite: liveArticle.siteName,
+        articleSourceTweetId: record.tweetId,
+        articleLocator: liveLocator,
+      },
+      status: 'ok',
+    };
+  }
+
+  const archivedLocator = bindArticleEnrichment(record.tweetId, record.links ?? [], {
+    articleText: record.articleText,
+    sourceTweetId: record.articleSourceTweetId,
+    sourceLocator: record.articleLocator,
+  });
+  const reaffirmedLocator = bindArticleEnrichment(record.tweetId, currentLinks, {
+    articleText: record.articleText,
+    sourceTweetId: record.articleSourceTweetId,
+    sourceLocator: record.articleLocator,
+  });
+  const currentArticleLinks = currentLinks.filter(isXArticleLocator);
+  const locatorContradicted = Boolean(
+    archivedLocator
+    && isXArticleLocator(archivedLocator)
+    && currentArticleLinks.length > 0
+    && !currentArticleLinks.some((value) => sameSourceLocator(value, archivedLocator)),
+  );
+  const retainedLocator = locatorContradicted
+    ? undefined
+    : reaffirmedLocator ?? archivedLocator;
+  if (retainedLocator) {
+    return {
+      fields: {
+        articleTitle: record.articleTitle ?? null,
+        articleText: record.articleText ?? null,
+        articleSite: record.articleSite ?? null,
+        articleSourceTweetId: record.tweetId,
+        articleLocator: retainedLocator,
+      },
+      status: 'unresolved',
+    };
+  }
+
+  const unresolved = Boolean(
+    liveArticle
+    || record.articleText
+    || record.articleTitle
+    || record.articleSite
+    || record.articleLocator
+    || currentLinks.some(isXArticleLocator),
+  );
   return {
-    ...record,
-    id: record.id,
-    tweetId: record.tweetId,
-    url: snapshot.url || record.url,
-    text: snapshot.text || record.text,
-    authorHandle: snapshot.authorHandle ?? record.authorHandle,
-    authorName: snapshot.authorName ?? record.authorName,
-    authorProfileImageUrl: snapshot.authorProfileImageUrl ?? record.authorProfileImageUrl,
-    postedAt: snapshot.postedAt ?? record.postedAt,
-    conversationId: snapshot.conversationId ?? record.conversationId,
-    inReplyToStatusId: snapshot.inReplyToStatusId ?? record.inReplyToStatusId,
-    media: snapshot.media ?? record.media,
-    mediaObjects: snapshot.mediaObjects ?? record.mediaObjects,
-    links: articleLinks,
-    articleTitle: result.article?.title ?? null,
-    articleText: result.article?.text ?? null,
-    articleSite: result.article?.siteName ?? null,
-    articleSourceTweetId: result.article?.sourceTweetId ?? null,
-    articleLocator: result.article?.sourceLocator ?? null,
+    fields: {
+      articleTitle: null,
+      articleText: null,
+      articleSite: null,
+      articleSourceTweetId: null,
+      articleLocator: null,
+    },
+    status: unresolved ? 'unresolved' : 'not_applicable',
+  };
+}
+
+function refreshedRoot(
+  record: BookmarkRecord,
+  result: TweetFetchResult,
+): { record: BookmarkRecord; articleStatus: ExactXRefreshObservation['article_status'] } {
+  const snapshot = result.snapshot;
+  if (!snapshot) return { record, articleStatus: 'unresolved' };
+  const links = snapshot.links ?? record.links ?? [];
+  const liveArticleLocator = result.article
+    && result.article.sourceTweetId === record.tweetId
+    && result.article.text.trim()
+      ? result.article.sourceLocator
+      : undefined;
+  const articleLinks = liveArticleLocator
+    && !links.some((value) => sameSourceLocator(value, liveArticleLocator))
+      ? [...links, liveArticleLocator]
+      : links;
+  const article = reduceArticleCurrentness(record, articleLinks, result.article);
+  return {
+    record: {
+      ...record,
+      id: record.id,
+      tweetId: record.tweetId,
+      url: snapshot.url || record.url,
+      text: snapshot.text || record.text,
+      authorHandle: snapshot.authorHandle ?? record.authorHandle,
+      authorName: snapshot.authorName ?? record.authorName,
+      authorProfileImageUrl: snapshot.authorProfileImageUrl ?? record.authorProfileImageUrl,
+      postedAt: snapshot.postedAt ?? record.postedAt,
+      conversationId: snapshot.conversationId ?? record.conversationId,
+      inReplyToStatusId: snapshot.inReplyToStatusId ?? record.inReplyToStatusId,
+      media: snapshot.media ?? record.media,
+      mediaObjects: snapshot.mediaObjects ?? record.mediaObjects,
+      links: article.fields.articleLocator
+        && !articleLinks.some((value) => sameSourceLocator(value, article.fields.articleLocator!))
+          ? [...articleLinks, article.fields.articleLocator]
+          : articleLinks,
+      ...article.fields,
+    },
+    articleStatus: article.status,
   };
 }
 
@@ -169,7 +256,8 @@ export async function refreshExactXBookmark(
     };
   }
 
-  const record = refreshedRoot(archived, root);
+  const refreshed = refreshedRoot(archived, root);
+  const record = refreshed.record;
   const parents = await traverseParents(record, options, executor, maxParents);
 
   const detail = await fetchTweetDetailViaGraphQL(
@@ -197,11 +285,7 @@ export async function refreshExactXBookmark(
     quoteStatus = quoted.status;
     if (quoted.status === 'ok' && quoted.snapshot) quotedTweet = quoted.snapshot;
   }
-  const articleStatus = root.article
-    ? 'ok'
-    : archived.articleText || hasXArticleIdentity(record)
-      ? 'unresolved'
-      : 'not_applicable';
+  const articleStatus = refreshed.articleStatus;
   const complete = refreshComplete({ parents, detail, quoteStatus, articleStatus });
 
   return {

--- a/src/x-materialize.ts
+++ b/src/x-materialize.ts
@@ -31,6 +31,22 @@ export interface ExactXRefreshOptions {
   now?: string;
 }
 
+function hasXArticleIdentity(record: BookmarkRecord): boolean {
+  return Boolean(
+    record.articleTitle
+    || record.articleSite
+    || record.links?.some((value) => {
+      try {
+        const parsed = new URL(value);
+        return (parsed.hostname === 'x.com' || parsed.hostname === 'twitter.com')
+          && parsed.pathname.startsWith('/i/article/');
+      } catch {
+        return false;
+      }
+    }),
+  );
+}
+
 function refreshedRoot(record: BookmarkRecord, result: TweetFetchResult): BookmarkRecord {
   const snapshot = result.snapshot;
   if (!snapshot) return record;
@@ -129,7 +145,7 @@ export async function refreshExactXBookmark(
   }
   const articleStatus = root.article
     ? 'ok'
-    : archived.articleText
+    : archived.articleText || hasXArticleIdentity(record)
       ? 'unresolved'
       : 'not_applicable';
   const complete = parentStatus === 'ok'

--- a/src/x-materialize.ts
+++ b/src/x-materialize.ts
@@ -1,0 +1,145 @@
+import {
+  fetchTweetByIdViaGraphQL,
+  fetchTweetDetailViaGraphQL,
+  type TweetFetchResult,
+} from './graphql-bookmarks.js';
+import { extractSameAuthorThreadBelow } from './tweet-snapshots.js';
+import type { BookmarkRecord, ThreadTweetSnapshot } from './types.js';
+
+export interface ExactXRefreshObservation {
+  status: 'complete' | 'partial' | 'unavailable';
+  root_status: TweetFetchResult['status'];
+  parent_status: TweetFetchResult['status'];
+  continuation_status: TweetFetchResult['status'];
+  quote_status: TweetFetchResult['status'];
+  parent_limit_reached: boolean;
+}
+
+export interface ExactXRefreshResult {
+  record: BookmarkRecord;
+  observation: ExactXRefreshObservation;
+}
+
+export interface ExactXRefreshOptions {
+  csrfToken: string;
+  cookieHeader?: string;
+  delayMs?: number;
+  maxParents?: number;
+  maxPages?: number;
+  now?: string;
+}
+
+function refreshedRoot(record: BookmarkRecord, result: TweetFetchResult): BookmarkRecord {
+  const snapshot = result.snapshot;
+  if (!snapshot) return record;
+  return {
+    ...record,
+    id: record.id,
+    tweetId: record.tweetId,
+    url: snapshot.url || record.url,
+    text: snapshot.text || record.text,
+    authorHandle: snapshot.authorHandle ?? record.authorHandle,
+    authorName: snapshot.authorName ?? record.authorName,
+    authorProfileImageUrl: snapshot.authorProfileImageUrl ?? record.authorProfileImageUrl,
+    postedAt: snapshot.postedAt ?? record.postedAt,
+    conversationId: snapshot.conversationId ?? record.conversationId,
+    inReplyToStatusId: snapshot.inReplyToStatusId ?? record.inReplyToStatusId,
+    media: snapshot.media ?? record.media,
+    mediaObjects: snapshot.mediaObjects ?? record.mediaObjects,
+    links: snapshot.links ?? record.links,
+    articleTitle: result.article?.title ?? record.articleTitle,
+    articleText: result.article?.text ?? record.articleText,
+    articleSite: result.article?.siteName ?? record.articleSite,
+  };
+}
+
+export async function refreshExactXBookmark(
+  archived: BookmarkRecord,
+  options: ExactXRefreshOptions,
+): Promise<ExactXRefreshResult> {
+  const delayMs = options.delayMs ?? 300;
+  const maxParents = options.maxParents ?? 25;
+  const root = await fetchTweetByIdViaGraphQL(
+    archived.tweetId,
+    options.csrfToken,
+    options.cookieHeader,
+  );
+  if (root.status !== 'ok' || !root.snapshot) {
+    return {
+      record: archived,
+      observation: {
+        status: 'unavailable',
+        root_status: root.status,
+        parent_status: 'empty',
+        continuation_status: 'empty',
+        quote_status: archived.quotedStatusId ? 'empty' : 'ok',
+        parent_limit_reached: false,
+      },
+    };
+  }
+
+  const record = refreshedRoot(archived, root);
+  const context: ThreadTweetSnapshot[] = [];
+  const seen = new Set<string>();
+  let parentStatus: TweetFetchResult['status'] = 'ok';
+  let nextParent = record.inReplyToStatusId;
+  while (nextParent && !seen.has(nextParent) && context.length < maxParents) {
+    seen.add(nextParent);
+    const parent = await fetchTweetByIdViaGraphQL(
+      nextParent,
+      options.csrfToken,
+      options.cookieHeader,
+    );
+    if (parent.status !== 'ok' || !parent.snapshot) {
+      parentStatus = parent.status;
+      break;
+    }
+    const snapshot = parent.snapshot as ThreadTweetSnapshot;
+    context.unshift(snapshot);
+    nextParent = snapshot.inReplyToStatusId;
+    if (nextParent) await new Promise((resolve) => setTimeout(resolve, delayMs));
+  }
+  const parentLimitReached = Boolean(nextParent && context.length >= maxParents);
+  if (parentLimitReached) parentStatus = 'error';
+
+  const detail = await fetchTweetDetailViaGraphQL(
+    archived.tweetId,
+    options.csrfToken,
+    options.cookieHeader,
+    { maxPages: options.maxPages ?? 3, delayMs },
+  );
+  const continuationStatus = detail.status === 'empty' ? 'ok' : detail.status;
+  const below = detail.status === 'ok'
+    ? extractSameAuthorThreadBelow(detail.tweets, record.tweetId, record.authorHandle)
+    : [];
+  let quoteStatus: TweetFetchResult['status'] = 'ok';
+  let quotedTweet = record.quotedTweet;
+  if (record.quotedStatusId) {
+    const quoted = await fetchTweetByIdViaGraphQL(
+      record.quotedStatusId,
+      options.csrfToken,
+      options.cookieHeader,
+    );
+    quoteStatus = quoted.status;
+    if (quoted.status === 'ok' && quoted.snapshot) quotedTweet = quoted.snapshot;
+  }
+  const complete = parentStatus === 'ok' && continuationStatus === 'ok' && quoteStatus === 'ok';
+
+  return {
+    record: {
+      ...record,
+      threadContext: context,
+      threadBelow: below,
+      quotedTweet,
+      ...(complete ? { threadExpandedAt: options.now ?? new Date().toISOString() } : {}),
+    },
+    observation: {
+      status: complete ? 'complete' : 'partial',
+      root_status: root.status,
+      parent_status: parentStatus,
+      continuation_status: continuationStatus,
+      quote_status: quoteStatus,
+      parent_limit_reached: parentLimitReached,
+    },
+  };
+}

--- a/src/x-materialize.ts
+++ b/src/x-materialize.ts
@@ -77,6 +77,14 @@ export async function refreshExactXBookmark(
 ): Promise<ExactXRefreshResult> {
   const delayMs = options.delayMs ?? 300;
   const maxParents = options.maxParents ?? 25;
+  let requestCount = 0;
+  const waitForNextRequest = async (): Promise<void> => {
+    if (requestCount > 0 && delayMs > 0) {
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+    }
+    requestCount += 1;
+  };
+  await waitForNextRequest();
   const root = await fetchTweetByIdViaGraphQL(
     archived.tweetId,
     options.csrfToken,
@@ -105,6 +113,7 @@ export async function refreshExactXBookmark(
   let nextParent = record.inReplyToStatusId;
   while (nextParent && !seen.has(nextParent) && context.length < maxParents) {
     seen.add(nextParent);
+    await waitForNextRequest();
     const parent = await fetchTweetByIdViaGraphQL(
       nextParent,
       options.csrfToken,
@@ -117,11 +126,11 @@ export async function refreshExactXBookmark(
     const snapshot = parent.snapshot as ThreadTweetSnapshot;
     context.unshift(snapshot);
     nextParent = snapshot.inReplyToStatusId;
-    if (nextParent) await new Promise((resolve) => setTimeout(resolve, delayMs));
   }
   const parentLimitReached = Boolean(nextParent && context.length >= maxParents);
   if (parentLimitReached) parentStatus = 'error';
 
+  await waitForNextRequest();
   const detail = await fetchTweetDetailViaGraphQL(
     archived.tweetId,
     options.csrfToken,
@@ -137,6 +146,7 @@ export async function refreshExactXBookmark(
   let quoteStatus: TweetFetchResult['status'] = 'ok';
   let quotedTweet = record.quotedTweet;
   if (record.quotedStatusId) {
+    await waitForNextRequest();
     const quoted = await fetchTweetByIdViaGraphQL(
       record.quotedStatusId,
       options.csrfToken,

--- a/src/x-request-policy.ts
+++ b/src/x-request-policy.ts
@@ -1,0 +1,123 @@
+export type XRequestStatus =
+  | 'ok'
+  | 'not_found'
+  | 'forbidden'
+  | 'rate_limited'
+  | 'server_error'
+  | 'error';
+
+export interface XJsonResponse {
+  status: XRequestStatus;
+  json?: unknown;
+  httpStatus?: number;
+  attempts: number;
+}
+
+export interface XRequestExecutorOptions {
+  delayMs?: number;
+  maxAttempts?: number;
+  fetchImpl?: typeof fetch;
+  sleep?: (milliseconds: number) => Promise<void>;
+  retryBackoffMs?: (status: 'network' | 'rate_limited' | 'server_error', attempt: number, response?: Response) => number;
+}
+
+function retryAfterMs(response?: Response): number | undefined {
+  const value = response?.headers.get('retry-after');
+  if (!value) return undefined;
+  const seconds = Number(value);
+  if (Number.isFinite(seconds) && seconds >= 0) return Math.ceil(seconds * 1000);
+  const resumeAt = Date.parse(value);
+  if (Number.isNaN(resumeAt)) return undefined;
+  return Math.max(0, resumeAt - Date.now());
+}
+
+function defaultRetryBackoffMs(
+  status: 'network' | 'rate_limited' | 'server_error',
+  attempt: number,
+  response?: Response,
+): number {
+  if (status === 'rate_limited') {
+    return retryAfterMs(response) ?? Math.min(15 * Math.pow(2, attempt - 1), 120) * 1000;
+  }
+  if (status === 'server_error') return 5000 * attempt;
+  return 2000 * attempt;
+}
+
+export class XRequestExecutor {
+  private readonly delayMs: number;
+  private readonly maxAttempts: number;
+  private readonly fetchImpl: typeof fetch;
+  private readonly sleep: (milliseconds: number) => Promise<void>;
+  private readonly retryBackoffMs: NonNullable<XRequestExecutorOptions['retryBackoffMs']>;
+  private actualAttempts = 0;
+
+  constructor(options: XRequestExecutorOptions = {}) {
+    this.delayMs = Math.max(0, options.delayMs ?? 0);
+    this.maxAttempts = Math.max(1, options.maxAttempts ?? 4);
+    this.fetchImpl = options.fetchImpl ?? globalThis.fetch;
+    this.sleep = options.sleep ?? ((milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds)));
+    this.retryBackoffMs = options.retryBackoffMs ?? defaultRetryBackoffMs;
+  }
+
+  get attemptCount(): number {
+    return this.actualAttempts;
+  }
+
+  private async beforeAttempt(retryBackoffMs: number): Promise<void> {
+    if (this.actualAttempts > 0) {
+      await this.sleep(Math.max(this.delayMs, retryBackoffMs));
+    }
+    this.actualAttempts += 1;
+  }
+
+  async requestJson(input: string | URL | Request, init?: RequestInit): Promise<XJsonResponse> {
+    let retryBackoff = 0;
+    for (let attempt = 1; attempt <= this.maxAttempts; attempt++) {
+      await this.beforeAttempt(retryBackoff);
+      let response: Response;
+      try {
+        response = await this.fetchImpl(input, init);
+      } catch {
+        if (attempt === this.maxAttempts) return { status: 'error', attempts: attempt };
+        retryBackoff = this.retryBackoffMs('network', attempt);
+        continue;
+      }
+
+      if (response.ok) {
+        try {
+          return {
+            status: 'ok',
+            json: await response.json(),
+            httpStatus: response.status,
+            attempts: attempt,
+          };
+        } catch {
+          return { status: 'error', httpStatus: response.status, attempts: attempt };
+        }
+      }
+
+      if (response.status === 429) {
+        if (attempt === this.maxAttempts) {
+          return { status: 'rate_limited', httpStatus: response.status, attempts: attempt };
+        }
+        retryBackoff = this.retryBackoffMs('rate_limited', attempt, response);
+        continue;
+      }
+      if (response.status >= 500) {
+        if (attempt === this.maxAttempts) {
+          return { status: 'server_error', httpStatus: response.status, attempts: attempt };
+        }
+        retryBackoff = this.retryBackoffMs('server_error', attempt, response);
+        continue;
+      }
+      if (response.status === 404) {
+        return { status: 'not_found', httpStatus: response.status, attempts: attempt };
+      }
+      if (response.status === 401 || response.status === 403) {
+        return { status: 'forbidden', httpStatus: response.status, attempts: attempt };
+      }
+      return { status: 'error', httpStatus: response.status, attempts: attempt };
+    }
+    return { status: 'error', attempts: this.maxAttempts };
+  }
+}

--- a/src/x-request-policy.ts
+++ b/src/x-request-policy.ts
@@ -71,6 +71,7 @@ export class XRequestExecutor {
   private readonly sleep: (milliseconds: number) => Promise<void>;
   private readonly retryBackoffMs: NonNullable<XRequestExecutorOptions['retryBackoffMs']>;
   private actualAttempts = 0;
+  private attemptAdmission = Promise.resolve();
 
   constructor(options: XRequestExecutorOptions = {}) {
     this.delayMs = Math.max(0, options.delayMs ?? 0);
@@ -85,11 +86,17 @@ export class XRequestExecutor {
   }
 
   private async beforeAttempt(retryBackoffMs: number): Promise<void> {
-    if (this.actualAttempts > 0) {
-      const waitMs = Math.max(this.delayMs, retryBackoffMs);
-      if (waitMs > 0) await this.sleep(waitMs);
-    }
-    this.actualAttempts += 1;
+    const admitted = this.attemptAdmission.then(async () => {
+      if (this.actualAttempts > 0) {
+        const waitMs = Math.max(this.delayMs, retryBackoffMs);
+        if (waitMs > 0) await this.sleep(waitMs);
+      }
+      this.actualAttempts += 1;
+    });
+    // Propagate a scheduler failure to this caller, but recover the shared queue
+    // so a later logical request can still be admitted and delayed normally.
+    this.attemptAdmission = admitted.catch(() => undefined);
+    await admitted;
   }
 
   private async requestDecoded<T>(
@@ -162,7 +169,7 @@ export class XRequestExecutor {
       }
       return { status: 'error', httpStatus: response.status, attempts: attempt };
     }
-    return { status: 'error', attempts: this.maxAttempts };
+    throw new Error('X request executor exhausted without a terminal attempt result');
   }
 
   async requestJson(input: string | URL | Request, init?: RequestInit): Promise<XJsonResponse> {

--- a/src/x-request-policy.ts
+++ b/src/x-request-policy.ts
@@ -7,12 +7,31 @@ export type XRequestStatus =
   | 'server_error'
   | 'error';
 
-export interface XJsonResponse {
+export type XRequestFailureKind = 'network' | 'decode' | 'graphql' | 'aborted';
+
+interface XRequestResult {
   status: XRequestStatus;
-  json?: unknown;
-  graphqlErrors?: unknown;
   httpStatus?: number;
   attempts: number;
+  failureKind?: XRequestFailureKind;
+  errorMessage?: string;
+}
+
+export interface XJsonResponse extends XRequestResult {
+  json?: unknown;
+  graphqlErrors?: unknown;
+}
+
+export interface XHeaderResponse extends XRequestResult {
+  headers?: {
+    contentLength?: string;
+    contentType?: string;
+  };
+}
+
+export interface XBytesResponse extends XRequestResult {
+  bytes?: Buffer;
+  contentType?: string;
 }
 
 export interface XRequestExecutorOptions {
@@ -67,20 +86,38 @@ export class XRequestExecutor {
 
   private async beforeAttempt(retryBackoffMs: number): Promise<void> {
     if (this.actualAttempts > 0) {
-      await this.sleep(Math.max(this.delayMs, retryBackoffMs));
+      const waitMs = Math.max(this.delayMs, retryBackoffMs);
+      if (waitMs > 0) await this.sleep(waitMs);
     }
     this.actualAttempts += 1;
   }
 
-  async requestJson(input: string | URL | Request, init?: RequestInit): Promise<XJsonResponse> {
+  private async requestDecoded<T>(
+    input: string | URL | Request,
+    init: RequestInit | undefined,
+    decode: (response: Response) => Promise<T>,
+  ): Promise<XRequestResult & { value?: T }> {
+    if (init?.signal?.aborted) {
+      return { status: 'error', attempts: 0, failureKind: 'aborted' };
+    }
     let retryBackoff = 0;
     for (let attempt = 1; attempt <= this.maxAttempts; attempt++) {
       await this.beforeAttempt(retryBackoff);
       let response: Response;
       try {
         response = await this.fetchImpl(input, init);
-      } catch {
-        if (attempt === this.maxAttempts) return { status: 'error', attempts: attempt };
+      } catch (error) {
+        if (init?.signal?.aborted || (error instanceof Error && error.name === 'AbortError')) {
+          return { status: 'error', attempts: attempt, failureKind: 'aborted' };
+        }
+        if (attempt === this.maxAttempts) {
+          return {
+            status: 'error',
+            attempts: attempt,
+            failureKind: 'network',
+            errorMessage: error instanceof Error ? error.message : String(error),
+          };
+        }
         retryBackoff = this.retryBackoffMs('network', attempt);
         continue;
       }
@@ -89,12 +126,17 @@ export class XRequestExecutor {
         try {
           return {
             status: 'ok',
-            json: await response.json(),
+            value: await decode(response),
             httpStatus: response.status,
             attempts: attempt,
           };
         } catch {
-          return { status: 'error', httpStatus: response.status, attempts: attempt };
+          return {
+            status: 'error',
+            httpStatus: response.status,
+            attempts: attempt,
+            failureKind: 'decode',
+          };
         }
       }
 
@@ -123,6 +165,12 @@ export class XRequestExecutor {
     return { status: 'error', attempts: this.maxAttempts };
   }
 
+  async requestJson(input: string | URL | Request, init?: RequestInit): Promise<XJsonResponse> {
+    const response = await this.requestDecoded(input, init, (value) => value.json());
+    const { value, ...result } = response;
+    return { ...result, ...(value !== undefined ? { json: value } : {}) };
+  }
+
   async requestGraphqlJson(input: string | URL | Request, init?: RequestInit): Promise<XJsonResponse> {
     const response = await this.requestJson(input, init);
     if (response.status !== 'ok') return response;
@@ -135,6 +183,28 @@ export class XRequestExecutor {
       ...response,
       status: 'graphql_error',
       graphqlErrors: errors,
+      failureKind: 'graphql',
+    };
+  }
+
+  async requestHeaders(input: string | URL | Request, init?: RequestInit): Promise<XHeaderResponse> {
+    const response = await this.requestDecoded(input, init, async (value) => ({
+      contentLength: value.headers.get('content-length') ?? undefined,
+      contentType: value.headers.get('content-type') ?? undefined,
+    }));
+    const { value, ...result } = response;
+    return { ...result, ...(value ? { headers: value } : {}) };
+  }
+
+  async requestBytes(input: string | URL | Request, init?: RequestInit): Promise<XBytesResponse> {
+    const response = await this.requestDecoded(input, init, async (value) => ({
+      bytes: Buffer.from(await value.arrayBuffer()),
+      contentType: value.headers.get('content-type') ?? undefined,
+    }));
+    const { value, ...result } = response;
+    return {
+      ...result,
+      ...(value ? { bytes: value.bytes, contentType: value.contentType } : {}),
     };
   }
 }

--- a/src/x-request-policy.ts
+++ b/src/x-request-policy.ts
@@ -1,5 +1,6 @@
 export type XRequestStatus =
   | 'ok'
+  | 'graphql_error'
   | 'not_found'
   | 'forbidden'
   | 'rate_limited'
@@ -9,6 +10,7 @@ export type XRequestStatus =
 export interface XJsonResponse {
   status: XRequestStatus;
   json?: unknown;
+  graphqlErrors?: unknown;
   httpStatus?: number;
   attempts: number;
 }
@@ -119,5 +121,20 @@ export class XRequestExecutor {
       return { status: 'error', httpStatus: response.status, attempts: attempt };
     }
     return { status: 'error', attempts: this.maxAttempts };
+  }
+
+  async requestGraphqlJson(input: string | URL | Request, init?: RequestInit): Promise<XJsonResponse> {
+    const response = await this.requestJson(input, init);
+    if (response.status !== 'ok') return response;
+    if (!response.json || typeof response.json !== 'object' || !Object.hasOwn(response.json, 'errors')) {
+      return response;
+    }
+    const errors = (response.json as { errors?: unknown }).errors;
+    if (Array.isArray(errors) && errors.length === 0) return response;
+    return {
+      ...response,
+      status: 'graphql_error',
+      graphqlErrors: errors,
+    };
   }
 }

--- a/tests/bookmark-materialization.test.ts
+++ b/tests/bookmark-materialization.test.ts
@@ -1,0 +1,140 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { materializeBookmark } from '../src/bookmark-materialization.js';
+import type { MediaFetchManifest } from '../src/bookmark-media.js';
+import type { BookmarkRecord } from '../src/types.js';
+
+function record(overrides: Partial<BookmarkRecord> = {}): BookmarkRecord {
+  return {
+    id: '2080296884187652381',
+    tweetId: '2080296884187652381',
+    url: 'https://x.com/operator/status/2080296884187652381',
+    text: 'Root post with a linked paper and an attached image.',
+    authorHandle: 'operator',
+    authorName: 'Operator',
+    postedAt: '2026-08-01T12:00:00.000Z',
+    syncedAt: '2026-08-10T12:00:00.000Z',
+    links: ['https://example.com/paper.pdf'],
+    quotedStatusId: '2080000000000000000',
+    quotedTweet: {
+      id: '2080000000000000000',
+      text: 'Quoted source with evidence.',
+      authorHandle: 'quoted',
+      url: 'https://x.com/quoted/status/2080000000000000000',
+      links: ['https://example.com/source'],
+    },
+    threadContext: [{
+      id: '2080296884187652380',
+      text: 'Parent context.',
+      authorHandle: 'operator',
+      url: 'https://x.com/operator/status/2080296884187652380',
+    }],
+    threadBelow: [{
+      id: '2080296884187652382',
+      text: 'Same-author continuation with the actual repository.',
+      authorHandle: 'operator',
+      url: 'https://x.com/operator/status/2080296884187652382',
+      links: ['https://github.com/example/project'],
+    }],
+    threadExpandedAt: '2026-08-10T12:01:00.000Z',
+    articleTitle: 'A long-form argument',
+    articleText: 'Complete X Article body.',
+    articleSite: 'X Articles',
+    enrichedAt: '2026-08-10T12:00:30.000Z',
+    ...overrides,
+  };
+}
+
+test('materializeBookmark emits exact components without leaking source-local paths', async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), 'ft-materialize-'));
+  const assetPath = path.join(dir, 'image.jpg');
+  await writeFile(assetPath, Buffer.from([1, 2, 3, 4]));
+  try {
+    const source = record({
+      mediaObjects: [{
+        type: 'photo',
+        url: 'https://pbs.twimg.com/media/root.jpg',
+        width: 1200,
+        height: 800,
+        altText: 'Architecture diagram',
+      }],
+    });
+    const manifest: MediaFetchManifest = {
+      schemaVersion: 1,
+      generatedAt: '2026-08-10T12:02:00.000Z',
+      limit: 1,
+      maxBytes: 1024,
+      processed: 1,
+      downloaded: 1,
+      skippedTooLarge: 0,
+      failed: 0,
+      entries: [{
+        bookmarkId: source.id,
+        tweetId: source.tweetId,
+        tweetUrl: source.url,
+        sourceUrl: 'https://pbs.twimg.com/media/root.jpg',
+        localPath: assetPath,
+        contentType: 'image/jpeg',
+        bytes: 4,
+        status: 'downloaded',
+        fetchedAt: '2026-08-10T12:02:00.000Z',
+      }],
+    };
+
+    const result = await materializeBookmark(source, manifest);
+    const relations = result.components.map((row) => row.relation);
+    assert.equal(result.source_family, 'field_theory_x');
+    assert.equal(result.topology.enumeration_complete, true);
+    assert.equal(result.topology.thread_context_count, 1);
+    assert.equal(result.topology.thread_continuation_count, 1);
+    assert.ok(relations.includes('root_post'));
+    assert.ok(relations.includes('thread_parent_context'));
+    assert.ok(relations.includes('thread_same_author_continuation'));
+    assert.ok(relations.includes('quoted_post'));
+    assert.ok(relations.includes('embedded_x_article'));
+    assert.ok(relations.includes('post_outbound_pdf'));
+    assert.ok(relations.includes('post_attached_media'));
+    assert.ok(relations.includes('post_media_interpretation'));
+    assert.deepEqual(
+      result.components.find((row) => row.relation === 'post_attached_media')?.source_asset,
+      {
+        sha256: '9f64a747e1b97f131fabb6b447296c9b6f0201e79fb3c5356e6c77e89b6a806a',
+        bytes: 4,
+        content_type: 'image/jpeg',
+      },
+    );
+    assert.equal(
+      result.components.find((row) => row.relation === 'post_outbound_pdf')?.disposition,
+      'unresolved',
+    );
+    assert.equal(
+      result.components.find((row) => row.relation === 'post_media_interpretation')?.disposition,
+      'unresolved',
+    );
+    assert.ok(!JSON.stringify(result).includes(assetPath));
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('materializeBookmark exposes missing thread and quote content as explicit gaps', async () => {
+  const result = await materializeBookmark(record({
+    quotedTweet: undefined,
+    threadContext: [],
+    threadBelow: [],
+    threadExpandedAt: undefined,
+    articleText: null,
+  }));
+  assert.equal(result.topology.enumeration_complete, false);
+  assert.equal(
+    result.components.find((row) => row.relation === 'thread_completeness')?.disposition,
+    'unresolved',
+  );
+  assert.equal(
+    result.components.find((row) => row.relation === 'quoted_post')?.disposition,
+    'unavailable',
+  );
+});

--- a/tests/bookmark-materialization.test.ts
+++ b/tests/bookmark-materialization.test.ts
@@ -111,6 +111,14 @@ test('materializeBookmark emits exact components without leaking source-local pa
       'unresolved',
     );
     assert.equal(
+      result.components.find((row) => row.relation === 'post_outbound_pdf')?.traversal_hop,
+      2,
+    );
+    assert.equal(
+      result.components.find((row) => row.relation === 'post_outbound_pdf')?.mandatory_direct,
+      false,
+    );
+    assert.equal(
       result.components.find((row) => row.relation === 'post_media_interpretation')?.disposition,
       'unresolved',
     );

--- a/tests/bookmark-materialization.test.ts
+++ b/tests/bookmark-materialization.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
@@ -55,7 +55,11 @@ function record(overrides: Partial<BookmarkRecord> = {}): BookmarkRecord {
 
 test('materializeBookmark emits exact components without leaking source-local paths', async () => {
   const dir = await mkdtemp(path.join(tmpdir(), 'ft-materialize-'));
-  const assetPath = path.join(dir, 'image.jpg');
+  const savedDataDir = process.env.FT_DATA_DIR;
+  process.env.FT_DATA_DIR = dir;
+  const mediaDir = path.join(dir, 'media');
+  await mkdir(mediaDir);
+  const assetPath = path.join(mediaDir, '2080296884187652381-9f64a747e1b97f13.jpg');
   await writeFile(assetPath, Buffer.from([1, 2, 3, 4]));
   try {
     const source = record({
@@ -129,6 +133,8 @@ test('materializeBookmark emits exact components without leaking source-local pa
     );
     assert.ok(!JSON.stringify(result).includes(assetPath));
   } finally {
+    if (savedDataDir === undefined) delete process.env.FT_DATA_DIR;
+    else process.env.FT_DATA_DIR = savedDataDir;
     await rm(dir, { recursive: true, force: true });
   }
 });
@@ -211,10 +217,28 @@ test('materializeBookmark leaves every X Article locator unresolved when body id
   assert.equal(result.achieved_depth, 'source-owned root and enumerated components with explicit unresolved depth');
 });
 
+test('materializeBookmark does not infer a missing article locator from a sole root link', async () => {
+  const articleUrl = 'https://x.com/i/article/2042676487711584257';
+  const result = await materializeBookmark(record({
+    links: [articleUrl],
+    articleLocator: null,
+  }));
+
+  const article = result.components.find((row) => row.relation === 'embedded_x_article');
+  assert.equal(article?.source_locator, articleUrl);
+  assert.equal(article?.disposition, 'unresolved');
+  assert.equal(article?.content, null);
+  assert.equal(JSON.stringify(result).includes('Complete X Article body.'), false);
+});
+
 test('materializeBookmark binds poster and video variant to separate exact assets', async () => {
   const dir = await mkdtemp(path.join(tmpdir(), 'ft-materialize-video-'));
-  const posterPath = path.join(dir, 'poster.jpg');
-  const videoPath = path.join(dir, 'video.mp4');
+  const savedDataDir = process.env.FT_DATA_DIR;
+  process.env.FT_DATA_DIR = dir;
+  const mediaDir = path.join(dir, 'media');
+  await mkdir(mediaDir);
+  const posterPath = path.join(mediaDir, '2080296884187652381-9f64a747e1b97f13.jpg');
+  const videoPath = path.join(mediaDir, '2080296884187652381-55e5509f80529982.mp4');
   await writeFile(posterPath, Buffer.from([1, 2, 3, 4]));
   await writeFile(videoPath, Buffer.from([5, 6, 7, 8]));
   try {
@@ -289,6 +313,106 @@ test('materializeBookmark binds poster and video variant to separate exact asset
     assert.match(assets[1].content ?? '', /\"asset_role\":\"video_variant\"/);
     assert.match(assets[1].content ?? '', /\"bitrate\":832000/);
   } finally {
+    if (savedDataDir === undefined) delete process.env.FT_DATA_DIR;
+    else process.env.FT_DATA_DIR = savedDataDir;
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('materializeBookmark rejects corrupted, non-addressed, or out-of-custody manifest bytes', async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), 'ft-materialize-invalid-assets-'));
+  const savedDataDir = process.env.FT_DATA_DIR;
+  process.env.FT_DATA_DIR = dir;
+  const mediaDir = path.join(dir, 'media');
+  await mkdir(mediaDir);
+  const sourceUrl = 'https://pbs.twimg.com/media/root.jpg';
+  const source = record({ mediaObjects: [{ type: 'photo', url: sourceUrl }] });
+  const manifestFor = (localPath: string): MediaFetchManifest => ({
+    schemaVersion: 1,
+    generatedAt: '2026-08-10T12:02:00.000Z',
+    limit: 1,
+    maxBytes: 1024,
+    processed: 1,
+    downloaded: 1,
+    skippedTooLarge: 0,
+    failed: 0,
+    entries: [{
+      bookmarkId: source.id,
+      tweetId: source.tweetId,
+      tweetUrl: source.url,
+      sourceUrl,
+      localPath,
+      contentType: 'image/jpeg',
+      bytes: 4,
+      status: 'downloaded',
+      fetchedAt: '2026-08-10T12:02:00.000Z',
+    }],
+  });
+
+  try {
+    const corrupted = path.join(mediaDir, `${source.tweetId}-9f64a747e1b97f13.jpg`);
+    await writeFile(corrupted, Buffer.from([9, 9, 9, 9]));
+    const nonAddressed = path.join(mediaDir, 'plain-name.jpg');
+    await writeFile(nonAddressed, Buffer.from([1, 2, 3, 4]));
+    const outside = path.join(dir, `${source.tweetId}-9f64a747e1b97f13.jpg`);
+    await writeFile(outside, Buffer.from([1, 2, 3, 4]));
+
+    for (const localPath of [corrupted, nonAddressed, outside]) {
+      const result = await materializeBookmark(source, manifestFor(localPath));
+      assert.equal(
+        result.components.find((row) => row.relation === 'post_attached_media')?.source_asset,
+        null,
+      );
+    }
+  } finally {
+    if (savedDataDir === undefined) delete process.env.FT_DATA_DIR;
+    else process.env.FT_DATA_DIR = savedDataDir;
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('materializeBookmark admits verified shared bytes whose filename belongs to another tweet', async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), 'ft-materialize-shared-asset-'));
+  const savedDataDir = process.env.FT_DATA_DIR;
+  process.env.FT_DATA_DIR = dir;
+  const mediaDir = path.join(dir, 'media');
+  await mkdir(mediaDir);
+  const bytes = Buffer.from([1, 2, 3, 4]);
+  const localPath = path.join(mediaDir, '1111111111111111111-9f64a747e1b97f13.jpg');
+  await writeFile(localPath, bytes);
+  const sourceUrl = 'https://pbs.twimg.com/media/shared.jpg';
+  const source = record({ mediaObjects: [{ type: 'photo', url: sourceUrl }] });
+  const manifest: MediaFetchManifest = {
+    schemaVersion: 1,
+    generatedAt: '2026-08-10T12:02:00.000Z',
+    limit: 1,
+    maxBytes: 1024,
+    processed: 1,
+    downloaded: 1,
+    skippedTooLarge: 0,
+    failed: 0,
+    entries: [{
+      bookmarkId: source.id,
+      tweetId: source.tweetId,
+      tweetUrl: source.url,
+      sourceUrl,
+      localPath,
+      contentType: 'image/jpeg',
+      bytes: 4,
+      status: 'downloaded',
+      fetchedAt: '2026-08-10T12:02:00.000Z',
+    }],
+  };
+
+  try {
+    const result = await materializeBookmark(source, manifest);
+    assert.equal(
+      result.components.find((row) => row.relation === 'post_attached_media')?.source_asset?.sha256,
+      '9f64a747e1b97f131fabb6b447296c9b6f0201e79fb3c5356e6c77e89b6a806a',
+    );
+  } finally {
+    if (savedDataDir === undefined) delete process.env.FT_DATA_DIR;
+    else process.env.FT_DATA_DIR = savedDataDir;
     await rm(dir, { recursive: true, force: true });
   }
 });

--- a/tests/bookmark-materialization.test.ts
+++ b/tests/bookmark-materialization.test.ts
@@ -141,14 +141,18 @@ test('materializeBookmark exposes missing thread and quote content as explicit g
 
 test('materializeBookmark does not duplicate a recovered X Article as an unresolved outbound gap', async () => {
   const articleUrl = 'https://x.com/i/article/2042676487711584257';
+  const articleAlias = 'https://twitter.com/i/article/2042676487711584257';
   const result = await materializeBookmark(record({
-    links: [articleUrl, 'https://example.com/other'],
+    links: [articleUrl, articleAlias, 'https://example.com/other'],
   }));
   const article = result.components.find((row) => row.relation === 'embedded_x_article');
   assert.equal(article?.source_locator, articleUrl);
   assert.equal(article?.disposition, 'used');
   assert.equal(
-    result.components.some((row) => row.source_locator === articleUrl && row.disposition === 'unresolved'),
+    result.components.some((row) => (
+      (row.source_locator === articleUrl || row.source_locator === articleAlias)
+      && row.disposition === 'unresolved'
+    )),
     false,
   );
   assert.equal(

--- a/tests/bookmark-materialization.test.ts
+++ b/tests/bookmark-materialization.test.ts
@@ -139,6 +139,24 @@ test('materializeBookmark exposes missing thread and quote content as explicit g
   );
 });
 
+test('materializeBookmark does not duplicate a recovered X Article as an unresolved outbound gap', async () => {
+  const articleUrl = 'https://x.com/i/article/2042676487711584257';
+  const result = await materializeBookmark(record({
+    links: [articleUrl, 'https://example.com/other'],
+  }));
+  const article = result.components.find((row) => row.relation === 'embedded_x_article');
+  assert.equal(article?.source_locator, articleUrl);
+  assert.equal(article?.disposition, 'used');
+  assert.equal(
+    result.components.some((row) => row.source_locator === articleUrl && row.disposition === 'unresolved'),
+    false,
+  );
+  assert.equal(
+    result.components.find((row) => row.source_locator === 'https://example.com/other')?.disposition,
+    'unresolved',
+  );
+});
+
 test('materializeBookmark binds poster and video variant to separate exact assets', async () => {
   const dir = await mkdtemp(path.join(tmpdir(), 'ft-materialize-video-'));
   const posterPath = path.join(dir, 'poster.jpg');

--- a/tests/bookmark-materialization.test.ts
+++ b/tests/bookmark-materialization.test.ts
@@ -138,3 +138,85 @@ test('materializeBookmark exposes missing thread and quote content as explicit g
     'unavailable',
   );
 });
+
+test('materializeBookmark binds poster and video variant to separate exact assets', async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), 'ft-materialize-video-'));
+  const posterPath = path.join(dir, 'poster.jpg');
+  const videoPath = path.join(dir, 'video.mp4');
+  await writeFile(posterPath, Buffer.from([1, 2, 3, 4]));
+  await writeFile(videoPath, Buffer.from([5, 6, 7, 8]));
+  try {
+    const posterUrl = 'https://pbs.twimg.com/amplify_video_thumb/root.jpg';
+    const videoUrl = 'https://video.twimg.com/ext_tw_video/root.mp4';
+    const source = record({
+      mediaObjects: [{
+        type: 'video',
+        url: posterUrl,
+        videoVariants: [{ url: videoUrl, contentType: 'video/mp4', bitrate: 832000 }],
+      }],
+    });
+    const manifest: MediaFetchManifest = {
+      schemaVersion: 1,
+      generatedAt: '2026-08-10T12:02:00.000Z',
+      limit: 1,
+      maxBytes: 1024,
+      processed: 2,
+      downloaded: 2,
+      skippedTooLarge: 0,
+      failed: 0,
+      entries: [
+        {
+          bookmarkId: source.id,
+          tweetId: source.tweetId,
+          tweetUrl: source.url,
+          sourceUrl: posterUrl,
+          localPath: posterPath,
+          contentType: 'image/jpeg',
+          bytes: 4,
+          status: 'downloaded',
+          fetchedAt: '2026-08-10T12:02:00.000Z',
+        },
+        {
+          bookmarkId: source.id,
+          tweetId: source.tweetId,
+          tweetUrl: source.url,
+          sourceUrl: videoUrl,
+          localPath: videoPath,
+          contentType: 'video/mp4',
+          bytes: 4,
+          status: 'downloaded',
+          fetchedAt: '2026-08-10T12:02:00.000Z',
+        },
+      ],
+    };
+
+    const result = await materializeBookmark(source, manifest);
+    const assets = result.components
+      .filter((row) => row.relation === 'post_attached_media')
+      .map((row) => ({ locator: row.source_locator, asset: row.source_asset, content: row.content }));
+
+    assert.deepEqual(assets.map(({ locator, asset }) => ({ locator, asset })), [
+      {
+        locator: posterUrl,
+        asset: {
+          sha256: '9f64a747e1b97f131fabb6b447296c9b6f0201e79fb3c5356e6c77e89b6a806a',
+          bytes: 4,
+          content_type: 'image/jpeg',
+        },
+      },
+      {
+        locator: videoUrl,
+        asset: {
+          sha256: '55e5509f8052998294266ee5b50cb592938191fb5d67f73cac2e60b0276b1bdd',
+          bytes: 4,
+          content_type: 'video/mp4',
+        },
+      },
+    ]);
+    assert.match(assets[0].content ?? '', /\"asset_role\":\"media\"/);
+    assert.match(assets[1].content ?? '', /\"asset_role\":\"video_variant\"/);
+    assert.match(assets[1].content ?? '', /\"bitrate\":832000/);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/tests/bookmark-materialization.test.ts
+++ b/tests/bookmark-materialization.test.ts
@@ -150,8 +150,9 @@ test('materializeBookmark exposes missing thread and quote content as explicit g
 test('materializeBookmark does not duplicate a recovered X Article as an unresolved outbound gap', async () => {
   const articleUrl = 'https://x.com/i/article/2042676487711584257';
   const articleAlias = 'https://twitter.com/i/article/2042676487711584257';
+  const distinctArticle = 'https://x.com/i/article/1000000000000000000';
   const result = await materializeBookmark(record({
-    links: [articleUrl, articleAlias, 'https://example.com/other'],
+    links: [articleAlias, articleUrl, distinctArticle, 'https://example.com/other'],
   }));
   const article = result.components.find((row) => row.relation === 'embedded_x_article');
   assert.equal(article?.source_locator, articleUrl);
@@ -162,6 +163,10 @@ test('materializeBookmark does not duplicate a recovered X Article as an unresol
       && row.disposition === 'unresolved'
     )),
     false,
+  );
+  assert.equal(
+    result.components.find((row) => row.source_locator === distinctArticle)?.disposition,
+    'unresolved',
   );
   assert.equal(
     result.components.find((row) => row.source_locator === 'https://example.com/other')?.disposition,

--- a/tests/bookmark-materialization.test.ts
+++ b/tests/bookmark-materialization.test.ts
@@ -194,6 +194,71 @@ test('materializeBookmark does not duplicate a recovered X Article as an unresol
   );
 });
 
+test('materializeBookmark keeps ordinary enriched webpages as unresolved outbound gaps', async () => {
+  const externalArticle = 'https://example.com/article';
+  const externalBody = 'Destination-owned ordinary article body.';
+  const result = await materializeBookmark(record({
+    links: [externalArticle],
+    articleText: externalBody,
+    articleTitle: 'Ordinary external article',
+    articleSite: 'Example',
+    articleSourceTweetId: '2080296884187652381',
+    articleLocator: externalArticle,
+    threadExpandedAt: undefined,
+    enrichedAt: '2026-08-12T12:00:00.000Z',
+  }));
+
+  const outbound = result.components.find((row) => row.source_locator === externalArticle);
+  assert.equal(outbound?.relation, 'post_outbound_link');
+  assert.equal(outbound?.disposition, 'unresolved');
+  assert.equal(
+    result.components.some((row) => row.relation === 'embedded_x_article'),
+    false,
+  );
+  assert.equal(JSON.stringify(result).includes(externalBody), false);
+  assert.equal(result.source_cutoff, '2026-08-10T12:00:00.000Z');
+});
+
+test('materializeBookmark does not let ordinary enrichment consume a separate X Article gap', async () => {
+  const externalArticle = 'https://example.com/article';
+  const xArticle = 'https://x.com/i/article/2042676487711584257';
+  const externalBody = 'Destination-owned ordinary article body.';
+  const result = await materializeBookmark(record({
+    links: [externalArticle, xArticle],
+    articleText: externalBody,
+    articleSourceTweetId: '2080296884187652381',
+    articleLocator: externalArticle,
+  }));
+
+  assert.equal(
+    result.components.find((row) => row.source_locator === externalArticle)?.disposition,
+    'unresolved',
+  );
+  assert.equal(
+    result.components.find((row) => row.relation === 'embedded_x_article')?.source_locator,
+    xArticle,
+  );
+  assert.equal(
+    result.components.find((row) => row.relation === 'embedded_x_article')?.disposition,
+    'unresolved',
+  );
+  assert.equal(JSON.stringify(result).includes(externalBody), false);
+});
+
+test('materializeBookmark treats X Article prefix lookalikes as ordinary outbound links', async () => {
+  const lookalike = 'https://x.com/i/article/2042676487711584257/extra';
+  const result = await materializeBookmark(record({
+    links: [lookalike],
+    articleText: 'Content fetched from a non-article route.',
+    articleSourceTweetId: '2080296884187652381',
+    articleLocator: lookalike,
+  }));
+
+  assert.equal(result.components.find((row) => row.source_locator === lookalike)?.relation, 'post_outbound_link');
+  assert.equal(result.components.find((row) => row.source_locator === lookalike)?.disposition, 'unresolved');
+  assert.equal(result.components.some((row) => row.relation === 'embedded_x_article'), false);
+});
+
 test('materializeBookmark leaves every X Article locator unresolved when body identity is ambiguous', async () => {
   const firstArticle = 'https://x.com/i/article/2042676487711584257';
   const secondArticle = 'https://x.com/i/article/1000000000000000000';

--- a/tests/bookmark-materialization.test.ts
+++ b/tests/bookmark-materialization.test.ts
@@ -17,7 +17,10 @@ function record(overrides: Partial<BookmarkRecord> = {}): BookmarkRecord {
     authorName: 'Operator',
     postedAt: '2026-08-01T12:00:00.000Z',
     syncedAt: '2026-08-10T12:00:00.000Z',
-    links: ['https://example.com/paper.pdf'],
+    links: [
+      'https://x.com/i/article/2042676487711584257',
+      'https://example.com/paper.pdf',
+    ],
     quotedStatusId: '2080000000000000000',
     quotedTweet: {
       id: '2080000000000000000',
@@ -43,6 +46,8 @@ function record(overrides: Partial<BookmarkRecord> = {}): BookmarkRecord {
     articleTitle: 'A long-form argument',
     articleText: 'Complete X Article body.',
     articleSite: 'X Articles',
+    articleSourceTweetId: '2080296884187652381',
+    articleLocator: 'https://x.com/i/article/2042676487711584257',
     enrichedAt: '2026-08-10T12:00:30.000Z',
     ...overrides,
   };
@@ -147,6 +152,20 @@ test('materializeBookmark exposes missing thread and quote content as explicit g
   );
 });
 
+test('materializeBookmark never uses quoted content with the wrong quoted identity', async () => {
+  const result = await materializeBookmark(record({
+    quotedTweet: {
+      id: '1111111111111111111',
+      text: 'Wrong quoted content.',
+      url: 'https://x.com/wrong/status/1111111111111111111',
+    },
+  }));
+  const quote = result.components.find((row) => row.relation === 'quoted_post');
+  assert.equal(quote?.disposition, 'unavailable');
+  assert.equal(quote?.content, null);
+  assert.equal(JSON.stringify(result).includes('Wrong quoted content.'), false);
+});
+
 test('materializeBookmark does not duplicate a recovered X Article as an unresolved outbound gap', async () => {
   const articleUrl = 'https://x.com/i/article/2042676487711584257';
   const articleAlias = 'https://twitter.com/i/article/2042676487711584257';
@@ -174,11 +193,15 @@ test('materializeBookmark leaves every X Article locator unresolved when body id
   const secondArticle = 'https://x.com/i/article/1000000000000000000';
   const result = await materializeBookmark(record({
     links: [firstArticle, secondArticle],
+    articleLocator: null,
   }));
 
   const recovered = result.components.find((row) => row.relation === 'embedded_x_article');
-  assert.equal(recovered?.source_locator, result.locator);
-  assert.equal(recovered?.disposition, 'used');
+  assert.equal(recovered?.disposition, 'unresolved');
+  assert.equal(
+    result.components.some((row) => row.relation === 'embedded_x_article' && row.disposition === 'used'),
+    false,
+  );
   for (const locator of [firstArticle, secondArticle]) {
     assert.equal(
       result.components.find((row) => row.source_locator === locator)?.disposition,
@@ -268,4 +291,56 @@ test('materializeBookmark binds poster and video variant to separate exact asset
   } finally {
     await rm(dir, { recursive: true, force: true });
   }
+});
+
+test('materializeBookmark rejects a media manifest entry owned by a different bookmark', async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), 'ft-materialize-wrong-owner-'));
+  const assetPath = path.join(dir, 'image.jpg');
+  const sourceUrl = 'https://pbs.twimg.com/media/root.jpg';
+  await writeFile(assetPath, Buffer.from([1, 2, 3, 4]));
+  try {
+    const source = record({ mediaObjects: [{ type: 'photo', url: sourceUrl }] });
+    const manifest: MediaFetchManifest = {
+      schemaVersion: 1,
+      generatedAt: '2026-08-10T12:02:00.000Z',
+      limit: 1,
+      maxBytes: 1024,
+      processed: 1,
+      downloaded: 1,
+      skippedTooLarge: 0,
+      failed: 0,
+      entries: [{
+        bookmarkId: 'different-bookmark',
+        tweetId: source.tweetId,
+        tweetUrl: source.url,
+        sourceUrl,
+        localPath: assetPath,
+        contentType: 'image/jpeg',
+        bytes: 4,
+        status: 'downloaded',
+        fetchedAt: '2026-08-10T12:02:00.000Z',
+      }],
+    };
+
+    const result = await materializeBookmark(source, manifest);
+    assert.equal(
+      result.components.find((row) => row.relation === 'post_attached_media')?.source_asset,
+      null,
+    );
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('materializeBookmark output and component ordering are deterministic', async () => {
+  const source = record({
+    links: [
+      'https://z.example/source',
+      'https://x.com/i/article/2042676487711584257',
+      'https://a.example/source',
+    ],
+  });
+  const first = await materializeBookmark(source);
+  const second = await materializeBookmark({ ...source, links: [...source.links!].reverse() });
+  assert.deepEqual(second, first);
 });

--- a/tests/bookmark-materialization.test.ts
+++ b/tests/bookmark-materialization.test.ts
@@ -150,9 +150,8 @@ test('materializeBookmark exposes missing thread and quote content as explicit g
 test('materializeBookmark does not duplicate a recovered X Article as an unresolved outbound gap', async () => {
   const articleUrl = 'https://x.com/i/article/2042676487711584257';
   const articleAlias = 'https://twitter.com/i/article/2042676487711584257';
-  const distinctArticle = 'https://x.com/i/article/1000000000000000000';
   const result = await materializeBookmark(record({
-    links: [articleAlias, articleUrl, distinctArticle, 'https://example.com/other'],
+    links: [articleAlias, articleUrl, 'https://example.com/other'],
   }));
   const article = result.components.find((row) => row.relation === 'embedded_x_article');
   assert.equal(article?.source_locator, articleUrl);
@@ -165,13 +164,28 @@ test('materializeBookmark does not duplicate a recovered X Article as an unresol
     false,
   );
   assert.equal(
-    result.components.find((row) => row.source_locator === distinctArticle)?.disposition,
-    'unresolved',
-  );
-  assert.equal(
     result.components.find((row) => row.source_locator === 'https://example.com/other')?.disposition,
     'unresolved',
   );
+});
+
+test('materializeBookmark leaves every X Article locator unresolved when body identity is ambiguous', async () => {
+  const firstArticle = 'https://x.com/i/article/2042676487711584257';
+  const secondArticle = 'https://x.com/i/article/1000000000000000000';
+  const result = await materializeBookmark(record({
+    links: [firstArticle, secondArticle],
+  }));
+
+  const recovered = result.components.find((row) => row.relation === 'embedded_x_article');
+  assert.equal(recovered?.source_locator, result.locator);
+  assert.equal(recovered?.disposition, 'used');
+  for (const locator of [firstArticle, secondArticle]) {
+    assert.equal(
+      result.components.find((row) => row.source_locator === locator)?.disposition,
+      'unresolved',
+    );
+  }
+  assert.equal(result.achieved_depth, 'source-owned root and enumerated components with explicit unresolved depth');
 });
 
 test('materializeBookmark binds poster and video variant to separate exact assets', async () => {

--- a/tests/bookmark-media.test.ts
+++ b/tests/bookmark-media.test.ts
@@ -842,3 +842,44 @@ test('fetchBookmarkMediaBatch with skipProfileImages excludes pfp-only bookmarks
     globalThis.fetch = originalFetch;
   }
 });
+
+test('fetchBookmarkMediaBatch can be bounded to an exact in-memory record', async () => {
+  const selectedUrl = 'https://pbs.twimg.com/media/selected.jpg';
+  const excludedUrl = 'https://pbs.twimg.com/media/excluded.jpg';
+  const selected = {
+    id: '1', tweetId: '1', url: 'https://x.com/a/status/1', text: 'selected', syncedAt: '2026-08-11T00:00:00Z',
+    mediaObjects: [{ type: 'photo', url: selectedUrl }], links: [], tags: [], ingestedVia: 'graphql',
+  };
+  const excluded = {
+    id: '2', tweetId: '2', url: 'https://x.com/b/status/2', text: 'excluded', syncedAt: '2026-08-11T00:00:00Z',
+    mediaObjects: [{ type: 'photo', url: excludedUrl }], links: [], tags: [], ingestedVia: 'graphql',
+  };
+  const fetched: string[] = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+    const url = String(input instanceof Request ? input.url : input);
+    if ((init?.method ?? 'GET') === 'HEAD') {
+      return new Response(null, { status: 200, headers: { 'content-length': '4', 'content-type': 'image/jpeg' } });
+    }
+    fetched.push(url);
+    return new Response(Uint8Array.from([1, 2, 3, 4]), {
+      status: 200,
+      headers: { 'content-type': 'image/jpeg' },
+    });
+  }) as typeof fetch;
+  try {
+    await withMediaDataDir([selected, excluded], async () => {
+      const manifest = await fetchBookmarkMediaBatch({
+        records: [selected],
+        limit: 1,
+        maxBytes: 1024,
+        skipProfileImages: true,
+      });
+      assert.deepEqual(fetched, [selectedUrl]);
+      assert.ok(manifest.entries.some((entry) => entry.sourceUrl === selectedUrl));
+      assert.ok(!manifest.entries.some((entry) => entry.sourceUrl === excludedUrl));
+    });
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});

--- a/tests/bookmark-media.test.ts
+++ b/tests/bookmark-media.test.ts
@@ -256,6 +256,61 @@ test('fetchBookmarkMediaBatch reuses verified shared bytes across runs while pre
   }
 });
 
+test('fetchBookmarkMediaBatch refetches same-size cached bytes whose filename digest no longer matches', async () => {
+  const sharedPhotoUrl = 'https://pbs.twimg.com/media/shared-corrupted-later.jpg';
+  const quotedTweet = {
+    id: '99',
+    url: 'https://x.com/quoted/status/99',
+    text: 'shared quote',
+    authorHandle: 'quoted',
+    mediaObjects: [{ type: 'photo', url: sharedPhotoUrl }],
+  };
+  const records = ['1', '2'].map((id) => ({
+    id,
+    tweetId: id,
+    url: `https://x.com/operator/status/${id}`,
+    text: `root ${id}`,
+    syncedAt: '2026-04-09T00:00:00.000Z',
+    quotedStatusId: quotedTweet.id,
+    quotedTweet,
+    links: [],
+  }));
+  const originalFetch = globalThis.fetch;
+  let getCalls = 0;
+  globalThis.fetch = (async (_input: string | URL | Request, init?: RequestInit) => {
+    if (init?.method === 'HEAD') {
+      return new Response(null, {
+        status: 200,
+        headers: { 'content-length': '4', 'content-type': 'image/jpeg' },
+      });
+    }
+    getCalls += 1;
+    return new Response(Uint8Array.from([1, 2, 3, 4]), {
+      status: 200,
+      headers: { 'content-type': 'image/jpeg' },
+    });
+  }) as typeof fetch;
+
+  try {
+    await withMediaDataDir(records, async () => {
+      const first = await fetchBookmarkMediaBatch({ records: [records[0]], maxBytes: 1024, skipProfileImages: true });
+      const localPath = first.entries.find((entry) => entry.sourceUrl === sharedPhotoUrl)?.localPath;
+      assert.ok(localPath);
+      assert.equal(getCalls, 1);
+      await writeFile(localPath, Uint8Array.from([9, 9, 9, 9]));
+
+      const second = await fetchBookmarkMediaBatch({ records: [records[1]], maxBytes: 1024, skipProfileImages: true });
+      assert.equal(getCalls, 2);
+      const shared = second.entries.filter((entry) => entry.sourceUrl === sharedPhotoUrl);
+      assert.deepEqual(shared.map((entry) => entry.bookmarkId).sort(), ['1', '2']);
+      assert.equal(shared[0].localPath, shared[1].localPath);
+      assert.deepEqual([...await readFile(localPath)], [1, 2, 3, 4]);
+    });
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
 test('fetchBookmarkMediaBatch downloads shared profile images only once across bookmarks', async () => {
   const profileUrl = 'https://pbs.twimg.com/profile_images/123/avatar_normal.jpg';
   const fullProfileUrl = profileUrl.replace('_normal.', '_400x400.');

--- a/tests/bookmark-media.test.ts
+++ b/tests/bookmark-media.test.ts
@@ -5,6 +5,7 @@ import { rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { fetchBookmarkMediaBatch } from '../src/bookmark-media.js';
+import { materializeBookmark } from '../src/bookmark-materialization.js';
 
 async function withMediaDataDir(records: any[], fn: () => Promise<void>): Promise<void> {
   const dir = await mkdtemp(path.join(tmpdir(), 'ft-media-test-'));
@@ -144,6 +145,111 @@ test('fetchBookmarkMediaBatch downloads quoted tweet media targets', async () =>
         { tweetId: '99', sourceUrl: quotedProfileUrl.replace('_normal.', '_400x400.') },
         { tweetId: '99', sourceUrl: quotedVideoUrl },
       ]);
+    });
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('fetchBookmarkMediaBatch creates root-specific associations for one shared quoted asset in one run', async () => {
+  const sharedPhotoUrl = 'https://pbs.twimg.com/media/shared-quoted.jpg';
+  const quotedTweet = {
+    id: '99',
+    url: 'https://x.com/quoted/status/99',
+    text: 'shared quote',
+    authorHandle: 'quoted',
+    mediaObjects: [{ type: 'photo', url: sharedPhotoUrl }],
+  };
+  const records = ['1', '2'].map((id) => ({
+    id,
+    tweetId: id,
+    url: `https://x.com/operator/status/${id}`,
+    text: `root ${id}`,
+    syncedAt: '2026-04-09T00:00:00.000Z',
+    quotedStatusId: quotedTweet.id,
+    quotedTweet,
+    links: [],
+  }));
+  const originalFetch = globalThis.fetch;
+  let getCalls = 0;
+  globalThis.fetch = (async (_input: string | URL | Request, init?: RequestInit) => {
+    if (init?.method === 'HEAD') {
+      return new Response(null, {
+        status: 200,
+        headers: { 'content-length': '4', 'content-type': 'image/jpeg' },
+      });
+    }
+    getCalls += 1;
+    return new Response(Uint8Array.from([1, 2, 3, 4]), {
+      status: 200,
+      headers: { 'content-type': 'image/jpeg' },
+    });
+  }) as typeof fetch;
+
+  try {
+    await withMediaDataDir(records, async () => {
+      const manifest = await fetchBookmarkMediaBatch({ maxBytes: 1024, skipProfileImages: true });
+      const shared = manifest.entries.filter((entry) => entry.sourceUrl === sharedPhotoUrl);
+      assert.equal(getCalls, 1);
+      assert.deepEqual(shared.map((entry) => entry.bookmarkId).sort(), ['1', '2']);
+      assert.equal(shared[0].localPath, shared[1].localPath);
+    });
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('fetchBookmarkMediaBatch reuses verified shared bytes across runs while preserving root custody', async () => {
+  const sharedPhotoUrl = 'https://pbs.twimg.com/media/shared-quoted-later.jpg';
+  const quotedTweet = {
+    id: '99',
+    url: 'https://x.com/quoted/status/99',
+    text: 'shared quote',
+    authorHandle: 'quoted',
+    mediaObjects: [{ type: 'photo', url: sharedPhotoUrl }],
+  };
+  const records = ['1', '2'].map((id) => ({
+    id,
+    tweetId: id,
+    url: `https://x.com/operator/status/${id}`,
+    text: `root ${id}`,
+    syncedAt: '2026-04-09T00:00:00.000Z',
+    quotedStatusId: quotedTweet.id,
+    quotedTweet,
+    links: [],
+  }));
+  const originalFetch = globalThis.fetch;
+  let getCalls = 0;
+  globalThis.fetch = (async (_input: string | URL | Request, init?: RequestInit) => {
+    if (init?.method === 'HEAD') {
+      return new Response(null, {
+        status: 200,
+        headers: { 'content-length': '4', 'content-type': 'image/jpeg' },
+      });
+    }
+    getCalls += 1;
+    return new Response(Uint8Array.from([1, 2, 3, 4]), {
+      status: 200,
+      headers: { 'content-type': 'image/jpeg' },
+    });
+  }) as typeof fetch;
+
+  try {
+    await withMediaDataDir(records, async () => {
+      await fetchBookmarkMediaBatch({ records: [records[0]], maxBytes: 1024, skipProfileImages: true });
+      assert.equal(getCalls, 1);
+      globalThis.fetch = (async () => {
+        throw new Error('verified cached bytes should avoid another request');
+      }) as typeof fetch;
+      const manifest = await fetchBookmarkMediaBatch({ records: [records[1]], maxBytes: 1024, skipProfileImages: true });
+      const shared = manifest.entries.filter((entry) => entry.sourceUrl === sharedPhotoUrl);
+      assert.deepEqual(shared.map((entry) => entry.bookmarkId).sort(), ['1', '2']);
+      assert.equal(shared[0].localPath, shared[1].localPath);
+
+      const materialized = await materializeBookmark(records[1], manifest);
+      const component = materialized.components.find((row) => row.source_locator === sharedPhotoUrl);
+      assert.ok(component?.source_asset);
+      assert.equal(component.source_asset.bytes, 4);
     });
   } finally {
     globalThis.fetch = originalFetch;

--- a/tests/bookmark-media.test.ts
+++ b/tests/bookmark-media.test.ts
@@ -6,6 +6,11 @@ import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { fetchBookmarkMediaBatch } from '../src/bookmark-media.js';
 import { materializeBookmark } from '../src/bookmark-materialization.js';
+import { XRequestExecutor } from '../src/x-request-policy.js';
+
+function mediaExecutor(): XRequestExecutor {
+  return new XRequestExecutor({ maxAttempts: 1 });
+}
 
 async function withMediaDataDir(records: any[], fn: () => Promise<void>): Promise<void> {
   const dir = await mkdtemp(path.join(tmpdir(), 'ft-media-test-'));
@@ -64,7 +69,7 @@ test('fetchBookmarkMediaBatch downloads post media from GraphQL mediaObjects sha
 
   try {
     await withMediaDataDir(records, async () => {
-      const manifest = await fetchBookmarkMediaBatch({ limit: 10, maxBytes: 1024 });
+      const manifest = await fetchBookmarkMediaBatch(mediaExecutor(), { limit: 10, maxBytes: 1024 });
       const downloaded = manifest.entries
         .filter((entry) => entry.status === 'downloaded')
         .map((entry) => entry.sourceUrl)
@@ -133,7 +138,7 @@ test('fetchBookmarkMediaBatch downloads quoted tweet media targets', async () =>
 
   try {
     await withMediaDataDir(records, async () => {
-      const manifest = await fetchBookmarkMediaBatch({ limit: 10, maxBytes: 1024 });
+      const manifest = await fetchBookmarkMediaBatch(mediaExecutor(), { limit: 10, maxBytes: 1024 });
       const downloaded = manifest.entries
         .filter((entry) => entry.status === 'downloaded')
         .map((entry) => ({ tweetId: entry.tweetId, sourceUrl: entry.sourceUrl }))
@@ -188,7 +193,7 @@ test('fetchBookmarkMediaBatch creates root-specific associations for one shared 
 
   try {
     await withMediaDataDir(records, async () => {
-      const manifest = await fetchBookmarkMediaBatch({ maxBytes: 1024, skipProfileImages: true });
+      const manifest = await fetchBookmarkMediaBatch(mediaExecutor(), { maxBytes: 1024, skipProfileImages: true });
       const shared = manifest.entries.filter((entry) => entry.sourceUrl === sharedPhotoUrl);
       assert.equal(getCalls, 1);
       assert.deepEqual(shared.map((entry) => entry.bookmarkId).sort(), ['1', '2']);
@@ -236,12 +241,12 @@ test('fetchBookmarkMediaBatch reuses verified shared bytes across runs while pre
 
   try {
     await withMediaDataDir(records, async () => {
-      await fetchBookmarkMediaBatch({ records: [records[0]], maxBytes: 1024, skipProfileImages: true });
+      await fetchBookmarkMediaBatch(mediaExecutor(), { records: [records[0]], maxBytes: 1024, skipProfileImages: true });
       assert.equal(getCalls, 1);
       globalThis.fetch = (async () => {
         throw new Error('verified cached bytes should avoid another request');
       }) as typeof fetch;
-      const manifest = await fetchBookmarkMediaBatch({ records: [records[1]], maxBytes: 1024, skipProfileImages: true });
+      const manifest = await fetchBookmarkMediaBatch(mediaExecutor(), { records: [records[1]], maxBytes: 1024, skipProfileImages: true });
       const shared = manifest.entries.filter((entry) => entry.sourceUrl === sharedPhotoUrl);
       assert.deepEqual(shared.map((entry) => entry.bookmarkId).sort(), ['1', '2']);
       assert.equal(shared[0].localPath, shared[1].localPath);
@@ -293,13 +298,13 @@ test('fetchBookmarkMediaBatch refetches same-size cached bytes whose filename di
 
   try {
     await withMediaDataDir(records, async () => {
-      const first = await fetchBookmarkMediaBatch({ records: [records[0]], maxBytes: 1024, skipProfileImages: true });
+      const first = await fetchBookmarkMediaBatch(mediaExecutor(), { records: [records[0]], maxBytes: 1024, skipProfileImages: true });
       const localPath = first.entries.find((entry) => entry.sourceUrl === sharedPhotoUrl)?.localPath;
       assert.ok(localPath);
       assert.equal(getCalls, 1);
       await writeFile(localPath, Uint8Array.from([9, 9, 9, 9]));
 
-      const second = await fetchBookmarkMediaBatch({ records: [records[1]], maxBytes: 1024, skipProfileImages: true });
+      const second = await fetchBookmarkMediaBatch(mediaExecutor(), { records: [records[1]], maxBytes: 1024, skipProfileImages: true });
       assert.equal(getCalls, 2);
       const shared = second.entries.filter((entry) => entry.sourceUrl === sharedPhotoUrl);
       assert.deepEqual(shared.map((entry) => entry.bookmarkId).sort(), ['1', '2']);
@@ -365,7 +370,7 @@ test('fetchBookmarkMediaBatch downloads shared profile images only once across b
 
   try {
     await withMediaDataDir(records, async () => {
-      const manifest = await fetchBookmarkMediaBatch({ limit: 10, maxBytes: 1024 });
+      const manifest = await fetchBookmarkMediaBatch(mediaExecutor(), { limit: 10, maxBytes: 1024 });
       const downloadedProfileEntries = manifest.entries.filter(
         (entry) => entry.status === 'downloaded' && entry.sourceUrl === fullProfileUrl,
       );
@@ -438,7 +443,7 @@ test('fetchBookmarkMediaBatch deduplicates shared profile image failure within o
 
   try {
     await withMediaDataDir(records, async () => {
-      const manifest = await fetchBookmarkMediaBatch({ limit: 10, maxBytes: 1024 });
+      const manifest = await fetchBookmarkMediaBatch(mediaExecutor(), { limit: 10, maxBytes: 1024 });
       const downloadedProfileEntries = manifest.entries.filter(
         (entry) => entry.status === 'downloaded' && entry.sourceUrl === fullProfileUrl,
       );
@@ -491,7 +496,7 @@ test('fetchBookmarkMediaBatch retries failed profile image when requested', asyn
         return new Response(null, { status: 500 });
       };
 
-      const firstManifest = await fetchBookmarkMediaBatch({ limit: 10, maxBytes: 1024 });
+      const firstManifest = await fetchBookmarkMediaBatch(mediaExecutor(), { limit: 10, maxBytes: 1024 });
       assert.equal(
         firstManifest.entries.filter((entry) => entry.status === 'failed' && entry.sourceUrl === fullProfileUrl).length,
         1,
@@ -513,7 +518,7 @@ test('fetchBookmarkMediaBatch retries failed profile image when requested', asyn
         });
       };
 
-      const secondManifest = await fetchBookmarkMediaBatch({ limit: 10, maxBytes: 1024, retryFailed: true });
+      const secondManifest = await fetchBookmarkMediaBatch(mediaExecutor(), { limit: 10, maxBytes: 1024, retryFailed: true });
       const downloadedProfileEntries = secondManifest.entries.filter(
         (entry) => entry.status === 'downloaded' && entry.sourceUrl === fullProfileUrl,
       );
@@ -560,7 +565,7 @@ test('fetchBookmarkMediaBatch reports progress as assets complete', async () => 
 
   try {
     await withMediaDataDir(records, async () => {
-      await fetchBookmarkMediaBatch({
+      await fetchBookmarkMediaBatch(mediaExecutor(), {
         limit: 10,
         maxBytes: 1024,
         onProgress: (progress) => {
@@ -635,7 +640,7 @@ test('fetchBookmarkMediaBatch aborts at boundary and writes completed entries to
 
   try {
     await withMediaDataDir(records, async () => {
-      const manifest = await fetchBookmarkMediaBatch({
+      const manifest = await fetchBookmarkMediaBatch(mediaExecutor(), {
         maxBytes: 1024,
         signal: controller.signal,
         onProgress: (progress) => {
@@ -709,11 +714,11 @@ test('fetchBookmarkMediaBatch applies limit after filtering out already-download
 
   try {
     await withMediaDataDir(records, async () => {
-      const firstRun = await fetchBookmarkMediaBatch({ limit: 1, maxBytes: 1024 });
+      const firstRun = await fetchBookmarkMediaBatch(mediaExecutor(), { limit: 1, maxBytes: 1024 });
       assert.equal(firstRun.downloaded, 1);
       assert.equal(fetchedUrls.at(-1), firstUrl);
 
-      const secondRun = await fetchBookmarkMediaBatch({ limit: 1, maxBytes: 1024 });
+      const secondRun = await fetchBookmarkMediaBatch(mediaExecutor(), { limit: 1, maxBytes: 1024 });
       assert.equal(secondRun.downloaded, 1);
       assert.equal(fetchedUrls.at(-1), secondUrl);
     });
@@ -760,11 +765,11 @@ test('fetchBookmarkMediaBatch backs off failed non-profile media unless retry is
             });
       };
 
-      const firstRun = await fetchBookmarkMediaBatch({ maxBytes: 1024 });
+      const firstRun = await fetchBookmarkMediaBatch(mediaExecutor(), { maxBytes: 1024 });
       assert.equal(firstRun.failed, 1);
       assert.equal(firstRun.entries.filter((entry) => entry.sourceUrl === photoUrl).length, 1);
 
-      const secondRun = await fetchBookmarkMediaBatch({ maxBytes: 1024 });
+      const secondRun = await fetchBookmarkMediaBatch(mediaExecutor(), { maxBytes: 1024 });
       assert.equal(secondRun.downloaded, 0);
       assert.equal(getCalls, 1);
       assert.equal(secondRun.entries.filter((entry) => entry.sourceUrl === photoUrl).length, 1);
@@ -773,7 +778,7 @@ test('fetchBookmarkMediaBatch backs off failed non-profile media unless retry is
         'failed',
       );
 
-      const thirdRun = await fetchBookmarkMediaBatch({ maxBytes: 1024, retryFailed: true });
+      const thirdRun = await fetchBookmarkMediaBatch(mediaExecutor(), { maxBytes: 1024, retryFailed: true });
       assert.equal(thirdRun.downloaded, 1);
       assert.equal(getCalls, 2);
       assert.equal(thirdRun.entries.filter((entry) => entry.sourceUrl === photoUrl).length, 1);
@@ -825,7 +830,7 @@ test('fetchBookmarkMediaBatch retries stale failed non-profile media after backo
             });
       };
 
-      const firstRun = await fetchBookmarkMediaBatch({ maxBytes: 1024 });
+      const firstRun = await fetchBookmarkMediaBatch(mediaExecutor(), { maxBytes: 1024 });
       assert.equal(firstRun.failed, 1);
 
       const manifestPath = path.join(process.env.FT_DATA_DIR!, 'media-manifest.json');
@@ -833,7 +838,7 @@ test('fetchBookmarkMediaBatch retries stale failed non-profile media after backo
       manifest.entries[0].fetchedAt = '2026-01-01T00:00:00.000Z';
       await writeFile(manifestPath, JSON.stringify(manifest, null, 2));
 
-      const secondRun = await fetchBookmarkMediaBatch({ maxBytes: 1024 });
+      const secondRun = await fetchBookmarkMediaBatch(mediaExecutor(), { maxBytes: 1024 });
       assert.equal(secondRun.downloaded, 1);
       assert.equal(getCalls, 2);
     });
@@ -890,7 +895,7 @@ test('fetchBookmarkMediaBatch does not retry the same failing asset twice in one
         return new Response(null, { status: 500 });
       };
 
-      const manifest = await fetchBookmarkMediaBatch({ maxBytes: 1024 });
+      const manifest = await fetchBookmarkMediaBatch(mediaExecutor(), { maxBytes: 1024 });
       assert.equal(manifest.failed, 2);
       assert.equal(getCalls, 1);
       assert.equal(manifest.entries.filter((entry) => entry.sourceUrl === sharedPhotoUrl).length, 2);
@@ -949,7 +954,7 @@ test('fetchBookmarkMediaBatch with skipProfileImages skips profile images but do
 
   try {
     await withMediaDataDir(records, async () => {
-      const manifest = await fetchBookmarkMediaBatch({ limit: 10, maxBytes: 1024, skipProfileImages: true });
+      const manifest = await fetchBookmarkMediaBatch(mediaExecutor(), { limit: 10, maxBytes: 1024, skipProfileImages: true });
 
       assert.equal(manifest.entries.filter((e) => e.sourceUrl.includes('/profile_images/')).length, 0);
       assert.ok(!fetchedUrls.some((u) => u.includes('/profile_images/')));
@@ -994,7 +999,7 @@ test('fetchBookmarkMediaBatch with skipProfileImages excludes pfp-only bookmarks
 
   try {
     await withMediaDataDir(records, async () => {
-      const manifest = await fetchBookmarkMediaBatch({ limit: 10, maxBytes: 1024, skipProfileImages: true });
+      const manifest = await fetchBookmarkMediaBatch(mediaExecutor(), { limit: 10, maxBytes: 1024, skipProfileImages: true });
       assert.equal(manifest.downloaded, 0);
       assert.equal(manifest.processed, 0);
       assert.equal(fetchCalled, false);
@@ -1035,7 +1040,7 @@ test('fetchBookmarkMediaBatch can be bounded to an exact in-memory record', asyn
   }) as typeof fetch;
   try {
     await withMediaDataDir([selected, excluded], async () => {
-      const manifest = await fetchBookmarkMediaBatch({
+      const manifest = await fetchBookmarkMediaBatch(mediaExecutor(), {
         records: [selected],
         limit: 1,
         maxBytes: 1024,
@@ -1050,4 +1055,73 @@ test('fetchBookmarkMediaBatch can be bounded to an exact in-memory record', asyn
   } finally {
     globalThis.fetch = originalFetch;
   }
+});
+
+test('fetchBookmarkMediaBatch routes every exact media attempt through the injected request executor', async () => {
+  const selectedUrl = 'https://pbs.twimg.com/media/policy-bound.jpg';
+  const selected = {
+    id: '1', tweetId: '1', url: 'https://x.com/a/status/1', text: 'selected', syncedAt: '2026-08-11T00:00:00Z',
+    mediaObjects: [{ type: 'photo', url: selectedUrl }], links: [], tags: [], ingestedVia: 'graphql',
+  };
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (async () => {
+    throw new Error('raw global fetch escaped the injected executor');
+  }) as typeof fetch;
+  const executor = new XRequestExecutor({
+    maxAttempts: 1,
+    fetchImpl: (async (_input: string | URL | Request, init?: RequestInit) => {
+      if (init?.method === 'HEAD') {
+        return new Response(null, {
+          status: 200,
+          headers: { 'content-length': '4', 'content-type': 'image/jpeg' },
+        });
+      }
+      return new Response(Uint8Array.from([1, 2, 3, 4]), {
+        status: 200,
+        headers: { 'content-type': 'image/jpeg' },
+      });
+    }) as typeof fetch,
+  });
+  try {
+    await withMediaDataDir([selected], async () => {
+      const manifest = await fetchBookmarkMediaBatch(executor, {
+        records: [selected],
+        limit: 1,
+        maxBytes: 1024,
+        skipProfileImages: true,
+      });
+      assert.equal(manifest.downloaded, 1);
+      assert.equal(manifest.failed, 0);
+      assert.equal(executor.attemptCount, 2);
+    });
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('standalone one-attempt media policy preserves terminal HEAD network failure behavior', async () => {
+  const selectedUrl = 'https://pbs.twimg.com/media/head-network-failure.jpg';
+  const selected = {
+    id: '1', tweetId: '1', url: 'https://x.com/a/status/1', text: 'selected', syncedAt: '2026-08-11T00:00:00Z',
+    mediaObjects: [{ type: 'photo', url: selectedUrl }], links: [], tags: [], ingestedVia: 'graphql',
+  };
+  let calls = 0;
+  const executor = new XRequestExecutor({
+    maxAttempts: 1,
+    fetchImpl: (async () => {
+      calls += 1;
+      throw new Error('head transport unavailable');
+    }) as typeof fetch,
+  });
+
+  await withMediaDataDir([selected], async () => {
+    const manifest = await fetchBookmarkMediaBatch(executor, {
+      records: [selected],
+      maxBytes: 1024,
+      skipProfileImages: true,
+    });
+    assert.equal(calls, 1);
+    assert.equal(manifest.failed, 1);
+    assert.equal(manifest.entries.at(-1)?.reason, 'head transport unavailable');
+  });
 });

--- a/tests/bookmark-media.test.ts
+++ b/tests/bookmark-media.test.ts
@@ -845,10 +845,15 @@ test('fetchBookmarkMediaBatch with skipProfileImages excludes pfp-only bookmarks
 
 test('fetchBookmarkMediaBatch can be bounded to an exact in-memory record', async () => {
   const selectedUrl = 'https://pbs.twimg.com/media/selected.jpg';
+  const parentUrl = 'https://pbs.twimg.com/media/selected-parent.jpg';
+  const continuationUrl = 'https://pbs.twimg.com/media/selected-continuation.jpg';
   const excludedUrl = 'https://pbs.twimg.com/media/excluded.jpg';
   const selected = {
     id: '1', tweetId: '1', url: 'https://x.com/a/status/1', text: 'selected', syncedAt: '2026-08-11T00:00:00Z',
-    mediaObjects: [{ type: 'photo', url: selectedUrl }], links: [], tags: [], ingestedVia: 'graphql',
+    mediaObjects: [{ type: 'photo', url: selectedUrl }],
+    threadContext: [{ id: '0', url: 'https://x.com/a/status/0', text: 'parent', mediaObjects: [{ type: 'photo', url: parentUrl }] }],
+    threadBelow: [{ id: '3', url: 'https://x.com/a/status/3', text: 'continuation', mediaObjects: [{ type: 'photo', url: continuationUrl }] }],
+    links: [], tags: [], ingestedVia: 'graphql',
   };
   const excluded = {
     id: '2', tweetId: '2', url: 'https://x.com/b/status/2', text: 'excluded', syncedAt: '2026-08-11T00:00:00Z',
@@ -875,8 +880,10 @@ test('fetchBookmarkMediaBatch can be bounded to an exact in-memory record', asyn
         maxBytes: 1024,
         skipProfileImages: true,
       });
-      assert.deepEqual(fetched, [selectedUrl]);
+      assert.deepEqual(fetched, [selectedUrl, parentUrl, continuationUrl]);
       assert.ok(manifest.entries.some((entry) => entry.sourceUrl === selectedUrl));
+      assert.ok(manifest.entries.some((entry) => entry.sourceUrl === parentUrl && entry.tweetId === '0'));
+      assert.ok(manifest.entries.some((entry) => entry.sourceUrl === continuationUrl && entry.tweetId === '3'));
       assert.ok(!manifest.entries.some((entry) => entry.sourceUrl === excludedUrl));
     });
   } finally {

--- a/tests/bookmark-snapshot.test.ts
+++ b/tests/bookmark-snapshot.test.ts
@@ -1,0 +1,112 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { hydrateCanonicalBookmark } from '../src/bookmark-snapshot.js';
+import type { BookmarkTimelineItem } from '../src/bookmarks-db.js';
+import type { BookmarkRecord } from '../src/types.js';
+
+const ROOT = '2042685676949270724';
+const QUOTE = '2042685676949270000';
+const ARTICLE = 'https://x.com/i/article/2042676487711584257';
+
+function archived(overrides: Partial<BookmarkRecord> = {}): BookmarkRecord {
+  return {
+    id: ROOT,
+    tweetId: ROOT,
+    url: `https://x.com/operator/status/${ROOT}`,
+    text: 'New archive-owned root text.',
+    postedAt: '2026-08-11T00:00:00.000Z',
+    syncedAt: '2026-08-11T01:00:00.000Z',
+    quotedStatusId: QUOTE,
+    links: [ARTICLE],
+    ...overrides,
+  };
+}
+
+function indexed(overrides: Partial<BookmarkTimelineItem> = {}): BookmarkTimelineItem {
+  return {
+    id: ROOT,
+    tweetId: ROOT,
+    url: `https://x.com/operator/status/${ROOT}`,
+    text: 'Stale indexed root text.',
+    postedAt: '2026-01-01T00:00:00.000Z',
+    syncedAt: '2026-01-01T01:00:00.000Z',
+    categories: [],
+    domains: [],
+    githubUrls: [],
+    links: ['https://example.com/stale'],
+    articleTitle: 'Bound indexed article',
+    articleText: 'Legitimate DB-only article enrichment.',
+    articleSite: 'X Articles',
+    articleSourceTweetId: ROOT,
+    articleLocator: 'https://twitter.com/i/article/2042676487711584257',
+    quotedStatusId: QUOTE,
+    quotedTweet: {
+      id: QUOTE,
+      text: 'Legitimate DB-only quoted source.',
+      url: `https://x.com/quoted/status/${QUOTE}`,
+    },
+    mediaCount: 0,
+    linkCount: 1,
+    folderIds: [],
+    folderNames: [],
+    ...overrides,
+  };
+}
+
+test('canonical hydration keeps every archive-owned root field while accepting exactly bound DB enrichment', () => {
+  const source = archived();
+  const result = hydrateCanonicalBookmark(source, indexed());
+
+  assert.equal(result.id, source.id);
+  assert.equal(result.tweetId, source.tweetId);
+  assert.equal(result.url, source.url);
+  assert.equal(result.text, source.text);
+  assert.equal(result.postedAt, source.postedAt);
+  assert.equal(result.syncedAt, source.syncedAt);
+  assert.deepEqual(result.links, source.links);
+  assert.equal(result.quotedStatusId, QUOTE);
+  assert.equal(result.quotedTweet?.id, QUOTE);
+  assert.equal(result.quotedTweet?.text, 'Legitimate DB-only quoted source.');
+  assert.equal(result.articleText, 'Legitimate DB-only article enrichment.');
+  assert.equal(result.articleSourceTweetId, ROOT);
+  assert.equal(result.articleLocator, ARTICLE);
+});
+
+test('canonical hydration rejects stale quote identity and wrong-root or wrong-locator article enrichment', () => {
+  const wrongQuote = hydrateCanonicalBookmark(archived(), indexed({
+    quotedStatusId: '1111111111111111111',
+    quotedTweet: {
+      id: '1111111111111111111',
+      text: 'Wrong quote.',
+      url: 'https://x.com/wrong/status/1111111111111111111',
+    },
+  }));
+  assert.equal(wrongQuote.quotedTweet, undefined);
+
+  for (const badIndex of [
+    indexed({ articleSourceTweetId: '9999999999999999999' }),
+    indexed({ articleLocator: 'https://x.com/i/article/1000000000000000000' }),
+    indexed({ tweetId: '9999999999999999999' }),
+  ]) {
+    const result = hydrateCanonicalBookmark(archived(), badIndex);
+    assert.equal(result.articleText, null);
+    assert.equal(result.articleLocator, null);
+  }
+});
+
+test('canonical hydration rejects unbound component content already present in the archive', () => {
+  const result = hydrateCanonicalBookmark(archived({
+    quotedTweet: {
+      id: '1111111111111111111',
+      text: 'Wrong archived quote.',
+      url: 'https://x.com/wrong/status/1111111111111111111',
+    },
+    articleText: 'Ambiguous archived body.',
+    articleSourceTweetId: ROOT,
+    articleLocator: 'https://x.com/i/article/1000000000000000000',
+  }), null);
+
+  assert.equal(result.quotedTweet, undefined);
+  assert.equal(result.articleText, null);
+  assert.equal(result.articleLocator, null);
+});

--- a/tests/bookmark-snapshot.test.ts
+++ b/tests/bookmark-snapshot.test.ts
@@ -110,3 +110,38 @@ test('canonical hydration rejects unbound component content already present in t
   assert.equal(result.articleText, null);
   assert.equal(result.articleLocator, null);
 });
+
+test('canonical hydration requires explicit archived article provenance and locator binding', () => {
+  for (const source of [
+    archived({
+      articleText: 'Body without a source tweet.',
+      articleSourceTweetId: null,
+      articleLocator: ARTICLE,
+    }),
+    archived({
+      articleText: 'Body without a source locator.',
+      articleSourceTweetId: ROOT,
+      articleLocator: null,
+    }),
+    archived({
+      links: [ARTICLE, 'https://x.com/i/article/1000000000000000000'],
+      articleText: 'Body with ambiguous locator identity.',
+      articleSourceTweetId: ROOT,
+      articleLocator: null,
+    }),
+  ]) {
+    const result = hydrateCanonicalBookmark(source, null);
+    assert.equal(result.articleText, null);
+    assert.equal(result.articleSourceTweetId, null);
+    assert.equal(result.articleLocator, null);
+  }
+
+  const valid = hydrateCanonicalBookmark(archived({
+    articleText: 'Explicitly source-bound archived article body.',
+    articleSourceTweetId: ROOT,
+    articleLocator: ARTICLE,
+  }), null);
+  assert.equal(valid.articleText, 'Explicitly source-bound archived article body.');
+  assert.equal(valid.articleSourceTweetId, ROOT);
+  assert.equal(valid.articleLocator, ARTICLE);
+});

--- a/tests/bookmarks-db.test.ts
+++ b/tests/bookmarks-db.test.ts
@@ -82,6 +82,67 @@ test('buildIndex refreshes existing rows without dropping classifications', asyn
   });
 });
 
+test('buildIndex writes named fields correctly after a direct pre-folder schema migration', async () => {
+  const articleLocator = 'https://x.com/i/article/1234567890123456789';
+  const fixture = {
+    ...FIXTURES[0],
+    links: [articleLocator],
+    folderIds: ['folder-1'],
+    folderNames: ['Research'],
+    articleTitle: 'Bound article',
+    articleText: 'A source-bound article body retained through a legacy schema migration.',
+    articleSite: 'X Articles',
+    articleSourceTweetId: '1',
+    articleLocator,
+  };
+
+  await withIsolatedDataDir(async () => {
+    const dbPath = twitterBookmarksIndexPath();
+    const legacyDb = await openDb(dbPath);
+    try {
+      legacyDb.run(`CREATE TABLE bookmarks (
+        id TEXT PRIMARY KEY, tweet_id TEXT NOT NULL, url TEXT NOT NULL, text TEXT NOT NULL,
+        author_handle TEXT, author_name TEXT, author_profile_image_url TEXT, posted_at TEXT,
+        bookmarked_at TEXT, synced_at TEXT NOT NULL, conversation_id TEXT,
+        in_reply_to_status_id TEXT, quoted_status_id TEXT, language TEXT,
+        like_count INTEGER, repost_count INTEGER, reply_count INTEGER, quote_count INTEGER,
+        bookmark_count INTEGER, view_count INTEGER, media_count INTEGER DEFAULT 0,
+        link_count INTEGER DEFAULT 0, links_json TEXT, tags_json TEXT, ingested_via TEXT,
+        categories TEXT, primary_category TEXT, github_urls TEXT, domains TEXT,
+        primary_domain TEXT, quoted_tweet_json TEXT, article_title TEXT, article_text TEXT,
+        article_site TEXT, enriched_at TEXT
+      )`);
+      saveDb(legacyDb, dbPath);
+    } finally {
+      legacyDb.close();
+    }
+
+    await buildIndex();
+
+    const migratedDb = await openDb(dbPath);
+    try {
+      const columns = migratedDb.exec('PRAGMA table_info(bookmarks)')[0].values
+        .map((row) => String(row[1]));
+      assert.deepEqual(columns.slice(-4), [
+        'article_source_tweet_id',
+        'article_locator',
+        'folder_ids',
+        'folder_names',
+      ]);
+      const row = migratedDb.exec(
+        `SELECT folder_ids, folder_names, article_source_tweet_id, article_locator
+         FROM bookmarks WHERE id = '1'`,
+      )[0].values[0];
+      assert.deepEqual(JSON.parse(String(row[0])), ['folder-1']);
+      assert.deepEqual(JSON.parse(String(row[1])), ['Research']);
+      assert.equal(row[2], '1');
+      assert.equal(row[3], articleLocator);
+    } finally {
+      migratedDb.close();
+    }
+  }, [fixture]);
+});
+
 test('getBookmarkById and listBookmarks hydrate quoted tweets', async () => {
   const fixtures = [{
     ...FIXTURES[0],

--- a/tests/bookmarks-db.test.ts
+++ b/tests/bookmarks-db.test.ts
@@ -143,6 +143,47 @@ test('buildIndex writes named fields correctly after a direct pre-folder schema 
   }, [fixture]);
 });
 
+test('buildIndex admits raw article content only with explicit root and locator provenance', async () => {
+  const firstArticle = 'https://x.com/i/article/1234567890123456789';
+  const secondArticle = 'https://x.com/i/article/2234567890123456789';
+  const fixtures = [
+    {
+      ...FIXTURES[0],
+      id: '10', tweetId: '10', links: [firstArticle],
+      articleText: 'Missing source tweet.', articleSourceTweetId: null, articleLocator: firstArticle,
+    },
+    {
+      ...FIXTURES[0],
+      id: '11', tweetId: '11', links: [firstArticle],
+      articleText: 'Missing source locator.', articleSourceTweetId: '11', articleLocator: null,
+    },
+    {
+      ...FIXTURES[0],
+      id: '12', tweetId: '12', links: [firstArticle, secondArticle],
+      articleText: 'Ambiguous source locator.', articleSourceTweetId: '12', articleLocator: null,
+    },
+    {
+      ...FIXTURES[0],
+      id: '13', tweetId: '13', links: [firstArticle],
+      articleText: 'Explicitly bound raw article.', articleSourceTweetId: '13', articleLocator: firstArticle,
+    },
+  ];
+
+  await withIsolatedDataDir(async () => {
+    await buildIndex();
+    for (const id of ['10', '11', '12']) {
+      const invalid = await getBookmarkById(id);
+      assert.equal(invalid?.articleText, null);
+      assert.equal(invalid?.articleSourceTweetId, null);
+      assert.equal(invalid?.articleLocator, null);
+    }
+    const valid = await getBookmarkById('13');
+    assert.equal(valid?.articleText, 'Explicitly bound raw article.');
+    assert.equal(valid?.articleSourceTweetId, '13');
+    assert.equal(valid?.articleLocator, firstArticle);
+  }, fixtures);
+});
+
 test('getBookmarkById and listBookmarks hydrate quoted tweets', async () => {
   const fixtures = [{
     ...FIXTURES[0],

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -880,6 +880,18 @@ test('ft sync: media is on by default and exposes --no-media', () => {
   assert.equal(mediaOption.long, '--no-media');
 });
 
+test('ft materialize exposes one exact-id bounded source-depth operation', () => {
+  const program = buildCli();
+  const command = program.commands.find((candidate: any) => candidate.name() === 'materialize');
+  assert.ok(command, 'materialize command should be registered');
+  const options = command.options.map((option: any) => option.long);
+  assert.ok(options.includes('--refresh'));
+  assert.ok(options.includes('--fetch-media'));
+  assert.ok(options.includes('--json'));
+  assert.ok(!options.includes('--classify'));
+  assert.ok(!options.includes('--engine'));
+});
+
 test('ft wiki: description mentions engine prerequisite', () => {
   const program = buildCli();
   const wikiCmd = program.commands.find((c: any) => c.name() === 'wiki');

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -6,6 +6,7 @@ import os from 'node:os';
 import { compareVersions, runWithSpinner, buildCli, parseCookieOption, shouldInferStdinFromStats } from '../src/cli.js';
 import { dataDir } from '../src/paths.js';
 import { skillWithFrontmatter } from '../src/skill.js';
+import { buildIndex, updateArticleContent, updateQuotedTweets } from '../src/bookmarks-db.js';
 
 async function captureStdout(fn: () => Promise<void>): Promise<string> {
   const chunks: string[] = [];
@@ -890,6 +891,58 @@ test('ft materialize exposes one exact-id bounded source-depth operation', () =>
   assert.ok(options.includes('--json'));
   assert.ok(!options.includes('--classify'));
   assert.ok(!options.includes('--engine'));
+});
+
+test('ft materialize overlays article and quote enrichment retained in the bookmark index', async () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ft-materialize-index-'));
+  const origEnv = process.env.FT_DATA_DIR;
+  process.env.FT_DATA_DIR = tmpDir;
+  const id = '2042685676949270724';
+  const raw = {
+    id,
+    tweetId: id,
+    url: `https://x.com/operator/status/${id}`,
+    text: 'Archived root.',
+    authorHandle: 'operator',
+    syncedAt: '2026-08-11T00:00:00.000Z',
+    quotedStatusId: '2042685676949270000',
+    links: ['https://x.com/i/article/2042676487711584257'],
+  };
+  fs.writeFileSync(path.join(tmpDir, 'bookmarks.jsonl'), `${JSON.stringify(raw)}\n`);
+
+  try {
+    await buildIndex();
+    await updateArticleContent([{
+      id,
+      articleTitle: 'Indexed article',
+      articleText: 'Exact long-form content retained only in the SQLite index.',
+      articleSite: 'X Articles',
+    }]);
+    await updateQuotedTweets([{
+      id,
+      quotedTweet: {
+        id: '2042685676949270000',
+        text: 'Indexed quoted source.',
+        url: 'https://x.com/quoted/status/2042685676949270000',
+      },
+    }]);
+
+    const output = await captureStdout(async () => {
+      await buildCli().parseAsync(['node', 'ft', 'materialize', id, '--json']);
+    });
+    const result = JSON.parse(output);
+    assert.equal(
+      result.components.find((row: any) => row.relation === 'embedded_x_article')?.content,
+      'Exact long-form content retained only in the SQLite index.',
+    );
+    assert.equal(
+      result.components.find((row: any) => row.relation === 'quoted_post')?.content,
+      'Indexed quoted source.',
+    );
+  } finally {
+    process.env.FT_DATA_DIR = origEnv;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
 });
 
 test('ft wiki: description mentions engine prerequisite', () => {

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -27,6 +27,18 @@ async function captureStdout(fn: () => Promise<void>): Promise<string> {
   return chunks.join('');
 }
 
+async function captureConsoleLog(fn: () => Promise<void>): Promise<string> {
+  const chunks: string[] = [];
+  const originalLog = console.log;
+  console.log = (...values: unknown[]) => { chunks.push(values.map(String).join(' ')); };
+  try {
+    await fn();
+  } finally {
+    console.log = originalLog;
+  }
+  return chunks.join('\n');
+}
+
 async function captureStderr(fn: () => Promise<void>): Promise<string> {
   const chunks: string[] = [];
   const origWrite = process.stderr.write;
@@ -1038,6 +1050,133 @@ test('ft materialize --refresh retains indexed article content when the current 
     assert.equal(article?.disposition, 'used');
     assert.equal(currentness?.disposition, 'unresolved');
     assert.equal(JSON.parse(currentness?.content ?? '{}').article_status, 'unresolved');
+  } finally {
+    globalThis.fetch = originalFetch;
+    process.env.FT_DATA_DIR = origEnv;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test('ft materialize shares one configured request schedule across refresh and media attempts', async () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ft-materialize-request-policy-'));
+  const origEnv = process.env.FT_DATA_DIR;
+  const originalFetch = globalThis.fetch;
+  process.env.FT_DATA_DIR = tmpDir;
+  const id = '2042685676949270724';
+  const mediaUrl = 'https://pbs.twimg.com/media/exact-policy.jpg';
+  fs.writeFileSync(path.join(tmpDir, 'bookmarks.jsonl'), `${JSON.stringify({
+    id,
+    tweetId: id,
+    url: `https://x.com/operator/status/${id}`,
+    text: 'Archived root.',
+    authorHandle: 'operator',
+    syncedAt: '2026-08-11T00:00:00.000Z',
+    mediaObjects: [{ type: 'photo', url: mediaUrl }],
+    links: [],
+  })}\n`);
+
+  const focal = {
+    rest_id: id,
+    legacy: {
+      id_str: id,
+      full_text: 'Current root.',
+      created_at: 'Tue Aug 11 12:00:00 +0000 2026',
+      conversation_id_str: id,
+      entities: { urls: [] },
+      extended_entities: { media: [{ type: 'photo', media_url_https: mediaUrl }] },
+    },
+    core: {
+      user_results: {
+        result: {
+          rest_id: '1',
+          core: { screen_name: 'operator', name: 'Operator' },
+          legacy: {},
+        },
+      },
+    },
+  };
+  const attemptTimes: number[] = [];
+  const methods: string[] = [];
+  globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+    attemptTimes.push(Date.now());
+    methods.push(init?.method ?? 'GET');
+    const url = String(input);
+    if (url === mediaUrl && init?.method === 'HEAD') {
+      return new Response(null, {
+        status: 200,
+        headers: { 'content-length': '4', 'content-type': 'image/jpeg' },
+      });
+    }
+    if (url === mediaUrl) {
+      return new Response(Uint8Array.from([1, 2, 3, 4]), {
+        status: 200,
+        headers: { 'content-type': 'image/jpeg' },
+      });
+    }
+    const body = url.includes('/TweetResultByRestId?')
+      ? { data: { tweetResult: { result: focal } } }
+      : {
+          data: {
+            threaded_conversation_with_injections_v2: {
+              instructions: [{
+                type: 'TimelineAddEntries',
+                entries: [{
+                  entryId: `tweet-${id}`,
+                  content: { itemContent: { tweet_results: { result: focal } } },
+                }],
+              }],
+            },
+          },
+        };
+    return new Response(JSON.stringify(body), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
+  }) as typeof fetch;
+
+  try {
+    const output = await captureConsoleLog(async () => {
+      await buildCli().parseAsync([
+        'node',
+        'ft',
+        'materialize',
+        id,
+        '--refresh',
+        '--fetch-media',
+        '--skip-profile-images',
+        '--cookies',
+        'ct0',
+        '--delay-ms',
+        '20',
+        '--json',
+      ]);
+    });
+    const result = JSON.parse(output);
+    assert.equal(result.components.some((row: any) => row.relation === 'post_attached_media' && row.disposition === 'used'), true);
+    assert.deepEqual(methods, ['GET', 'GET', 'HEAD', 'GET']);
+    assert.equal(attemptTimes.length, 4);
+    for (let index = 1; index < attemptTimes.length; index++) {
+      assert.ok(attemptTimes[index] - attemptTimes[index - 1] >= 15);
+    }
+
+    const zeroDelayStart = attemptTimes.length;
+    await captureConsoleLog(async () => {
+      await buildCli().parseAsync([
+        'node',
+        'ft',
+        'materialize',
+        id,
+        '--refresh',
+        '--cookies',
+        'ct0',
+        '--delay-ms',
+        '0',
+        '--json',
+      ]);
+    });
+    const zeroDelayAttempts = attemptTimes.slice(zeroDelayStart);
+    assert.equal(zeroDelayAttempts.length, 2);
+    assert.ok(zeroDelayAttempts[1] - zeroDelayAttempts[0] < 200);
   } finally {
     globalThis.fetch = originalFetch;
     process.env.FT_DATA_DIR = origEnv;

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -947,6 +947,104 @@ test('ft materialize overlays article and quote enrichment retained in the bookm
   }
 });
 
+test('ft materialize --refresh retains indexed article content when the current focal response does not contradict it', async () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ft-materialize-refresh-index-'));
+  const origEnv = process.env.FT_DATA_DIR;
+  const originalFetch = globalThis.fetch;
+  process.env.FT_DATA_DIR = tmpDir;
+  const id = '2042685676949270724';
+  const articleLocator = 'https://x.com/i/article/2042676487711584257';
+  fs.writeFileSync(path.join(tmpDir, 'bookmarks.jsonl'), `${JSON.stringify({
+    id,
+    tweetId: id,
+    url: `https://x.com/operator/status/${id}`,
+    text: 'Archived root.',
+    authorHandle: 'operator',
+    syncedAt: '2026-08-11T00:00:00.000Z',
+    links: [articleLocator],
+  })}\n`);
+
+  const focal = {
+    rest_id: id,
+    legacy: {
+      id_str: id,
+      full_text: 'Current root.',
+      created_at: 'Tue Aug 11 12:00:00 +0000 2026',
+      conversation_id_str: id,
+      entities: { urls: [] },
+    },
+    core: {
+      user_results: {
+        result: {
+          rest_id: '1',
+          core: { screen_name: 'operator', name: 'Operator' },
+          legacy: {},
+        },
+      },
+    },
+  };
+  globalThis.fetch = (async (input: string | URL | Request) => {
+    const url = String(input);
+    const body = url.includes('/TweetResultByRestId?')
+      ? { data: { tweetResult: { result: focal } } }
+      : {
+          data: {
+            threaded_conversation_with_injections_v2: {
+              instructions: [{
+                type: 'TimelineAddEntries',
+                entries: [{
+                  entryId: `tweet-${id}`,
+                  content: { itemContent: { tweet_results: { result: focal } } },
+                }],
+              }],
+            },
+          },
+        };
+    return new Response(JSON.stringify(body), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
+  }) as typeof fetch;
+
+  try {
+    await buildIndex();
+    await updateArticleContent([{
+      id,
+      sourceTweetId: id,
+      sourceLocator: articleLocator,
+      articleTitle: 'Indexed article',
+      articleText: 'Legitimate bound article content retained through refresh.',
+      articleSite: 'X Articles',
+    }]);
+
+    const output = await captureStdout(async () => {
+      await buildCli().parseAsync([
+        'node',
+        'ft',
+        'materialize',
+        id,
+        '--refresh',
+        '--cookies',
+        'ct0',
+        '--delay-ms',
+        '1',
+        '--json',
+      ]);
+    });
+    const result = JSON.parse(output);
+    const article = result.components.find((row: any) => row.relation === 'embedded_x_article');
+    const currentness = result.components.find((row: any) => row.relation === 'source_currentness');
+    assert.equal(article?.content, 'Legitimate bound article content retained through refresh.');
+    assert.equal(article?.disposition, 'used');
+    assert.equal(currentness?.disposition, 'unresolved');
+    assert.equal(JSON.parse(currentness?.content ?? '{}').article_status, 'unresolved');
+  } finally {
+    globalThis.fetch = originalFetch;
+    process.env.FT_DATA_DIR = origEnv;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
 test('ft materialize never lets a stale index replace newer archive identity or content', async () => {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ft-materialize-stale-index-'));
   const origEnv = process.env.FT_DATA_DIR;

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -959,6 +959,50 @@ test('ft materialize overlays article and quote enrichment retained in the bookm
   }
 });
 
+test('ft materialize keeps indexed ordinary webpage content search-only and outbound', async () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ft-materialize-ordinary-index-'));
+  const origEnv = process.env.FT_DATA_DIR;
+  process.env.FT_DATA_DIR = tmpDir;
+  const id = '2042685676949270724';
+  const externalArticle = 'https://example.com/article';
+  const externalBody = 'Destination-owned body retained only for index search.';
+  fs.writeFileSync(path.join(tmpDir, 'bookmarks.jsonl'), `${JSON.stringify({
+    id,
+    tweetId: id,
+    url: `https://x.com/operator/status/${id}`,
+    text: 'Archived root.',
+    authorHandle: 'operator',
+    syncedAt: '2026-08-11T00:00:00.000Z',
+    links: [externalArticle],
+  })}\n`);
+
+  try {
+    await buildIndex();
+    await updateArticleContent([{
+      id,
+      sourceTweetId: id,
+      sourceLocator: externalArticle,
+      articleTitle: 'Ordinary indexed article',
+      articleText: externalBody,
+      articleSite: 'Example',
+    }]);
+
+    const output = await captureStdout(async () => {
+      await buildCli().parseAsync(['node', 'ft', 'materialize', id, '--json']);
+    });
+    const result = JSON.parse(output);
+    const outbound = result.components.find((row: any) => row.source_locator === externalArticle);
+    assert.equal(outbound?.relation, 'post_outbound_link');
+    assert.equal(outbound?.disposition, 'unresolved');
+    assert.equal(result.components.some((row: any) => row.relation === 'embedded_x_article'), false);
+    assert.equal(JSON.stringify(result).includes(externalBody), false);
+    assert.equal(result.source_cutoff, '2026-08-11T00:00:00.000Z');
+  } finally {
+    process.env.FT_DATA_DIR = origEnv;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
 test('ft materialize --refresh retains indexed article content when the current focal response does not contradict it', async () => {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ft-materialize-refresh-index-'));
   const origEnv = process.env.FT_DATA_DIR;

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -914,6 +914,8 @@ test('ft materialize overlays article and quote enrichment retained in the bookm
     await buildIndex();
     await updateArticleContent([{
       id,
+      sourceTweetId: id,
+      sourceLocator: 'https://x.com/i/article/2042676487711584257',
       articleTitle: 'Indexed article',
       articleText: 'Exact long-form content retained only in the SQLite index.',
       articleSite: 'X Articles',
@@ -939,6 +941,67 @@ test('ft materialize overlays article and quote enrichment retained in the bookm
       result.components.find((row: any) => row.relation === 'quoted_post')?.content,
       'Indexed quoted source.',
     );
+  } finally {
+    process.env.FT_DATA_DIR = origEnv;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test('ft materialize never lets a stale index replace newer archive identity or content', async () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ft-materialize-stale-index-'));
+  const origEnv = process.env.FT_DATA_DIR;
+  process.env.FT_DATA_DIR = tmpDir;
+  const id = '2042685676949270724';
+  const oldQuote = '2042685676949270000';
+  const newQuote = '2042685676949270001';
+  const oldArticle = 'https://x.com/i/article/2042676487711584257';
+  const newArticle = 'https://x.com/i/article/2042676487711584258';
+  const old = {
+    id,
+    tweetId: id,
+    url: `https://x.com/operator/status/${id}`,
+    text: 'Old archived root.',
+    authorHandle: 'operator',
+    syncedAt: '2026-08-10T00:00:00.000Z',
+    quotedStatusId: oldQuote,
+    links: [oldArticle],
+  };
+  fs.writeFileSync(path.join(tmpDir, 'bookmarks.jsonl'), `${JSON.stringify(old)}\n`);
+
+  try {
+    await buildIndex();
+    await updateArticleContent([{
+      id,
+      sourceTweetId: id,
+      sourceLocator: oldArticle,
+      articleTitle: 'Old indexed article',
+      articleText: 'Old indexed article body.',
+    }]);
+    await updateQuotedTweets([{
+      id,
+      quotedTweet: {
+        id: oldQuote,
+        text: 'Old indexed quote.',
+        url: `https://x.com/quoted/status/${oldQuote}`,
+      },
+    }]);
+    fs.writeFileSync(path.join(tmpDir, 'bookmarks.jsonl'), `${JSON.stringify({
+      ...old,
+      text: 'New archive-owned root.',
+      syncedAt: '2026-08-11T00:00:00.000Z',
+      quotedStatusId: newQuote,
+      links: [newArticle],
+    })}\n`);
+
+    const output = await captureStdout(async () => {
+      await buildCli().parseAsync(['node', 'ft', 'materialize', id, '--json']);
+    });
+    const result = JSON.parse(output);
+    assert.equal(result.components.find((row: any) => row.relation === 'root_post')?.content, 'New archive-owned root.');
+    assert.equal(result.source_cutoff, '2026-08-11T00:00:00.000Z');
+    assert.equal(result.components.find((row: any) => row.relation === 'quoted_post')?.source_locator, `https://x.com/i/status/${newQuote}`);
+    assert.equal(result.components.some((row: any) => row.content === 'Old indexed quote.'), false);
+    assert.equal(result.components.some((row: any) => row.content === 'Old indexed article body.'), false);
   } finally {
     process.env.FT_DATA_DIR = origEnv;
     fs.rmSync(tmpDir, { recursive: true, force: true });

--- a/tests/graphql-bookmarks.test.ts
+++ b/tests/graphql-bookmarks.test.ts
@@ -1172,6 +1172,44 @@ test('syncGaps: permanent quoted-tweet failure stamps quotedTweetFailedAt so rer
   }, [deadQuoted]);
 });
 
+test('syncGaps rejects a quote response whose owned identity differs from the requested id', async () => {
+  const quoted: BookmarkRecord = {
+    id: '222',
+    tweetId: '222',
+    url: 'https://x.com/user/status/222',
+    text: 'Check out this tweet',
+    syncedAt: NOW,
+    tags: [],
+    ingestedVia: 'graphql',
+    quotedStatusId: '999999999',
+  };
+
+  await withIsolatedGapFillDataDir(async () => {
+    await buildIndex();
+    const result = await syncGaps({
+      tweetFetcher: async () => ({
+        snapshot: {
+          id: '111111111',
+          text: 'Wrong quoted entity.',
+          url: 'https://x.com/wrong/status/111111111',
+        },
+        status: 'ok',
+        source: 'syndication',
+      }),
+    });
+
+    assert.equal(result.quotedTweetsFilled, 0);
+    assert.equal(result.failed, 1);
+    assert.match(result.failures[0].reason, /did not bind to the requested tweet identity/);
+
+    const jsonl = await readFile(path.join(process.env.FT_DATA_DIR!, 'bookmarks.jsonl'), 'utf8');
+    const stored = JSON.parse(jsonl.trim());
+    assert.equal(stored.quotedTweet, undefined);
+    assert.equal(stored.quotedTweetFailedAt, undefined);
+    assert.equal((await getBookmarkById(quoted.id))?.quotedTweet, null);
+  }, [quoted]);
+});
+
 test('parseBookmarksResponse: preserves sortIndex for bookmark ordering without fabricating bookmarkedAt', () => {
   const tr = makeTweetResult();
   const resp = {

--- a/tests/graphql-bookmarks.test.ts
+++ b/tests/graphql-bookmarks.test.ts
@@ -455,6 +455,7 @@ test('parseTweetArticleByRestId: extracts X Article rich-text content', () => {
           legacy: {
             id_str: '2042685676949270724',
             full_text: 'x.com/i/article/2042...',
+            entities: { urls: [{ expanded_url: 'https://x.com/i/article/2042676487711584257' }] },
           },
           article_results: {
             result: {
@@ -473,6 +474,8 @@ test('parseTweetArticleByRestId: extracts X Article rich-text content', () => {
   const article = parseTweetArticleByRestId(fixture);
   assert.ok(article);
   assert.equal(article.title, 'How agents should use context');
+  assert.equal(article.sourceTweetId, '2042685676949270724');
+  assert.equal(article.sourceLocator, 'https://x.com/i/article/2042676487711584257');
   assert.match(article.text, /Context discipline/);
   assert.match(article.text, /useful body lives in the X Article payload/);
 });
@@ -486,6 +489,7 @@ test('parseTweetArticleByRestId: extracts current X Article content_state shape'
           legacy: {
             id_str: '2045577435484221722',
             full_text: 'x.com/i/article/2045...',
+            entities: { urls: [{ expanded_url: 'https://x.com/i/article/2045577000000000000' }] },
           },
           article: {
             article_results: {
@@ -522,9 +526,45 @@ test('parseTweetArticleByRestId: rejects preview-only X Article payloads', () =>
           article: {
             article_results: {
               result: {
-                title: 'Preview is not the article',
+              title: 'Preview is not the article',
                 preview_text: 'This preview is deliberately longer than fifty characters but is not a recovered article body.',
                 summary_text: 'This summary is also not source-complete long-form content.',
+              },
+            },
+          },
+          legacy: {
+            id_str: '2045577435484221722',
+            full_text: 'x.com/i/article/2045...',
+            entities: { urls: [{ expanded_url: 'https://x.com/i/article/2045577000000000000' }] },
+          },
+        },
+      },
+    },
+  };
+
+  assert.equal(parseTweetArticleByRestId(fixture), null);
+});
+
+test('parseTweetArticleByRestId never attaches a quoted tweet article to the focal tweet', () => {
+  const fixture = {
+    data: {
+      tweetResult: {
+        result: {
+          rest_id: '100',
+          legacy: { id_str: '100', full_text: 'Root quoting an article.', entities: { urls: [] } },
+          quoted_status_result: {
+            result: {
+              rest_id: '200',
+              legacy: {
+                id_str: '200',
+                full_text: 'Quoted article.',
+                entities: { urls: [{ expanded_url: 'https://x.com/i/article/300' }] },
+              },
+              article_results: {
+                result: {
+                  title: 'Quoted article',
+                  articleBody: 'This is a sufficiently long quoted article body that must never bind to the focal root.',
+                },
               },
             },
           },
@@ -533,7 +573,7 @@ test('parseTweetArticleByRestId: rejects preview-only X Article payloads', () =>
     },
   };
 
-  assert.equal(parseTweetArticleByRestId(fixture), null);
+  assert.equal(parseTweetArticleByRestId(fixture, '100'), null);
 });
 
 test('parseTweetResultByRestId: returns null on tombstone / unavailable tweets', () => {
@@ -574,6 +614,8 @@ test('syncGaps: enriches X Article bookmarks through TweetResult payload', async
             title: 'How agents should use context',
             text: 'The article body is the useful content. It should not be lost behind an X Article link.',
             siteName: 'X Articles',
+            sourceTweetId: tweetId,
+            sourceLocator: 'https://x.com/i/article/2042676487711584257',
           },
           status: 'ok',
           source: 'graphql',
@@ -633,6 +675,39 @@ test('syncGaps: reports X Article when fallback only returns tweet preview', asy
     const refreshed = await getBookmarkById('2042685676949270724');
     assert.ok(refreshed);
     assert.equal(refreshed.articleText, null);
+  }, [xArticle]);
+});
+
+test('syncGaps: refuses to persist an article bound to a quoted or unrelated tweet', async () => {
+  const xArticle: BookmarkRecord = {
+    id: '2042685676949270724',
+    tweetId: '2042685676949270724',
+    url: 'https://x.com/danveloper/status/2042685676949270724',
+    text: 'x.com/i/article/2042...',
+    syncedAt: NOW,
+    links: ['https://x.com/i/article/2042676487711584257'],
+  };
+
+  await withIsolatedGapFillDataDir(async () => {
+    await buildIndex();
+    const result = await syncGaps({
+      tweetFetcher: async (tweetId) => ({
+        snapshot: { id: tweetId, text: xArticle.text, url: xArticle.url },
+        article: {
+          title: 'Quoted article',
+          text: 'This body belongs to a quoted tweet and must not be stored under the focal bookmark.',
+          sourceTweetId: '2042685676949270000',
+          sourceLocator: 'https://x.com/i/article/2042676487711584257',
+        },
+        status: 'ok',
+        source: 'graphql',
+      }),
+    });
+
+    assert.equal(result.articlesEnriched, 0);
+    assert.equal(result.failed, 1);
+    assert.match(result.failures[0].reason, /did not bind/);
+    assert.equal((await getBookmarkById(xArticle.id))?.articleText, null);
   }, [xArticle]);
 });
 

--- a/tests/graphql-bookmarks.test.ts
+++ b/tests/graphql-bookmarks.test.ts
@@ -513,6 +513,29 @@ test('parseTweetArticleByRestId: extracts current X Article content_state shape'
   assert.match(article.text, /components, styles, variables, and props/);
 });
 
+test('parseTweetArticleByRestId: rejects preview-only X Article payloads', () => {
+  const fixture = {
+    data: {
+      tweetResult: {
+        result: {
+          rest_id: '2045577435484221722',
+          article: {
+            article_results: {
+              result: {
+                title: 'Preview is not the article',
+                preview_text: 'This preview is deliberately longer than fifty characters but is not a recovered article body.',
+                summary_text: 'This summary is also not source-complete long-form content.',
+              },
+            },
+          },
+        },
+      },
+    },
+  };
+
+  assert.equal(parseTweetArticleByRestId(fixture), null);
+});
+
 test('parseTweetResultByRestId: returns null on tombstone / unavailable tweets', () => {
   assert.equal(
     parseTweetResultByRestId({ data: { tweetResult: { result: { __typename: 'TweetTombstone' } } } }, '123'),

--- a/tests/graphql-bookmarks.test.ts
+++ b/tests/graphql-bookmarks.test.ts
@@ -21,7 +21,8 @@ import {
   syncBookmarksGraphQL,
   syncGaps,
 } from '../src/graphql-bookmarks.js';
-import { buildIndex, getBookmarkById } from '../src/bookmarks-db.js';
+import { buildIndex, getBookmarkById, updateArticleContent } from '../src/bookmarks-db.js';
+import { loadCanonicalBookmarkSnapshot } from '../src/bookmark-snapshot.js';
 import { resolveFolder, formatFolderMirrorStats } from '../src/cli.js';
 import type { BookmarkFolder, BookmarkRecord } from '../src/types.js';
 
@@ -709,6 +710,68 @@ test('syncGaps: refuses to persist an article bound to a quoted or unrelated twe
     assert.match(result.failures[0].reason, /did not bind/);
     assert.equal((await getBookmarkById(xArticle.id))?.articleText, null);
   }, [xArticle]);
+});
+
+test('syncGaps repairs redirect-resolved article rows with the archive-owned source locator', async () => {
+  const shortUrl = 'https://t.co/source-link';
+  const finalUrl = 'https://example.com/final-article';
+  const linkOnly: BookmarkRecord = {
+    id: '2042685676949270800',
+    tweetId: '2042685676949270800',
+    url: 'https://x.com/operator/status/2042685676949270800',
+    text: `Read ${shortUrl}`,
+    syncedAt: NOW,
+    links: [shortUrl],
+  };
+  const originalFetch = globalThis.fetch;
+
+  try {
+    await withIsolatedGapFillDataDir(async () => {
+      await buildIndex();
+      await updateArticleContent([{
+        id: linkOnly.id,
+        sourceTweetId: linkOnly.tweetId,
+        sourceLocator: finalUrl,
+        articleTitle: 'Stranded redirect article',
+        articleText: 'This legacy body is stranded because its final fetch URL is not the archived source locator.',
+      }]);
+
+      let fetchCalls = 0;
+      globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+        fetchCalls += 1;
+        const url = String(input);
+        if (url === shortUrl && init?.method === 'HEAD') {
+          return new Response(null, { status: 302, headers: { location: finalUrl } });
+        }
+        if (url === finalUrl && init?.method === 'HEAD') {
+          return new Response(null, { status: 200 });
+        }
+        assert.equal(url, finalUrl);
+        assert.equal(init?.method, 'GET');
+        return new Response(
+          '<html><title>Recovered</title><article>This redirected article body is long enough to be admitted and rebound to its archived source locator.</article></html>',
+          { status: 200, headers: { 'content-type': 'text/html' } },
+        );
+      }) as typeof fetch;
+
+      const repaired = await syncGaps({ tweetFetcher: async () => ({ snapshot: null, status: 'empty' }) });
+      assert.equal(repaired.articlesEnriched, 1);
+      assert.equal(fetchCalls, 3);
+      const hydrated = await getBookmarkById(linkOnly.id);
+      assert.equal(hydrated?.articleLocator, shortUrl);
+      assert.match(hydrated?.articleText ?? '', /redirected article body/);
+      const canonical = await loadCanonicalBookmarkSnapshot(linkOnly.tweetId);
+      assert.equal(canonical.record.articleLocator, shortUrl);
+      assert.match(canonical.record.articleText ?? '', /redirected article body/);
+
+      fetchCalls = 0;
+      const settled = await syncGaps({ tweetFetcher: async () => ({ snapshot: null, status: 'empty' }) });
+      assert.equal(settled.articlesEnriched, 0);
+      assert.equal(fetchCalls, 0);
+    }, [linkOnly]);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
 });
 
 async function withIsolatedGapFillDataDir(

--- a/tests/graphql-bookmarks.test.ts
+++ b/tests/graphql-bookmarks.test.ts
@@ -447,6 +447,81 @@ test('parseTweetResultByRestId: extracts note_tweet body from live TweetResultBy
   assert.ok(snapshot.text.startsWith('LLM Knowledge Bases'));
 });
 
+test('parseTweetResultByRestId preserves the focal tweet live quote identity', () => {
+  const row = makeTweetResult({ legacy: { quoted_status_id_str: '5555555' } });
+  const snapshot = parseTweetResultByRestId({
+    data: { tweetResult: { result: row } },
+  }, '1234567890');
+
+  assert.equal(snapshot?.quotedStatusId, '5555555');
+});
+
+test('parseTweetResultByRestId uses an exact wrapped quoted-result identity as fallback', () => {
+  const row = makeTweetResult({
+    tweet: {
+      quoted_status_result: {
+        result: {
+          tweet: {
+            rest_id: '5555555',
+            legacy: { id_str: '5555555', full_text: 'Embedded quote.' },
+          },
+        },
+      },
+    },
+  });
+  const snapshot = parseTweetResultByRestId({
+    data: { tweetResult: { result: row } },
+  }, '1234567890');
+
+  assert.equal(snapshot?.quotedStatusId, '5555555');
+});
+
+test('parseTweetResultByRestId rejects contradictory or malformed quote identity', () => {
+  for (const row of [
+    makeTweetResult({
+      legacy: { quoted_status_id_str: '5555555' },
+      tweet: { quoted_status_result: { result: { rest_id: '6666666' } } },
+    }),
+    makeTweetResult({ legacy: { quoted_status_id_str: 5555555 } }),
+    makeTweetResult({
+      tweet: {
+        quoted_status_result: {
+          result: { rest_id: '6666666', legacy: { id_str: '5555555' } },
+        },
+      },
+    }),
+  ]) {
+    assert.equal(parseTweetResultByRestId({
+      data: { tweetResult: { result: row } },
+    }, '1234567890'), null);
+  }
+});
+
+test('parseTweetResultByRestId rejects malformed or contradictory focal identity aliases', () => {
+  for (const row of [
+    makeTweetResult({ tweet: { rest_id: '9999999999' } }),
+    makeTweetResult({ legacy: { id_str: 1234567890 } }),
+    makeTweetResult({ tweet: { rest_id: 1234567890 } }),
+  ]) {
+    assert.equal(parseTweetResultByRestId({
+      data: { tweetResult: { result: row } },
+    }, '1234567890'), null);
+  }
+});
+
+test('parseTweetResultByRestId preserves the focal root when quote identity is unavailable', () => {
+  const row = makeTweetResult({
+    tweet: { quoted_status_result: { result: { __typename: 'TweetTombstone' } } },
+  });
+  const snapshot = parseTweetResultByRestId({
+    data: { tweetResult: { result: row } },
+  }, '1234567890');
+
+  assert.equal(snapshot?.id, '1234567890');
+  assert.equal(snapshot?.quotedStatusId, undefined);
+  assert.equal(snapshot?.quotedStatusIdentityUnresolved, true);
+});
+
 test('parseTweetArticleByRestId: extracts X Article rich-text content', () => {
   const fixture = {
     data: {
@@ -516,6 +591,62 @@ test('parseTweetArticleByRestId: extracts current X Article content_state shape'
   assert.equal(article.title, 'Thoughts and Feelings around Claude Design');
   assert.match(article.text, /I tried Claude Design yesterday/);
   assert.match(article.text, /components, styles, variables, and props/);
+});
+
+test('parseTweetArticleByRestId rejects malformed, contradictory, or locator-crossing exact IDs', () => {
+  const articleBody = 'This recovered article body is deliberately long enough to pass the source body threshold.';
+  for (const candidate of [
+    { rest_id: 2042676487711584257, articleBody },
+    { rest_id: '2042676487711584257', article_id: '2042676487711584258', articleBody },
+    { rest_id: '2042676487711584257', articleBody },
+  ]) {
+    const articleLink = candidate.rest_id === '2042676487711584257' && candidate.article_id === undefined
+      ? 'https://x.com/i/article/2042676487711584258'
+      : 'https://x.com/i/article/2042676487711584257';
+    const fixture = {
+      data: {
+        tweetResult: {
+          result: {
+            rest_id: '100',
+            legacy: {
+              id_str: '100',
+              full_text: 'Focal article post.',
+              entities: { urls: [{ expanded_url: articleLink }] },
+            },
+            article_results: { result: candidate },
+          },
+        },
+      },
+    };
+    assert.equal(parseTweetArticleByRestId(fixture, '100'), null);
+  }
+});
+
+test('parseTweetArticleByRestId accepts agreeing exact article aliases bound to the focal locator', () => {
+  const articleId = '2042676487711584257';
+  const fixture = {
+    data: {
+      tweetResult: {
+        result: {
+          rest_id: '100',
+          legacy: {
+            id_str: '100',
+            full_text: 'Focal article post.',
+            entities: { urls: [{ expanded_url: `https://x.com/i/article/${articleId}` }] },
+          },
+          article_results: {
+            result: {
+              rest_id: articleId,
+              article_id: articleId,
+              articleBody: 'This recovered article body has matching exact aliases and a matching focal locator.',
+            },
+          },
+        },
+      },
+    },
+  };
+
+  assert.equal(parseTweetArticleByRestId(fixture, '100')?.sourceLocator, `https://x.com/i/article/${articleId}`);
 });
 
 test('parseTweetArticleByRestId: rejects preview-only X Article payloads', () => {

--- a/tests/graphql-bookmarks.test.ts
+++ b/tests/graphql-bookmarks.test.ts
@@ -18,6 +18,7 @@ import {
   applyFolderMirror,
   clearFolderEverywhere,
   formatSyncResult,
+  fetchTweetByIdViaGraphQL,
   syncBookmarksGraphQL,
   syncGaps,
 } from '../src/graphql-bookmarks.js';
@@ -29,6 +30,21 @@ import type { BookmarkFolder, BookmarkRecord } from '../src/types.js';
 const FIXTURES_DIR = path.join(path.dirname(fileURLToPath(import.meta.url)), 'fixtures');
 function loadFixture(name: string): any {
   return JSON.parse(readFileSync(path.join(FIXTURES_DIR, name), 'utf8'));
+}
+
+async function fetchTweetEvidenceFixture(tweetResult: any) {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (async () => new Response(JSON.stringify({
+    data: { tweetResult: { result: tweetResult } },
+  }), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  })) as typeof fetch;
+  try {
+    return await fetchTweetByIdViaGraphQL('100', 'ct0', undefined, { delayMs: 0 });
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
 }
 
 const NOW = '2026-03-28T00:00:00.000Z';
@@ -447,6 +463,29 @@ test('parseTweetResultByRestId: extracts note_tweet body from live TweetResultBy
   assert.ok(snapshot.text.startsWith('LLM Knowledge Bases'));
 });
 
+test('parseTweetResultByRestId preserves a response-owned media-only tweet with empty text', () => {
+  const row = makeTweetResult({ legacy: { full_text: '' } });
+  const snapshot = parseTweetResultByRestId({
+    data: { tweetResult: { result: row } },
+  }, '1234567890');
+
+  assert.equal(snapshot?.id, '1234567890');
+  assert.equal(snapshot?.text, '');
+  assert.deepEqual(snapshot?.media, ['https://pbs.twimg.com/media/example.jpg']);
+});
+
+test('parseTweetResultByRestId rejects an empty focal envelope with no response-owned content', () => {
+  for (const media of [[], {}, [null], [{}]]) {
+    const row = makeTweetResult({
+      legacy: { full_text: '', extended_entities: { media } },
+    });
+
+    assert.equal(parseTweetResultByRestId({
+      data: { tweetResult: { result: row } },
+    }, '1234567890'), null);
+  }
+});
+
 test('parseTweetResultByRestId preserves the focal tweet live quote identity', () => {
   const row = makeTweetResult({ legacy: { quoted_status_id_str: '5555555' } });
   const snapshot = parseTweetResultByRestId({
@@ -649,6 +688,126 @@ test('parseTweetArticleByRestId accepts agreeing exact article aliases bound to 
   assert.equal(parseTweetArticleByRestId(fixture, '100')?.sourceLocator, `https://x.com/i/article/${articleId}`);
 });
 
+test('TweetResult article evidence rejects conflicting focal envelopes independent of slot order', async () => {
+  const bodyA = 'This is the first complete focal article body and it is long enough to be source material.';
+  const bodyB = 'This is the second complete focal article body and it deliberately conflicts with the first.';
+  const candidates = [
+    { rest_id: '111', title: 'First', articleBody: bodyA },
+    { rest_id: '222', title: 'Second', articleBody: bodyB },
+  ];
+
+  for (const [first, second] of [candidates, [...candidates].reverse()]) {
+    const tweetResult = {
+      rest_id: '100',
+      legacy: {
+        id_str: '100',
+        full_text: 'Focal post with contradictory article envelopes.',
+        entities: {
+          urls: [
+            { expanded_url: 'https://x.com/i/article/111' },
+            { expanded_url: 'https://x.com/i/article/222' },
+          ],
+        },
+      },
+      article_results: { result: first },
+      article: { article_results: { result: second } },
+    };
+    const fetched = await fetchTweetEvidenceFixture(tweetResult);
+    assert.equal(fetched.status, 'ok');
+    assert.equal(fetched.articleStatus, 'invalid');
+    assert.equal(fetched.article, null);
+    assert.equal(parseTweetArticleByRestId({
+      data: { tweetResult: { result: tweetResult } },
+    }, '100'), null);
+  }
+});
+
+test('TweetResult article evidence resolves convergent focal envelopes deterministically', async () => {
+  const articleId = '111';
+  const body = 'Every complete focal article envelope contains this exact normalized source-owned body.';
+  const candidates = [
+    { rest_id: articleId, title: 'Agreed title', siteName: 'X Articles', articleBody: body },
+    { article_id: articleId, title: 'Different optional title', articleBody: body },
+  ];
+
+  for (const [first, second] of [candidates, [...candidates].reverse()]) {
+    const fetched = await fetchTweetEvidenceFixture({
+      rest_id: '100',
+      legacy: {
+        id_str: '100',
+        full_text: 'Focal post with convergent article envelopes.',
+        entities: { urls: [{ expanded_url: `https://x.com/i/article/${articleId}` }] },
+      },
+      article_results: { result: first },
+      article: {
+        article_results: { result: second },
+        result: null,
+      },
+    });
+    assert.equal(fetched.articleStatus, 'resolved');
+    assert.equal(fetched.article?.sourceLocator, `https://x.com/i/article/${articleId}`);
+    assert.equal(fetched.article?.text, body);
+    assert.equal(fetched.article?.title, '');
+    assert.equal(fetched.article?.siteName, 'X Articles');
+  }
+});
+
+test('TweetResult article evidence has explicit, exhaustive absence and ambiguity states', async () => {
+  const articleId = '111';
+  const articleLink = `https://x.com/i/article/${articleId}`;
+  const body = 'This complete focal article body is deliberately long enough for exact source admission.';
+  const valid = { rest_id: articleId, title: 'Resolved article', articleBody: body };
+  const preview = {
+    rest_id: articleId,
+    title: 'Resolved article',
+    preview_text: 'This is only a preview even though it is long enough to resemble recovered content.',
+  };
+  const cases: Array<{
+    name: string;
+    links?: string[];
+    fields?: Record<string, unknown>;
+    expected: 'absent' | 'resolved' | 'unresolved' | 'invalid';
+  }> = [
+    { name: 'no slots and no locator', expected: 'absent' },
+    { name: 'recognized null slot', fields: { article_results: { result: null } }, expected: 'absent' },
+    { name: 'locator without a body', links: [articleLink], expected: 'unresolved' },
+    { name: 'preview-only candidate', links: [articleLink], fields: { article_results: { result: preview } }, expected: 'unresolved' },
+    { name: 'exact candidate without focal locator', fields: { article_results: { result: valid } }, expected: 'resolved' },
+    { name: 'unknown non-null article shape', fields: { article: { unexpected: true } }, expected: 'unresolved' },
+    { name: 'valid plus null', links: [articleLink], fields: { article_results: { result: valid }, article: { result: null } }, expected: 'resolved' },
+    { name: 'valid plus same-identity preview', links: [articleLink], fields: { article_results: { result: valid }, article: { result: preview } }, expected: 'resolved' },
+    {
+      name: 'same identity with different full bodies',
+      links: [articleLink],
+      fields: {
+        article_results: { result: valid },
+        article: { result: { ...valid, articleBody: `${body} Conflicting edit.` } },
+      },
+      expected: 'invalid',
+    },
+    {
+      name: 'malformed numeric identity',
+      links: [articleLink],
+      fields: { article_results: { result: { ...valid, rest_id: 111 } } },
+      expected: 'invalid',
+    },
+  ];
+
+  for (const testCase of cases) {
+    const fetched = await fetchTweetEvidenceFixture({
+      rest_id: '100',
+      legacy: {
+        id_str: '100',
+        full_text: testCase.name,
+        entities: { urls: (testCase.links ?? []).map((expanded_url) => ({ expanded_url })) },
+      },
+      ...testCase.fields,
+    });
+    assert.equal(fetched.articleStatus, testCase.expected, testCase.name);
+    assert.equal(Boolean(fetched.article), testCase.expected === 'resolved', testCase.name);
+  }
+});
+
 test('parseTweetArticleByRestId: rejects preview-only X Article payloads', () => {
   const fixture = {
     data: {
@@ -658,7 +817,7 @@ test('parseTweetArticleByRestId: rejects preview-only X Article payloads', () =>
           article: {
             article_results: {
               result: {
-              title: 'Preview is not the article',
+                title: 'Preview is not the article',
                 preview_text: 'This preview is deliberately longer than fifty characters but is not a recovered article body.',
                 summary_text: 'This summary is also not source-complete long-form content.',
               },

--- a/tests/md-export.test.ts
+++ b/tests/md-export.test.ts
@@ -81,6 +81,8 @@ test('exportBookmarks: includes enriched article content for X Article bookmarks
     await updateArticleContent([
       {
         id: '2042685676949270724',
+        sourceTweetId: '2042685676949270724',
+        sourceLocator: 'http://x.com/i/article/2042676487711584257',
         articleTitle: 'How agents should use context',
         articleText: 'The article body is the useful content. It should not be lost behind an X Article link.',
         articleSite: 'X Articles',
@@ -143,6 +145,8 @@ test('exportBookmarks: changed mode rewrites only stale enriched markdown', asyn
     await updateArticleContent([
       {
         id: '2042685676949270724',
+        sourceTweetId: '2042685676949270724',
+        sourceLocator: 'http://x.com/i/article/2042676487711584257',
         articleTitle: 'How agents should use context',
         articleText: 'The article body was added after the first markdown export.',
         articleSite: 'X Articles',

--- a/tests/skill.test.ts
+++ b/tests/skill.test.ts
@@ -32,6 +32,7 @@ describe('skill content', () => {
       assert.ok(content.includes('ft list'));
       assert.ok(content.includes('ft stats'));
       assert.ok(content.includes('ft show'));
+      assert.ok(content.includes('ft materialize <id> --json'));
       assert.ok(content.includes('ft seeds search'));
       assert.ok(content.includes('ft possible run'));
       assert.ok(content.includes('ft possible grid'));

--- a/tests/x-materialize.test.ts
+++ b/tests/x-materialize.test.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
+import { fetchTweetDetailViaGraphQL } from '../src/graphql-bookmarks.js';
 import { refreshExactXBookmark } from '../src/x-materialize.js';
 import { parseTweetDetailResponse } from '../src/tweet-snapshots.js';
 import { XRequestExecutor } from '../src/x-request-policy.js';
@@ -563,21 +564,86 @@ test('TweetDetail fails closed on an unsupported or valueless cursor entry', () 
 });
 
 test('TweetDetail fails closed on a tweet envelope with no response-owned result', () => {
+  for (const tweetResults of [{}, { result: null }]) {
+    const parsed = parseTweetDetailResponse({
+      data: {
+        threaded_conversation_with_injections_v2: {
+          instructions: [{
+            type: 'TimelineAddEntries',
+            entries: [{
+              entryId: 'tweet-malformed',
+              content: { itemContent: { tweet_results: tweetResults } },
+            }],
+          }],
+        },
+      },
+    });
+    assert.equal(parsed.sawUnparseableTweet, true);
+    assert.deepEqual(parsed.parserGaps, ['unparseable_entry']);
+  }
+});
+
+test('TweetDetail fails closed on an unconsumed module item beside a valid focal tweet', () => {
   const parsed = parseTweetDetailResponse({
     data: {
       threaded_conversation_with_injections_v2: {
         instructions: [{
           type: 'TimelineAddEntries',
-          entries: [{
-            entryId: 'tweet-malformed',
-            content: { itemContent: { tweet_results: {} } },
-          }],
+          entries: [
+            {
+              entryId: 'tweet-100',
+              content: { itemContent: { tweet_results: { result: tweet('100', 'Current root.') } } },
+            },
+            {
+              entryId: 'conversation-module-1',
+              content: {
+                items: [{
+                  entryId: 'module-item-unknown',
+                  item: { itemContent: { futureThreadEnvelope: { opaque: true } } },
+                }],
+              },
+            },
+          ],
         }],
       },
     },
   });
-  assert.equal(parsed.sawUnparseableTweet, true);
+  assert.equal(parsed.tweets.some((row) => row.id === '100'), true);
   assert.deepEqual(parsed.parserGaps, ['unparseable_entry']);
+});
+
+test('TweetDetail fails closed on an unknown instruction without entries', () => {
+  const parsed = parseTweetDetailResponse({
+    data: {
+      threaded_conversation_with_injections_v2: {
+        instructions: [{ type: 'TimelineFutureInstruction', opaque: true }],
+      },
+    },
+  });
+  assert.deepEqual(parsed.parserGaps, ['unknown_instruction']);
+});
+
+test('TweetDetail keeps a terminally failed cursor pending instead of processed', async () => {
+  let request = 0;
+  const executor = new XRequestExecutor({
+    delayMs: 0,
+    maxAttempts: 1,
+    fetchImpl: async () => {
+      request += 1;
+      if (request === 1) {
+        return new Response(JSON.stringify(detailResponse([tweet('100', 'Current root.')], 'PAGE-2')), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      return new Response(null, { status: 500 });
+    },
+  });
+  const result = await fetchTweetDetailViaGraphQL('100', 'ct0', undefined, { executor });
+  assert.equal(result.enumerationComplete, false);
+  assert.equal(result.enumerationTermination, 'error');
+  assert.deepEqual(result.pendingCursors, ['PAGE-2']);
+  assert.deepEqual(result.processedCursors, []);
 });
 
 test('refreshExactXBookmark rejects identity-less parent and quote responses', async () => {

--- a/tests/x-materialize.test.ts
+++ b/tests/x-materialize.test.ts
@@ -26,16 +26,19 @@ function tweet(id: string, text: string, parent?: string) {
   };
 }
 
-function detailResponse(rows: unknown[]) {
+function detailResponse(rows: unknown[], cursor?: string) {
   return {
     data: {
       threaded_conversation_with_injections_v2: {
         instructions: [{
           type: 'TimelineAddEntries',
-          entries: rows.map((row: any) => ({
-            entryId: `tweet-${row.rest_id}`,
-            content: { itemContent: { tweet_results: { result: row } } },
-          })),
+          entries: [
+            ...rows.map((row: any) => ({
+              entryId: `tweet-${row.rest_id}`,
+              content: { itemContent: { tweet_results: { result: row } } },
+            })),
+            ...(cursor ? [{ entryId: 'cursor-bottom-next', content: { value: cursor } }] : []),
+          ],
         }],
       },
     },
@@ -122,6 +125,86 @@ test('refreshExactXBookmark preserves archived bytes when the exact root is unav
     assert.equal(result.observation.status, 'unavailable');
     assert.deepEqual(result.record, source);
     assert.equal(result.observation.quote_status, 'ok');
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('refreshExactXBookmark rejects a mismatched exact-id response', async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (async () => new Response(JSON.stringify({
+    data: { tweetResult: { result: tweet('999', 'Wrong root.') } },
+  }), { status: 200, headers: { 'content-type': 'application/json' } })) as typeof fetch;
+  const source = archived();
+  try {
+    const result = await refreshExactXBookmark(source, { csrfToken: 'ct0', delayMs: 0 });
+    assert.equal(result.observation.status, 'unavailable');
+    assert.equal(result.observation.root_status, 'error');
+    assert.deepEqual(result.record, source);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('refreshExactXBookmark reports a remaining continuation cursor as partial', async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (async (input: string | URL | Request) => {
+    const url = String(input);
+    if (url.includes('/TweetResultByRestId?')) {
+      return new Response(JSON.stringify({ data: { tweetResult: { result: tweet('100', 'Current root.') } } }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }
+    return new Response(JSON.stringify(detailResponse([
+      tweet('100', 'Current root.'),
+      tweet('101', 'Continuation.', '100'),
+    ], 'MORE')), { status: 200, headers: { 'content-type': 'application/json' } });
+  }) as typeof fetch;
+  try {
+    const result = await refreshExactXBookmark(archived(), {
+      csrfToken: 'ct0',
+      delayMs: 0,
+      maxPages: 1,
+      now: '2026-08-11T00:00:00.000Z',
+    });
+    assert.equal(result.observation.status, 'partial');
+    assert.equal(result.observation.continuation_enumeration_complete, false);
+    assert.equal(result.record.threadExpandedAt, undefined);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('refreshExactXBookmark does not promote stale archived article text under a fresh cutoff', async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (async (input: string | URL | Request) => {
+    const url = String(input);
+    if (url.includes('/TweetResultByRestId?')) {
+      return new Response(JSON.stringify({ data: { tweetResult: { result: tweet('100', 'Current root.') } } }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }
+    return new Response(JSON.stringify(detailResponse([tweet('100', 'Current root.')])), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
+  }) as typeof fetch;
+  const source = archived();
+  source.articleTitle = 'Archived article';
+  source.articleText = 'Stale archived article body that must not inherit the refresh cutoff.';
+  source.articleSite = 'X Articles';
+  try {
+    const result = await refreshExactXBookmark(source, {
+      csrfToken: 'ct0',
+      delayMs: 0,
+      now: '2026-08-11T00:00:00.000Z',
+    });
+    assert.equal(result.observation.status, 'partial');
+    assert.equal(result.observation.article_status, 'unresolved');
+    assert.equal(result.record.articleText, null);
+    assert.equal(result.record.threadExpandedAt, undefined);
   } finally {
     globalThis.fetch = originalFetch;
   }

--- a/tests/x-materialize.test.ts
+++ b/tests/x-materialize.test.ts
@@ -214,10 +214,11 @@ test('refreshExactXBookmark does not promote stale archived article text under a
 test('TweetDetail recognizes every supported continuation cursor location', () => {
   const entries = [
     { entryId: 'cursor-bottom-a', content: { value: 'BOTTOM' } },
+    { entryId: 'sq-cursor-bottom-a', content: { value: 'SQ_BOTTOM' } },
     { entryId: 'cursor-showmorethreads-b', content: { itemContent: { value: 'ITEM' } } },
     { entryId: 'cursor-showmorethreads-c', content: { operation: { cursor: { value: 'OPERATION' } } } },
   ];
-  for (const [entry, expected] of entries.map((entry, index) => [entry, ['BOTTOM', 'ITEM', 'OPERATION'][index]] as const)) {
+  for (const [entry, expected] of entries.map((entry, index) => [entry, ['BOTTOM', 'SQ_BOTTOM', 'ITEM', 'OPERATION'][index]] as const)) {
     const parsed = parseTweetDetailResponse({
       data: {
         threaded_conversation_with_injections_v2: {
@@ -228,6 +229,21 @@ test('TweetDetail recognizes every supported continuation cursor location', () =
     assert.equal(parsed.nextCursor, expected);
     assert.equal(parsed.sawUnparseableTweet, false);
   }
+});
+
+test('TweetDetail consumes a continuation cursor from TimelineReplaceEntry', () => {
+  const parsed = parseTweetDetailResponse({
+    data: {
+      threaded_conversation_with_injections_v2: {
+        instructions: [{
+          type: 'TimelineReplaceEntry',
+          entry: { entryId: 'cursor-bottom-replacement', content: { value: 'REPLACED' } },
+        }],
+      },
+    },
+  });
+  assert.equal(parsed.nextCursor, 'REPLACED');
+  assert.equal(parsed.sawUnparseableTweet, false);
 });
 
 test('TweetDetail fails closed on an unsupported or valueless cursor entry', () => {

--- a/tests/x-materialize.test.ts
+++ b/tests/x-materialize.test.ts
@@ -442,6 +442,108 @@ test('refreshExactXBookmark does not promote stale archived article text under a
   }
 });
 
+test('refreshExactXBookmark retains source-bound enrichment when the current focal locator still matches', async () => {
+  const articleLocator = 'https://x.com/i/article/2042676487711584257';
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (async (input: string | URL | Request) => {
+    const url = String(input);
+    if (url.includes('/TweetResultByRestId?')) {
+      const row = tweet('100', 'Current root with the same article identity.');
+      row.legacy.entities.urls = [{ expanded_url: articleLocator }];
+      return new Response(JSON.stringify({ data: { tweetResult: { result: row } } }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }
+    return new Response(JSON.stringify(detailResponse([
+      tweet('100', 'Current root with the same article identity.'),
+    ])), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
+  }) as typeof fetch;
+  const source = archived();
+  source.links = [articleLocator];
+  source.articleTitle = 'Bound indexed article';
+  source.articleText = 'Legitimate source-bound SQLite enrichment.';
+  source.articleSite = 'X Articles';
+  source.articleSourceTweetId = source.tweetId;
+  source.articleLocator = articleLocator;
+  try {
+    const result = await refreshExactXBookmark(source, {
+      csrfToken: 'ct0',
+      delayMs: 0,
+      now: '2026-08-11T00:00:00.000Z',
+    });
+    assert.equal(result.observation.status, 'partial');
+    assert.equal(result.observation.article_status, 'unresolved');
+    assert.equal(result.record.articleText, 'Legitimate source-bound SQLite enrichment.');
+    assert.equal(result.record.articleSourceTweetId, source.tweetId);
+    assert.equal(result.record.articleLocator, articleLocator);
+    assert.equal(result.record.threadExpandedAt, undefined);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('refreshExactXBookmark clears contradicted or wrong-root enrichment', async () => {
+  const oldLocator = 'https://x.com/i/article/2042676487711584257';
+  const currentLocator = 'https://x.com/i/article/2042676487711584258';
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (async (input: string | URL | Request) => {
+    const url = String(input);
+    if (url.includes('/TweetResultByRestId?')) {
+      const row = tweet('100', 'Current root with a replacement article identity.');
+      row.legacy.entities.urls = [{ expanded_url: currentLocator }];
+      return new Response(JSON.stringify({ data: { tweetResult: { result: row } } }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }
+    return new Response(JSON.stringify(detailResponse([
+      tweet('100', 'Current root with a replacement article identity.'),
+    ])), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
+  }) as typeof fetch;
+  const source = archived();
+  source.links = [oldLocator];
+  source.articleText = 'Bound content for the old locator.';
+  source.articleSourceTweetId = source.tweetId;
+  source.articleLocator = oldLocator;
+  try {
+    const result = await refreshExactXBookmark(source, {
+      csrfToken: 'ct0',
+      delayMs: 0,
+      now: '2026-08-11T00:00:00.000Z',
+    });
+    assert.equal(result.observation.status, 'partial');
+    assert.equal(result.observation.article_status, 'unresolved');
+    assert.equal(result.record.articleText, null);
+    assert.equal(result.record.articleSourceTweetId, null);
+    assert.equal(result.record.articleLocator, null);
+    assert.deepEqual(result.record.links, [currentLocator]);
+
+    const wrongRoot = archived();
+    wrongRoot.links = [currentLocator];
+    wrongRoot.articleText = 'Content supplied by a different tweet.';
+    wrongRoot.articleSourceTweetId = '999';
+    wrongRoot.articleLocator = currentLocator;
+    const rejected = await refreshExactXBookmark(wrongRoot, {
+      csrfToken: 'ct0',
+      delayMs: 0,
+      now: '2026-08-11T00:00:00.000Z',
+    });
+    assert.equal(rejected.observation.article_status, 'unresolved');
+    assert.equal(rejected.record.articleText, null);
+    assert.equal(rejected.record.articleSourceTweetId, null);
+    assert.equal(rejected.record.articleLocator, null);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
 test('refreshExactXBookmark remains partial when the current root identifies an unrecovered X Article', async () => {
   const originalFetch = globalThis.fetch;
   globalThis.fetch = (async (input: string | URL | Request) => {

--- a/tests/x-materialize.test.ts
+++ b/tests/x-materialize.test.ts
@@ -293,6 +293,51 @@ test('refreshExactXBookmark requires the focal tweet before completing traversal
   }
 });
 
+test('refreshExactXBookmark fails closed on an unknown entry beside the focal tweet', async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (async (input: string | URL | Request) => {
+    const url = String(input);
+    if (url.includes('/TweetResultByRestId?')) {
+      return new Response(JSON.stringify({ data: { tweetResult: { result: tweet('100', 'Current root.') } } }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }
+    return new Response(JSON.stringify({
+      data: {
+        threaded_conversation_with_injections_v2: {
+          instructions: [{
+            type: 'TimelineAddEntries',
+            entries: [
+              {
+                entryId: 'tweet-100',
+                content: { itemContent: { tweet_results: { result: tweet('100', 'Current root.') } } },
+              },
+              {
+                entryId: 'future-thread-envelope',
+                content: { futureThreadItems: [{ opaque: true }] },
+              },
+            ],
+          }],
+        },
+      },
+    }), { status: 200, headers: { 'content-type': 'application/json' } });
+  }) as typeof fetch;
+  try {
+    const result = await refreshExactXBookmark(archived(), {
+      csrfToken: 'ct0',
+      delayMs: 0,
+      now: '2026-08-11T00:00:00.000Z',
+    });
+    assert.equal(result.observation.status, 'partial');
+    assert.equal(result.observation.continuation_termination, 'parser_gap');
+    assert.equal(result.observation.continuation_enumeration_complete, false);
+    assert.equal(result.record.threadExpandedAt, undefined);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
 test('refreshExactXBookmark converts a malformed TweetDetail body into a partial observation', async () => {
   const originalFetch = globalThis.fetch;
   globalThis.fetch = (async (input: string | URL | Request) => {
@@ -515,6 +560,24 @@ test('TweetDetail fails closed on an unsupported or valueless cursor entry', () 
     assert.equal(parsed.nextCursor, undefined);
     assert.equal(parsed.sawUnparseableTweet, true);
   }
+});
+
+test('TweetDetail fails closed on a tweet envelope with no response-owned result', () => {
+  const parsed = parseTweetDetailResponse({
+    data: {
+      threaded_conversation_with_injections_v2: {
+        instructions: [{
+          type: 'TimelineAddEntries',
+          entries: [{
+            entryId: 'tweet-malformed',
+            content: { itemContent: { tweet_results: {} } },
+          }],
+        }],
+      },
+    },
+  });
+  assert.equal(parsed.sawUnparseableTweet, true);
+  assert.deepEqual(parsed.parserGaps, ['unparseable_entry']);
 });
 
 test('refreshExactXBookmark rejects identity-less parent and quote responses', async () => {

--- a/tests/x-materialize.test.ts
+++ b/tests/x-materialize.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 import { refreshExactXBookmark } from '../src/x-materialize.js';
 import { parseTweetDetailResponse } from '../src/tweet-snapshots.js';
+import { XRequestExecutor } from '../src/x-request-policy.js';
 import type { BookmarkRecord } from '../src/types.js';
 
 function tweet(id: string, text: string, parent?: string) {
@@ -102,6 +103,8 @@ test('refreshExactXBookmark refreshes one root and bounded thread in memory', as
       now: '2026-08-11T00:00:00.000Z',
     });
     assert.equal(result.observation.status, 'complete');
+    assert.equal(result.observation.parent_termination, 'root');
+    assert.equal(result.observation.continuation_termination, 'exhausted');
     assert.equal(result.record.text, 'Current root.');
     assert.deepEqual(result.record.threadContext?.map((row) => row.id), ['99']);
     assert.deepEqual(result.record.threadBelow?.map((row) => row.id), ['101']);
@@ -171,6 +174,7 @@ test('refreshExactXBookmark reports a remaining continuation cursor as partial',
     });
     assert.equal(result.observation.status, 'partial');
     assert.equal(result.observation.continuation_enumeration_complete, false);
+    assert.equal(result.observation.continuation_termination, 'limit');
     assert.equal(result.record.threadExpandedAt, undefined);
   } finally {
     globalThis.fetch = originalFetch;
@@ -222,6 +226,7 @@ test('refreshExactXBookmark traverses every supported continuation branch before
       now: '2026-08-11T00:00:00.000Z',
     });
     assert.equal(result.observation.status, 'complete');
+    assert.equal(result.observation.continuation_termination, 'exhausted');
     assert.deepEqual(detailCursors, [undefined, 'BRANCH_A', 'BRANCH_B']);
     assert.deepEqual(result.record.threadBelow?.map((row) => row.id), ['101', '102']);
   } finally {
@@ -251,6 +256,7 @@ test('refreshExactXBookmark keeps a recognized tweet-free timeline partial', asy
     });
     assert.equal(result.observation.status, 'partial');
     assert.equal(result.observation.continuation_status, 'empty');
+    assert.equal(result.observation.continuation_termination, 'empty');
     assert.equal(result.observation.continuation_enumeration_complete, false);
     assert.equal(result.record.threadExpandedAt, undefined);
   } finally {
@@ -279,6 +285,7 @@ test('refreshExactXBookmark requires the focal tweet before completing traversal
       now: '2026-08-11T00:00:00.000Z',
     });
     assert.equal(result.observation.status, 'partial');
+    assert.equal(result.observation.continuation_termination, 'missing_focal');
     assert.deepEqual(result.record.threadBelow, []);
     assert.equal(result.record.threadExpandedAt, undefined);
   } finally {
@@ -309,6 +316,7 @@ test('refreshExactXBookmark converts a malformed TweetDetail body into a partial
     });
     assert.equal(result.observation.status, 'partial');
     assert.equal(result.observation.continuation_status, 'error');
+    assert.equal(result.observation.continuation_termination, 'error');
     assert.equal(result.observation.continuation_enumeration_complete, false);
     assert.equal(result.record.threadExpandedAt, undefined);
   } finally {
@@ -540,9 +548,85 @@ test('refreshExactXBookmark rejects identity-less parent and quote responses', a
     const result = await refreshExactXBookmark(source, { csrfToken: 'ct0', delayMs: 0 });
     assert.equal(result.observation.status, 'partial');
     assert.equal(result.observation.parent_status, 'error');
+    assert.equal(result.observation.parent_termination, 'error');
     assert.equal(result.observation.quote_status, 'error');
     assert.equal(result.record.threadExpandedAt, undefined);
     assert.equal(result.record.quotedTweet, undefined);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('refreshExactXBookmark sends helper retries through the shared configured request executor', async () => {
+  const sleeps: number[] = [];
+  let attempts = 0;
+  const executor = new XRequestExecutor({
+    delayMs: 41,
+    fetchImpl: (async (input: string | URL | Request) => {
+      attempts += 1;
+      const url = String(input);
+      if (attempts === 1) throw new Error('retry root');
+      if (url.includes('/TweetDetail?')) {
+        return new Response(JSON.stringify(detailResponse([tweet('100', 'Current root.')])), { status: 200 });
+      }
+      return new Response(JSON.stringify({ data: { tweetResult: { result: tweet('100', 'Current root.') } } }), { status: 200 });
+    }) as typeof fetch,
+    sleep: async (milliseconds) => { sleeps.push(milliseconds); },
+    retryBackoffMs: () => 0,
+  });
+
+  const result = await refreshExactXBookmark(archived(), {
+    csrfToken: 'ct0',
+    delayMs: 41,
+    requestExecutor: executor,
+    now: '2026-08-11T00:00:00.000Z',
+  });
+  assert.equal(result.observation.status, 'complete');
+  assert.equal(executor.attemptCount, 3);
+  assert.deepEqual(sleeps, [41, 41]);
+});
+
+test('refreshExactXBookmark distinguishes cyclic and limited parent traversal from root termination', async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (async (input: string | URL | Request) => {
+    const url = String(input);
+    if (url.includes('/TweetDetail?')) {
+      return new Response(JSON.stringify(detailResponse([tweet('100', 'Current root.', '99')])), { status: 200 });
+    }
+    const variables = JSON.parse(new URL(url).searchParams.get('variables') ?? '{}');
+    const row = variables.tweetId === '100'
+      ? tweet('100', 'Current root.', '99')
+      : variables.tweetId === '99'
+        ? tweet('99', 'Parent.', '100')
+        : tweet('98', 'Grandparent.');
+    return new Response(JSON.stringify({ data: { tweetResult: { result: row } } }), { status: 200 });
+  }) as typeof fetch;
+
+  try {
+    const cyclic = await refreshExactXBookmark(archived(), { csrfToken: 'ct0', delayMs: 0 });
+    assert.equal(cyclic.observation.status, 'partial');
+    assert.equal(cyclic.observation.parent_termination, 'cycle');
+    assert.equal(cyclic.record.threadExpandedAt, undefined);
+
+    globalThis.fetch = (async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url.includes('/TweetDetail?')) {
+        return new Response(JSON.stringify(detailResponse([tweet('100', 'Current root.', '99')])), { status: 200 });
+      }
+      const variables = JSON.parse(new URL(url).searchParams.get('variables') ?? '{}');
+      const row = variables.tweetId === '100'
+        ? tweet('100', 'Current root.', '99')
+        : tweet('99', 'Parent.', '98');
+      return new Response(JSON.stringify({ data: { tweetResult: { result: row } } }), { status: 200 });
+    }) as typeof fetch;
+    const limited = await refreshExactXBookmark(archived(), {
+      csrfToken: 'ct0',
+      delayMs: 0,
+      maxParents: 1,
+    });
+    assert.equal(limited.observation.status, 'partial');
+    assert.equal(limited.observation.parent_termination, 'limit');
+    assert.equal(limited.observation.parent_limit_reached, true);
   } finally {
     globalThis.fetch = originalFetch;
   }

--- a/tests/x-materialize.test.ts
+++ b/tests/x-materialize.test.ts
@@ -942,6 +942,102 @@ test('refreshExactXBookmark remains partial when the current root identifies an 
   }
 });
 
+test('refreshExactXBookmark cannot certify ambiguous article envelopes without focal locators', async () => {
+  const originalFetch = globalThis.fetch;
+  let rootResult: any;
+  globalThis.fetch = (async (input: string | URL | Request) => {
+    const url = String(input);
+    if (url.includes('/TweetResultByRestId?')) {
+      return new Response(JSON.stringify({ data: { tweetResult: { result: rootResult } } }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }
+    return new Response(JSON.stringify(detailResponse([tweet('100', 'Current focal root.')])), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
+  }) as typeof fetch;
+
+  const body = 'This is a complete article body that must never be admitted without focal locator custody.';
+  const cases = [
+    {
+      name: 'conflicting exact candidates',
+      fields: {
+        article_results: { result: { rest_id: '111', articleBody: body } },
+        article: { result: { rest_id: '222', articleBody: `${body} Different.` } },
+      },
+    },
+    {
+      name: 'unknown non-null focal article shape',
+      fields: { article: { unsupported_article_payload: { id: '111' } } },
+    },
+  ];
+
+  try {
+    for (const testCase of cases) {
+      rootResult = {
+        ...tweet('100', `Current root: ${testCase.name}.`),
+        ...testCase.fields,
+      };
+      const result = await refreshExactXBookmark(archived(), {
+        csrfToken: 'ct0',
+        delayMs: 0,
+        now: '2026-08-12T00:00:00.000Z',
+      });
+      assert.equal(result.observation.status, 'partial', testCase.name);
+      assert.equal(result.observation.article_status, 'unresolved', testCase.name);
+      assert.equal(result.record.articleText, null, testCase.name);
+      assert.equal(result.record.threadExpandedAt, undefined, testCase.name);
+    }
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('refreshExactXBookmark admits one response-owned exact article identity without a focal link', async () => {
+  const originalFetch = globalThis.fetch;
+  const body = 'This response-owned exact article body has one unambiguous decimal-string article identity.';
+  globalThis.fetch = (async (input: string | URL | Request) => {
+    const url = String(input);
+    if (url.includes('/TweetResultByRestId?')) {
+      return new Response(JSON.stringify({
+        data: {
+          tweetResult: {
+            result: {
+              ...tweet('100', 'Current root with response-owned article identity.'),
+              article_results: { result: { rest_id: '111', articleBody: body } },
+            },
+          },
+        },
+      }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }
+    return new Response(JSON.stringify(detailResponse([tweet('100', 'Current focal root.')])), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
+  }) as typeof fetch;
+
+  try {
+    const result = await refreshExactXBookmark(archived(), {
+      csrfToken: 'ct0',
+      delayMs: 0,
+      now: '2026-08-12T00:00:00.000Z',
+    });
+    assert.equal(result.observation.status, 'complete');
+    assert.equal(result.observation.article_status, 'ok');
+    assert.equal(result.record.articleText, body);
+    assert.equal(result.record.articleLocator, 'https://x.com/i/article/111');
+    assert.deepEqual(result.record.links, ['https://x.com/i/article/111']);
+    assert.equal(result.record.threadExpandedAt, '2026-08-12T00:00:00.000Z');
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
 test('TweetDetail recognizes every supported continuation cursor location', () => {
   const entries = [
     { entryId: 'cursor-bottom-a', content: { value: 'BOTTOM' } },
@@ -1047,6 +1143,34 @@ test('TweetDetail fails closed on a tweet envelope with no response-owned result
   }
 });
 
+test('TweetDetail retains a response-owned media-only focal tweet with empty text', () => {
+  const mediaOnly: any = tweet('100', '');
+  mediaOnly.legacy.extended_entities = {
+    media: [{
+      type: 'photo',
+      media_url_https: 'https://pbs.twimg.com/media/example.jpg',
+    }],
+  };
+
+  const parsed = parseTweetDetailResponse(detailResponse([mediaOnly]));
+  assert.equal(parsed.sawUnparseableTweet, false);
+  assert.equal(parsed.tweets.length, 1);
+  assert.equal(parsed.tweets[0].id, '100');
+  assert.equal(parsed.tweets[0].text, '');
+  assert.deepEqual(parsed.tweets[0].media, ['https://pbs.twimg.com/media/example.jpg']);
+});
+
+test('TweetDetail rejects an empty focal envelope with no response-owned content', () => {
+  for (const media of [undefined, {}, [null], [{}]]) {
+    const contentless: any = tweet('100', '');
+    if (media !== undefined) contentless.legacy.extended_entities = { media };
+    const parsed = parseTweetDetailResponse(detailResponse([contentless]));
+    assert.equal(parsed.tweets.length, 0);
+    assert.equal(parsed.sawUnparseableTweet, true);
+    assert.deepEqual(parsed.parserGaps, ['unparseable_entry']);
+  }
+});
+
 test('TweetDetail fails closed on malformed or contradictory tweet identity aliases', () => {
   for (const row of [
     { ...tweet('100', 'Current root.'), rest_id: '999' },
@@ -1087,6 +1211,35 @@ test('TweetDetail fails closed on an unconsumed module item beside a valid focal
   });
   assert.equal(parsed.tweets.some((row) => row.id === '100'), true);
   assert.deepEqual(parsed.parserGaps, ['unparseable_entry']);
+});
+
+test('TweetDetail records a module tombstone as unavailable with the correct typed gap', () => {
+  const parsed = parseTweetDetailResponse({
+    data: {
+      threaded_conversation_with_injections_v2: {
+        instructions: [{
+          type: 'TimelineAddEntries',
+          entries: [{
+            entryId: 'conversation-module-1',
+            content: {
+              items: [{
+                entryId: 'module-item-unavailable',
+                item: {
+                  itemContent: {
+                    tweet_results: { result: { __typename: 'TweetTombstone' } },
+                  },
+                },
+              }],
+            },
+          }],
+        }],
+      },
+    },
+  });
+
+  assert.equal(parsed.sawUnavailableTweet, true);
+  assert.equal(parsed.sawUnparseableTweet, false);
+  assert.deepEqual(parsed.parserGaps, ['unavailable_tweet']);
 });
 
 test('TweetDetail fails closed on an unknown instruction without entries', () => {

--- a/tests/x-materialize.test.ts
+++ b/tests/x-materialize.test.ts
@@ -177,6 +177,87 @@ test('refreshExactXBookmark reports a remaining continuation cursor as partial',
   }
 });
 
+test('refreshExactXBookmark traverses every supported continuation branch before completion', async () => {
+  const originalFetch = globalThis.fetch;
+  const detailCursors: Array<string | undefined> = [];
+  globalThis.fetch = (async (input: string | URL | Request) => {
+    const url = String(input);
+    if (url.includes('/TweetResultByRestId?')) {
+      return new Response(JSON.stringify({ data: { tweetResult: { result: tweet('100', 'Current root.') } } }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }
+    const variables = JSON.parse(new URL(url).searchParams.get('variables') ?? '{}');
+    const cursor = variables.cursor as string | undefined;
+    detailCursors.push(cursor);
+    const response = cursor === 'BRANCH_A'
+      ? detailResponse([tweet('101', 'First continuation branch.', '100')])
+      : cursor === 'BRANCH_B'
+        ? detailResponse([tweet('102', 'Second continuation branch.', '100')])
+        : {
+          data: {
+            threaded_conversation_with_injections_v2: {
+              instructions: [{
+                type: 'TimelineAddEntries',
+                entries: [
+                  { entryId: 'tweet-100', content: { itemContent: { tweet_results: { result: tweet('100', 'Current root.') } } } },
+                  { entryId: 'cursor-bottom-a', content: { value: 'BRANCH_A' } },
+                  { entryId: 'cursor-showmorethreads-b', content: { value: 'BRANCH_B' } },
+                ],
+              }],
+            },
+          },
+        };
+    return new Response(JSON.stringify(response), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
+  }) as typeof fetch;
+  try {
+    const result = await refreshExactXBookmark(archived(), {
+      csrfToken: 'ct0',
+      delayMs: 0,
+      maxPages: 3,
+      now: '2026-08-11T00:00:00.000Z',
+    });
+    assert.equal(result.observation.status, 'complete');
+    assert.deepEqual(detailCursors, [undefined, 'BRANCH_A', 'BRANCH_B']);
+    assert.deepEqual(result.record.threadBelow?.map((row) => row.id), ['101', '102']);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('refreshExactXBookmark keeps a recognized tweet-free timeline partial', async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (async (input: string | URL | Request) => {
+    const url = String(input);
+    if (url.includes('/TweetResultByRestId?')) {
+      return new Response(JSON.stringify({ data: { tweetResult: { result: tweet('100', 'Current root.') } } }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }
+    return new Response(JSON.stringify({
+      data: { threaded_conversation_with_injections_v2: { instructions: [] } },
+    }), { status: 200, headers: { 'content-type': 'application/json' } });
+  }) as typeof fetch;
+  try {
+    const result = await refreshExactXBookmark(archived(), {
+      csrfToken: 'ct0',
+      delayMs: 0,
+      now: '2026-08-11T00:00:00.000Z',
+    });
+    assert.equal(result.observation.status, 'partial');
+    assert.equal(result.observation.continuation_status, 'empty');
+    assert.equal(result.observation.continuation_enumeration_complete, false);
+    assert.equal(result.record.threadExpandedAt, undefined);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
 test('refreshExactXBookmark does not promote stale archived article text under a fresh cutoff', async () => {
   const originalFetch = globalThis.fetch;
   globalThis.fetch = (async (input: string | URL | Request) => {
@@ -229,6 +310,24 @@ test('TweetDetail recognizes every supported continuation cursor location', () =
     assert.equal(parsed.nextCursor, expected);
     assert.equal(parsed.sawUnparseableTweet, false);
   }
+});
+
+test('TweetDetail preserves every supported continuation cursor in one timeline', () => {
+  const parsed = parseTweetDetailResponse({
+    data: {
+      threaded_conversation_with_injections_v2: {
+        instructions: [{
+          type: 'TimelineAddEntries',
+          entries: [
+            { entryId: 'cursor-bottom-a', content: { value: 'BOTTOM' } },
+            { entryId: 'cursor-showmorethreads-b', content: { value: 'SHOW_MORE' } },
+          ],
+        }],
+      },
+    },
+  });
+  assert.deepEqual(parsed.continuationCursors, ['BOTTOM', 'SHOW_MORE']);
+  assert.equal(parsed.sawUnparseableTweet, false);
 });
 
 test('TweetDetail consumes a continuation cursor from TimelineReplaceEntry', () => {

--- a/tests/x-materialize.test.ts
+++ b/tests/x-materialize.test.ts
@@ -1,0 +1,128 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { refreshExactXBookmark } from '../src/x-materialize.js';
+import type { BookmarkRecord } from '../src/types.js';
+
+function tweet(id: string, text: string, parent?: string) {
+  return {
+    rest_id: id,
+    legacy: {
+      id_str: id,
+      full_text: text,
+      created_at: 'Tue Mar 10 12:00:00 +0000 2026',
+      conversation_id_str: '100',
+      in_reply_to_status_id_str: parent,
+      entities: { urls: [] },
+    },
+    core: {
+      user_results: {
+        result: {
+          rest_id: '1',
+          core: { screen_name: 'operator', name: 'Operator' },
+          legacy: {},
+        },
+      },
+    },
+  };
+}
+
+function detailResponse(rows: unknown[]) {
+  return {
+    data: {
+      threaded_conversation_with_injections_v2: {
+        instructions: [{
+          type: 'TimelineAddEntries',
+          entries: rows.map((row: any) => ({
+            entryId: `tweet-${row.rest_id}`,
+            content: { itemContent: { tweet_results: { result: row } } },
+          })),
+        }],
+      },
+    },
+  };
+}
+
+function archived(): BookmarkRecord {
+  return {
+    id: '100',
+    tweetId: '100',
+    url: 'https://x.com/operator/status/100',
+    text: 'Archived root.',
+    authorHandle: 'operator',
+    syncedAt: '2026-08-01T00:00:00.000Z',
+  };
+}
+
+test('refreshExactXBookmark refreshes one root and bounded thread in memory', async () => {
+  const originalFetch = globalThis.fetch;
+  const seen: string[] = [];
+  globalThis.fetch = (async (input: string | URL | Request) => {
+    const url = String(input);
+    seen.push(url);
+    if (url.includes('/TweetResultByRestId?')) {
+      const variables = JSON.parse(new URL(url).searchParams.get('variables') ?? '{}');
+      const row = variables.tweetId === '99'
+        ? tweet('99', 'Parent context.')
+        : variables.tweetId === '98'
+          ? tweet('98', 'Current quoted source.')
+          : tweet('100', 'Current root.', '99');
+      return new Response(JSON.stringify({ data: { tweetResult: { result: row } } }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }
+    if (url.includes('/TweetDetail?')) {
+      return new Response(JSON.stringify(detailResponse([
+        tweet('100', 'Current root.', '99'),
+        tweet('101', 'Same-author continuation.', '100'),
+      ])), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }
+    throw new Error(`Unexpected URL: ${url}`);
+  }) as typeof fetch;
+
+  try {
+    const source = archived();
+    source.quotedStatusId = '98';
+    source.quotedTweet = {
+      id: '98',
+      text: 'Old quote.',
+      url: 'https://x.com/operator/status/98',
+    };
+    const result = await refreshExactXBookmark(source, {
+      csrfToken: 'ct0',
+      cookieHeader: 'ct0=ct0; auth_token=auth',
+      delayMs: 0,
+      now: '2026-08-11T00:00:00.000Z',
+    });
+    assert.equal(result.observation.status, 'complete');
+    assert.equal(result.record.text, 'Current root.');
+    assert.deepEqual(result.record.threadContext?.map((row) => row.id), ['99']);
+    assert.deepEqual(result.record.threadBelow?.map((row) => row.id), ['101']);
+    assert.equal(result.record.quotedTweet?.text, 'Current quoted source.');
+    assert.equal(result.record.threadExpandedAt, '2026-08-11T00:00:00.000Z');
+    assert.equal(seen.filter((url) => url.includes('/TweetResultByRestId?')).length, 3);
+    assert.equal(seen.filter((url) => url.includes('/TweetDetail?')).length, 1);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('refreshExactXBookmark preserves archived bytes when the exact root is unavailable', async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (async () => new Response('', { status: 404 })) as typeof fetch;
+  const source = archived();
+  try {
+    const result = await refreshExactXBookmark(source, {
+      csrfToken: 'ct0',
+      delayMs: 0,
+    });
+    assert.equal(result.observation.status, 'unavailable');
+    assert.deepEqual(result.record, source);
+    assert.equal(result.observation.quote_status, 'ok');
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});

--- a/tests/x-materialize.test.ts
+++ b/tests/x-materialize.test.ts
@@ -370,6 +370,108 @@ test('refreshExactXBookmark converts a malformed TweetDetail body into a partial
   }
 });
 
+test('refreshExactXBookmark never completes partial TweetDetail data with top-level GraphQL errors', async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (async (input: string | URL | Request) => {
+    const url = String(input);
+    if (url.includes('/TweetResultByRestId?')) {
+      return new Response(JSON.stringify({ data: { tweetResult: { result: tweet('100', 'Current root.') } } }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }
+    return new Response(JSON.stringify({
+      ...detailResponse([tweet('100', 'Current root.')]),
+      errors: [{ message: 'timeline branch unavailable' }],
+    }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
+  }) as typeof fetch;
+  try {
+    const result = await refreshExactXBookmark(archived(), {
+      csrfToken: 'ct0',
+      delayMs: 0,
+      now: '2026-08-11T00:00:00.000Z',
+    });
+    assert.equal(result.observation.status, 'partial');
+    assert.equal(result.observation.continuation_status, 'graphql_error');
+    assert.equal(result.observation.continuation_termination, 'error');
+    assert.equal(result.observation.continuation_enumeration_complete, false);
+    assert.equal(result.record.threadExpandedAt, undefined);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('refreshExactXBookmark never accepts partial root data with top-level GraphQL errors', async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (async () => new Response(JSON.stringify({
+    data: { tweetResult: { result: tweet('100', 'Partial current root.') } },
+    errors: [{ message: 'root fields unavailable' }],
+  }), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  })) as typeof fetch;
+  try {
+    const result = await refreshExactXBookmark(archived(), {
+      csrfToken: 'ct0',
+      delayMs: 0,
+      now: '2026-08-11T00:00:00.000Z',
+    });
+    assert.equal(result.observation.status, 'unavailable');
+    assert.equal(result.observation.root_status, 'graphql_error');
+    assert.equal(result.record.text, 'Archived root.');
+    assert.equal(result.record.threadExpandedAt, undefined);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('refreshExactXBookmark never completes partial parent or quote data with GraphQL errors', async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (async (input: string | URL | Request) => {
+    const url = String(input);
+    if (url.includes('/TweetDetail?')) {
+      return new Response(JSON.stringify(detailResponse([tweet('100', 'Current root.', '99')])), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }
+    const variables = JSON.parse(new URL(url).searchParams.get('variables') ?? '{}');
+    const row = variables.tweetId === '100'
+      ? tweet('100', 'Current root.', '99')
+      : variables.tweetId === '99'
+        ? tweet('99', 'Partial parent.')
+        : tweet('98', 'Partial quote.');
+    return new Response(JSON.stringify({
+      data: { tweetResult: { result: row } },
+      ...(variables.tweetId === '100' ? {} : { errors: [{ message: 'component fields unavailable' }] }),
+    }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
+  }) as typeof fetch;
+  const source = archived();
+  source.inReplyToStatusId = '99';
+  source.quotedStatusId = '98';
+  try {
+    const result = await refreshExactXBookmark(source, {
+      csrfToken: 'ct0',
+      delayMs: 0,
+      now: '2026-08-11T00:00:00.000Z',
+    });
+    assert.equal(result.observation.status, 'partial');
+    assert.equal(result.observation.parent_status, 'graphql_error');
+    assert.equal(result.observation.parent_termination, 'error');
+    assert.equal(result.observation.quote_status, 'graphql_error');
+    assert.equal(result.record.threadExpandedAt, undefined);
+    assert.equal(result.record.quotedTweet, undefined);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
 test('refreshExactXBookmark applies the configured delay before every request after the root', async () => {
   const originalFetch = globalThis.fetch;
   const requestTimes: number[] = [];

--- a/tests/x-materialize.test.ts
+++ b/tests/x-materialize.test.ts
@@ -118,6 +118,182 @@ test('refreshExactXBookmark refreshes one root and bounded thread in memory', as
   }
 });
 
+test('refreshExactXBookmark discovers and fetches a live quote missing from the archive', async () => {
+  const originalFetch = globalThis.fetch;
+  const seenTweetIds: string[] = [];
+  globalThis.fetch = (async (input: string | URL | Request) => {
+    const url = String(input);
+    if (url.includes('/TweetResultByRestId?')) {
+      const variables = JSON.parse(new URL(url).searchParams.get('variables') ?? '{}');
+      seenTweetIds.push(variables.tweetId);
+      const row = variables.tweetId === '98'
+        ? tweet('98', 'Live quoted source.')
+        : tweet('100', 'Current root.');
+      if (variables.tweetId === '100') row.legacy.quoted_status_id_str = '98';
+      return new Response(JSON.stringify({ data: { tweetResult: { result: row } } }), { status: 200 });
+    }
+    return new Response(JSON.stringify(detailResponse([tweet('100', 'Current root.')])), { status: 200 });
+  }) as typeof fetch;
+
+  try {
+    const result = await refreshExactXBookmark(archived(), {
+      csrfToken: 'ct0',
+      delayMs: 0,
+      now: '2026-08-12T00:00:00.000Z',
+    });
+    assert.deepEqual(seenTweetIds, ['100', '98']);
+    assert.equal(result.record.quotedStatusId, '98');
+    assert.equal(result.record.quotedTweet?.id, '98');
+    assert.equal(result.record.quotedTweet?.text, 'Live quoted source.');
+    assert.equal(result.observation.quote_status, 'ok');
+    assert.equal(result.observation.status, 'complete');
+    assert.equal(result.record.threadExpandedAt, '2026-08-12T00:00:00.000Z');
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('refreshExactXBookmark replaces stale archived quote identity with the live focal identity', async () => {
+  const originalFetch = globalThis.fetch;
+  const seenTweetIds: string[] = [];
+  globalThis.fetch = (async (input: string | URL | Request) => {
+    const url = String(input);
+    if (url.includes('/TweetResultByRestId?')) {
+      const variables = JSON.parse(new URL(url).searchParams.get('variables') ?? '{}');
+      seenTweetIds.push(variables.tweetId);
+      const row = variables.tweetId === '98'
+        ? tweet('98', 'Replacement quoted source.')
+        : tweet('100', 'Current root.');
+      if (variables.tweetId === '100') row.legacy.quoted_status_id_str = '98';
+      return new Response(JSON.stringify({ data: { tweetResult: { result: row } } }), { status: 200 });
+    }
+    return new Response(JSON.stringify(detailResponse([tweet('100', 'Current root.')])), { status: 200 });
+  }) as typeof fetch;
+
+  const source = archived();
+  source.quotedStatusId = '97';
+  source.quotedTweet = { id: '97', text: 'Stale quote.', url: 'https://x.com/stale/status/97' };
+  try {
+    const result = await refreshExactXBookmark(source, { csrfToken: 'ct0', delayMs: 0 });
+    assert.deepEqual(seenTweetIds, ['100', '98']);
+    assert.equal(result.record.quotedStatusId, '98');
+    assert.equal(result.record.quotedTweet?.id, '98');
+    assert.equal(JSON.stringify(result).includes('Stale quote.'), false);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('refreshExactXBookmark remains partial when a newly discovered live quote is unavailable', async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (async (input: string | URL | Request) => {
+    const url = String(input);
+    if (url.includes('/TweetResultByRestId?')) {
+      const variables = JSON.parse(new URL(url).searchParams.get('variables') ?? '{}');
+      if (variables.tweetId === '98') return new Response('', { status: 404 });
+      const row = tweet('100', 'Current root.');
+      row.legacy.quoted_status_id_str = '98';
+      return new Response(JSON.stringify({ data: { tweetResult: { result: row } } }), { status: 200 });
+    }
+    return new Response(JSON.stringify(detailResponse([tweet('100', 'Current root.')])), { status: 200 });
+  }) as typeof fetch;
+
+  try {
+    const result = await refreshExactXBookmark(archived(), { csrfToken: 'ct0', delayMs: 0 });
+    assert.equal(result.record.quotedStatusId, '98');
+    assert.equal(result.record.quotedTweet, undefined);
+    assert.equal(result.observation.quote_status, 'not_found');
+    assert.equal(result.observation.status, 'partial');
+    assert.equal(result.record.threadExpandedAt, undefined);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('refreshExactXBookmark fails the root closed on contradictory live quote identities', async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (async () => {
+    const row = tweet('100', 'Current root.');
+    row.legacy.quoted_status_id_str = '98';
+    (row as any).quoted_status_result = { result: { rest_id: '97' } };
+    return new Response(JSON.stringify({ data: { tweetResult: { result: row } } }), { status: 200 });
+  }) as typeof fetch;
+
+  try {
+    const source = archived();
+    const result = await refreshExactXBookmark(source, { csrfToken: 'ct0', delayMs: 0 });
+    assert.equal(result.observation.status, 'unavailable');
+    assert.equal(result.observation.root_status, 'error');
+    assert.deepEqual(result.record, source);
+    assert.equal(result.record.threadExpandedAt, undefined);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('refreshExactXBookmark keeps a focal root with unavailable quote identity explicitly partial', async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (async (input: string | URL | Request) => {
+    const url = String(input);
+    if (url.includes('/TweetResultByRestId?')) {
+      const row: any = tweet('100', 'Current focal root.');
+      row.quoted_status_result = { result: { __typename: 'TweetTombstone' } };
+      return new Response(JSON.stringify({ data: { tweetResult: { result: row } } }), { status: 200 });
+    }
+    return new Response(JSON.stringify(detailResponse([tweet('100', 'Current focal root.')])), { status: 200 });
+  }) as typeof fetch;
+
+  try {
+    const result = await refreshExactXBookmark(archived(), {
+      csrfToken: 'ct0',
+      delayMs: 0,
+      now: '2026-08-12T00:00:00.000Z',
+    });
+    assert.equal(result.record.text, 'Current focal root.');
+    assert.equal(result.record.quotedStatusId, undefined);
+    assert.equal(result.observation.root_status, 'ok');
+    assert.equal(result.observation.quote_status, 'empty');
+    assert.equal(result.observation.status, 'partial');
+    assert.equal(result.record.threadExpandedAt, undefined);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('refreshExactXBookmark does not certify an archived quote when the live quote identity is unavailable', async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (async (input: string | URL | Request) => {
+    const url = String(input);
+    if (url.includes('/TweetResultByRestId?')) {
+      const variables = JSON.parse(new URL(url).searchParams.get('variables') ?? '{}');
+      if (variables.tweetId === '98') {
+        return new Response(JSON.stringify({ data: { tweetResult: { result: tweet('98', 'Archived candidate quote.') } } }), { status: 200 });
+      }
+      const row: any = tweet('100', 'Current focal root.');
+      row.quoted_status_result = { result: { __typename: 'TweetTombstone' } };
+      return new Response(JSON.stringify({ data: { tweetResult: { result: row } } }), { status: 200 });
+    }
+    return new Response(JSON.stringify(detailResponse([tweet('100', 'Current focal root.')])), { status: 200 });
+  }) as typeof fetch;
+
+  const source = archived();
+  source.quotedStatusId = '98';
+  try {
+    const result = await refreshExactXBookmark(source, {
+      csrfToken: 'ct0',
+      delayMs: 0,
+      now: '2026-08-12T00:00:00.000Z',
+    });
+    assert.equal(result.record.quotedStatusId, '98');
+    assert.equal(result.record.quotedTweet?.id, '98');
+    assert.equal(result.observation.quote_status, 'empty');
+    assert.equal(result.observation.status, 'partial');
+    assert.equal(result.record.threadExpandedAt, undefined);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
 test('refreshExactXBookmark preserves archived bytes when the exact root is unavailable', async () => {
   const originalFetch = globalThis.fetch;
   globalThis.fetch = (async () => new Response('', { status: 404 })) as typeof fetch;
@@ -488,15 +664,14 @@ test('refreshExactXBookmark applies the configured delay before every request af
     const row = variables.tweetId === '98'
       ? tweet('98', 'Current quoted source.')
       : tweet('100', 'Current root.');
+    if (variables.tweetId === '100') row.legacy.quoted_status_id_str = '98';
     return new Response(JSON.stringify({ data: { tweetResult: { result: row } } }), {
       status: 200,
       headers: { 'content-type': 'application/json' },
     });
   }) as typeof fetch;
-  const source = archived();
-  source.quotedStatusId = '98';
   try {
-    const result = await refreshExactXBookmark(source, {
+    const result = await refreshExactXBookmark(archived(), {
       csrfToken: 'ct0',
       delayMs: 20,
       now: '2026-08-11T00:00:00.000Z',
@@ -505,6 +680,91 @@ test('refreshExactXBookmark applies the configured delay before every request af
     assert.equal(requestTimes.length, 3);
     assert.ok(requestTimes[1] - requestTimes[0] >= 15);
     assert.ok(requestTimes[2] - requestTimes[1] >= 15);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('refreshExactXBookmark preserves current-bound ordinary enrichment without treating it as an X Article gap', async () => {
+  const externalArticle = 'https://example.com/article';
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (async (input: string | URL | Request) => {
+    const url = String(input);
+    if (url.includes('/TweetResultByRestId?')) {
+      const row = tweet('100', 'Current root with an ordinary outbound link.');
+      row.legacy.entities.urls = [{ expanded_url: externalArticle }];
+      return new Response(JSON.stringify({ data: { tweetResult: { result: row } } }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }
+    return new Response(JSON.stringify(detailResponse([
+      tweet('100', 'Current root with an ordinary outbound link.'),
+    ])), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
+  }) as typeof fetch;
+
+  const source = archived();
+  source.links = [externalArticle];
+  source.articleTitle = 'Ordinary external article';
+  source.articleText = 'Search-only destination body.';
+  source.articleSite = 'Example';
+  source.articleSourceTweetId = source.tweetId;
+  source.articleLocator = externalArticle;
+  try {
+    const result = await refreshExactXBookmark(source, {
+      csrfToken: 'ct0',
+      delayMs: 0,
+      now: '2026-08-12T00:00:00.000Z',
+    });
+    assert.equal(result.observation.status, 'complete');
+    assert.equal(result.observation.article_status, 'not_applicable');
+    assert.equal(result.record.articleText, 'Search-only destination body.');
+    assert.equal(result.record.articleLocator, externalArticle);
+    assert.equal(result.record.threadExpandedAt, '2026-08-12T00:00:00.000Z');
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('refreshExactXBookmark clears stale ordinary enrichment without creating an X Article gap', async () => {
+  const externalArticle = 'https://example.com/article';
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (async (input: string | URL | Request) => {
+    const url = String(input);
+    if (url.includes('/TweetResultByRestId?')) {
+      return new Response(JSON.stringify({ data: { tweetResult: { result: tweet('100', 'Current root.') } } }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }
+    return new Response(JSON.stringify(detailResponse([tweet('100', 'Current root.')])), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
+  }) as typeof fetch;
+
+  const source = archived();
+  source.links = [externalArticle];
+  source.articleTitle = 'Stale ordinary article';
+  source.articleText = 'Stale search-only destination body.';
+  source.articleSite = 'Example';
+  source.articleSourceTweetId = source.tweetId;
+  source.articleLocator = externalArticle;
+  try {
+    const result = await refreshExactXBookmark(source, {
+      csrfToken: 'ct0',
+      delayMs: 0,
+      now: '2026-08-12T00:00:00.000Z',
+    });
+    assert.equal(result.observation.status, 'complete');
+    assert.equal(result.observation.article_status, 'not_applicable');
+    assert.equal(result.record.articleText, null);
+    assert.equal(result.record.articleSourceTweetId, null);
+    assert.equal(result.record.articleLocator, null);
+    assert.equal(result.record.threadExpandedAt, '2026-08-12T00:00:00.000Z');
   } finally {
     globalThis.fetch = originalFetch;
   }
@@ -782,6 +1042,19 @@ test('TweetDetail fails closed on a tweet envelope with no response-owned result
         },
       },
     });
+    assert.equal(parsed.sawUnparseableTweet, true);
+    assert.deepEqual(parsed.parserGaps, ['unparseable_entry']);
+  }
+});
+
+test('TweetDetail fails closed on malformed or contradictory tweet identity aliases', () => {
+  for (const row of [
+    { ...tweet('100', 'Current root.'), rest_id: '999' },
+    { ...tweet('100', 'Current root.'), rest_id: 100 },
+    { ...tweet('100', 'Current root.'), legacy: { ...tweet('100', 'Current root.').legacy, id_str: 100 } },
+  ]) {
+    const parsed = parseTweetDetailResponse(detailResponse([row]));
+    assert.equal(parsed.tweets.length, 0);
     assert.equal(parsed.sawUnparseableTweet, true);
     assert.deepEqual(parsed.parserGaps, ['unparseable_entry']);
   }

--- a/tests/x-materialize.test.ts
+++ b/tests/x-materialize.test.ts
@@ -292,6 +292,42 @@ test('refreshExactXBookmark does not promote stale archived article text under a
   }
 });
 
+test('refreshExactXBookmark remains partial when the current root identifies an unrecovered X Article', async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (async (input: string | URL | Request) => {
+    const url = String(input);
+    if (url.includes('/TweetResultByRestId?')) {
+      const row = tweet('100', 'Current root with an X Article.');
+      row.legacy.entities.urls = [{
+        expanded_url: 'https://x.com/i/article/2042676487711584257',
+      }];
+      return new Response(JSON.stringify({ data: { tweetResult: { result: row } } }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }
+    return new Response(JSON.stringify(detailResponse([
+      tweet('100', 'Current root with an X Article.'),
+    ])), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
+  }) as typeof fetch;
+  try {
+    const result = await refreshExactXBookmark(archived(), {
+      csrfToken: 'ct0',
+      delayMs: 0,
+      now: '2026-08-11T00:00:00.000Z',
+    });
+    assert.equal(result.observation.status, 'partial');
+    assert.equal(result.observation.article_status, 'unresolved');
+    assert.equal(result.record.articleText, null);
+    assert.equal(result.record.threadExpandedAt, undefined);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
 test('TweetDetail recognizes every supported continuation cursor location', () => {
   const entries = [
     { entryId: 'cursor-bottom-a', content: { value: 'BOTTOM' } },

--- a/tests/x-materialize.test.ts
+++ b/tests/x-materialize.test.ts
@@ -286,6 +286,74 @@ test('refreshExactXBookmark requires the focal tweet before completing traversal
   }
 });
 
+test('refreshExactXBookmark converts a malformed TweetDetail body into a partial observation', async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (async (input: string | URL | Request) => {
+    const url = String(input);
+    if (url.includes('/TweetResultByRestId?')) {
+      return new Response(JSON.stringify({ data: { tweetResult: { result: tweet('100', 'Current root.') } } }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }
+    return new Response('<html>transient edge response</html>', {
+      status: 200,
+      headers: { 'content-type': 'text/html' },
+    });
+  }) as typeof fetch;
+  try {
+    const result = await refreshExactXBookmark(archived(), {
+      csrfToken: 'ct0',
+      delayMs: 0,
+      now: '2026-08-11T00:00:00.000Z',
+    });
+    assert.equal(result.observation.status, 'partial');
+    assert.equal(result.observation.continuation_status, 'error');
+    assert.equal(result.observation.continuation_enumeration_complete, false);
+    assert.equal(result.record.threadExpandedAt, undefined);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('refreshExactXBookmark applies the configured delay before every request after the root', async () => {
+  const originalFetch = globalThis.fetch;
+  const requestTimes: number[] = [];
+  globalThis.fetch = (async (input: string | URL | Request) => {
+    requestTimes.push(Date.now());
+    const url = String(input);
+    if (url.includes('/TweetDetail?')) {
+      return new Response(JSON.stringify(detailResponse([tweet('100', 'Current root.')])), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }
+    const variables = JSON.parse(new URL(url).searchParams.get('variables') ?? '{}');
+    const row = variables.tweetId === '98'
+      ? tweet('98', 'Current quoted source.')
+      : tweet('100', 'Current root.');
+    return new Response(JSON.stringify({ data: { tweetResult: { result: row } } }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
+  }) as typeof fetch;
+  const source = archived();
+  source.quotedStatusId = '98';
+  try {
+    const result = await refreshExactXBookmark(source, {
+      csrfToken: 'ct0',
+      delayMs: 20,
+      now: '2026-08-11T00:00:00.000Z',
+    });
+    assert.equal(result.observation.status, 'complete');
+    assert.equal(requestTimes.length, 3);
+    assert.ok(requestTimes[1] - requestTimes[0] >= 15);
+    assert.ok(requestTimes[2] - requestTimes[1] >= 15);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
 test('refreshExactXBookmark does not promote stale archived article text under a fresh cutoff', async () => {
   const originalFetch = globalThis.fetch;
   globalThis.fetch = (async (input: string | URL | Request) => {

--- a/tests/x-materialize.test.ts
+++ b/tests/x-materialize.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import { refreshExactXBookmark } from '../src/x-materialize.js';
+import { parseTweetDetailResponse } from '../src/tweet-snapshots.js';
 import type { BookmarkRecord } from '../src/types.js';
 
 function tweet(id: string, text: string, parent?: string) {
@@ -205,6 +206,81 @@ test('refreshExactXBookmark does not promote stale archived article text under a
     assert.equal(result.observation.article_status, 'unresolved');
     assert.equal(result.record.articleText, null);
     assert.equal(result.record.threadExpandedAt, undefined);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('TweetDetail recognizes every supported continuation cursor location', () => {
+  const entries = [
+    { entryId: 'cursor-bottom-a', content: { value: 'BOTTOM' } },
+    { entryId: 'cursor-showmorethreads-b', content: { itemContent: { value: 'ITEM' } } },
+    { entryId: 'cursor-showmorethreads-c', content: { operation: { cursor: { value: 'OPERATION' } } } },
+  ];
+  for (const [entry, expected] of entries.map((entry, index) => [entry, ['BOTTOM', 'ITEM', 'OPERATION'][index]] as const)) {
+    const parsed = parseTweetDetailResponse({
+      data: {
+        threaded_conversation_with_injections_v2: {
+          instructions: [{ type: 'TimelineAddEntries', entries: [entry] }],
+        },
+      },
+    });
+    assert.equal(parsed.nextCursor, expected);
+    assert.equal(parsed.sawUnparseableTweet, false);
+  }
+});
+
+test('TweetDetail fails closed on an unsupported or valueless cursor entry', () => {
+  for (const entry of [
+    { entryId: 'cursor-showmorethreads-empty', content: {} },
+    { entryId: 'cursor-new-continuation-shape', content: { value: 'UNKNOWN' } },
+  ]) {
+    const parsed = parseTweetDetailResponse({
+      data: {
+        threaded_conversation_with_injections_v2: {
+          instructions: [{ type: 'TimelineAddEntries', entries: [entry] }],
+        },
+      },
+    });
+    assert.equal(parsed.nextCursor, undefined);
+    assert.equal(parsed.sawUnparseableTweet, true);
+  }
+});
+
+test('refreshExactXBookmark rejects identity-less parent and quote responses', async () => {
+  const originalFetch = globalThis.fetch;
+  const identityless = (text: string) => {
+    const row = tweet('999', text);
+    delete row.rest_id;
+    delete row.legacy.id_str;
+    return row;
+  };
+  globalThis.fetch = (async (input: string | URL | Request) => {
+    const url = String(input);
+    if (url.includes('/TweetResultByRestId?')) {
+      const variables = JSON.parse(new URL(url).searchParams.get('variables') ?? '{}');
+      const row = variables.tweetId === '100'
+        ? tweet('100', 'Current root.', '99')
+        : identityless(variables.tweetId === '99' ? 'Identity-less parent.' : 'Identity-less quote.');
+      return new Response(JSON.stringify({ data: { tweetResult: { result: row } } }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }
+    return new Response(JSON.stringify(detailResponse([tweet('100', 'Current root.')])), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
+  }) as typeof fetch;
+  const source = archived();
+  source.quotedStatusId = '98';
+  try {
+    const result = await refreshExactXBookmark(source, { csrfToken: 'ct0', delayMs: 0 });
+    assert.equal(result.observation.status, 'partial');
+    assert.equal(result.observation.parent_status, 'error');
+    assert.equal(result.observation.quote_status, 'error');
+    assert.equal(result.record.threadExpandedAt, undefined);
+    assert.equal(result.record.quotedTweet, undefined);
   } finally {
     globalThis.fetch = originalFetch;
   }

--- a/tests/x-materialize.test.ts
+++ b/tests/x-materialize.test.ts
@@ -258,6 +258,34 @@ test('refreshExactXBookmark keeps a recognized tweet-free timeline partial', asy
   }
 });
 
+test('refreshExactXBookmark requires the focal tweet before completing traversal', async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (async (input: string | URL | Request) => {
+    const url = String(input);
+    if (url.includes('/TweetResultByRestId?')) {
+      return new Response(JSON.stringify({ data: { tweetResult: { result: tweet('100', 'Current root.') } } }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }
+    return new Response(JSON.stringify(detailResponse([
+      tweet('999', 'Unrelated parseable timeline entry.'),
+    ])), { status: 200, headers: { 'content-type': 'application/json' } });
+  }) as typeof fetch;
+  try {
+    const result = await refreshExactXBookmark(archived(), {
+      csrfToken: 'ct0',
+      delayMs: 0,
+      now: '2026-08-11T00:00:00.000Z',
+    });
+    assert.equal(result.observation.status, 'partial');
+    assert.deepEqual(result.record.threadBelow, []);
+    assert.equal(result.record.threadExpandedAt, undefined);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
 test('refreshExactXBookmark does not promote stale archived article text under a fresh cutoff', async () => {
   const originalFetch = globalThis.fetch;
   globalThis.fetch = (async (input: string | URL | Request) => {

--- a/tests/x-materialize.test.ts
+++ b/tests/x-materialize.test.ts
@@ -246,6 +246,21 @@ test('TweetDetail consumes a continuation cursor from TimelineReplaceEntry', () 
   assert.equal(parsed.sawUnparseableTweet, false);
 });
 
+test('TweetDetail fails closed on cursor entries in an unknown instruction envelope', () => {
+  const parsed = parseTweetDetailResponse({
+    data: {
+      threaded_conversation_with_injections_v2: {
+        instructions: [{
+          type: 'TimelineUnknownEntries',
+          entries: [{ entryId: 'cursor-new-envelope', content: { value: 'MORE' } }],
+        }],
+      },
+    },
+  });
+  assert.equal(parsed.nextCursor, undefined);
+  assert.equal(parsed.sawUnparseableTweet, true);
+});
+
 test('TweetDetail fails closed on an unsupported or valueless cursor entry', () => {
   for (const entry of [
     { entryId: 'cursor-showmorethreads-empty', content: {} },

--- a/tests/x-request-policy.test.ts
+++ b/tests/x-request-policy.test.ts
@@ -37,6 +37,72 @@ test('one XRequestExecutor schedules across logical helper boundaries', async ()
   assert.deepEqual(sleeps, [25]);
 });
 
+test('one XRequestExecutor serializes admission for concurrent logical callers', async () => {
+  const sleepReleases: Array<() => void> = [];
+  const calls: string[] = [];
+  const executor = new XRequestExecutor({
+    delayMs: 25,
+    fetchImpl: (async (input: string | URL | Request) => {
+      calls.push(String(input));
+      return new Response(JSON.stringify({ ok: true }), { status: 200 });
+    }) as typeof fetch,
+    sleep: async () => new Promise<void>((resolve) => { sleepReleases.push(resolve); }),
+  });
+
+  const pending = Promise.all([
+    executor.requestJson('https://x.com/first'),
+    executor.requestJson('https://x.com/second'),
+    executor.requestJson('https://x.com/third'),
+  ]);
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  assert.deepEqual(calls, ['https://x.com/first']);
+  assert.equal(sleepReleases.length, 1);
+
+  sleepReleases.shift()!();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  assert.deepEqual(calls, ['https://x.com/first', 'https://x.com/second']);
+  assert.equal(sleepReleases.length, 1);
+
+  sleepReleases.shift()!();
+  const results = await pending;
+  assert.deepEqual(calls, [
+    'https://x.com/first',
+    'https://x.com/second',
+    'https://x.com/third',
+  ]);
+  assert.equal(results.every((result) => result.status === 'ok'), true);
+  assert.equal(executor.attemptCount, 3);
+});
+
+test('attempt admission recovers without counting a rejected injected wait as an HTTP attempt', async () => {
+  let calls = 0;
+  let waits = 0;
+  const executor = new XRequestExecutor({
+    delayMs: 25,
+    fetchImpl: (async () => {
+      calls += 1;
+      return new Response(JSON.stringify({ ok: true }), { status: 200 });
+    }) as typeof fetch,
+    sleep: async () => {
+      waits += 1;
+      if (waits === 1) throw new Error('injected scheduler failure');
+    },
+  });
+
+  assert.equal((await executor.requestJson('https://x.com/first')).status, 'ok');
+  await assert.rejects(
+    executor.requestJson('https://x.com/not-attempted'),
+    /injected scheduler failure/,
+  );
+  assert.equal(executor.attemptCount, 1);
+  assert.equal(calls, 1);
+
+  assert.equal((await executor.requestJson('https://x.com/recovered')).status, 'ok');
+  assert.equal(executor.attemptCount, 2);
+  assert.equal(calls, 2);
+  assert.equal(waits, 2);
+});
+
 test('XRequestExecutor maps malformed successful bodies to a terminal decoding error', async () => {
   const executor = new XRequestExecutor({
     fetchImpl: (async () => new Response('<html>not json</html>', { status: 200 })) as typeof fetch,
@@ -62,6 +128,7 @@ test('XRequestExecutor reports nonempty or malformed GraphQL errors without disc
   for (const errors of [
     [{ message: 'partial branch unavailable' }],
     { message: 'malformed GraphQL errors shape' },
+    null,
   ]) {
     const json = { data: { focal: { id: '100' } }, errors };
     const executor = new XRequestExecutor({

--- a/tests/x-request-policy.test.ts
+++ b/tests/x-request-policy.test.ts
@@ -84,3 +84,99 @@ test('XRequestExecutor accepts an explicitly empty GraphQL errors list', async (
   const result = await executor.requestGraphqlJson('https://x.com/i/api/graphql/test');
   assert.equal(result.status, 'ok');
 });
+
+test('one XRequestExecutor schedules JSON, HEAD, binary, and binary retry attempts', async () => {
+  const calls: Array<{ url: string; method: string }> = [];
+  const sleeps: number[] = [];
+  let binaryGets = 0;
+  const executor = new XRequestExecutor({
+    delayMs: 11,
+    maxAttempts: 2,
+    fetchImpl: (async (input: string | URL | Request, init?: RequestInit) => {
+      const url = String(input);
+      const method = init?.method ?? 'GET';
+      calls.push({ url, method });
+      if (url.endsWith('/json')) {
+        return new Response(JSON.stringify({ ok: true }), { status: 200 });
+      }
+      if (method === 'HEAD') {
+        return new Response(null, {
+          status: 200,
+          headers: { 'content-length': '4', 'content-type': 'image/jpeg' },
+        });
+      }
+      binaryGets += 1;
+      if (binaryGets === 1) {
+        return new Response('temporary', { status: 503 });
+      }
+      return new Response(Uint8Array.from([1, 2, 3, 4]), {
+        status: 200,
+        headers: { 'content-type': 'image/jpeg' },
+      });
+    }) as typeof fetch,
+    sleep: async (milliseconds) => { sleeps.push(milliseconds); },
+    retryBackoffMs: () => 29,
+  });
+
+  assert.equal((await executor.requestJson('https://example.com/json')).status, 'ok');
+  const headers = await executor.requestHeaders('https://example.com/bytes', { method: 'HEAD' });
+  assert.deepEqual(headers.headers, { contentLength: '4', contentType: 'image/jpeg' });
+  const bytes = await executor.requestBytes('https://example.com/bytes');
+  assert.deepEqual(bytes.bytes, Buffer.from([1, 2, 3, 4]));
+  assert.equal(bytes.attempts, 2);
+  assert.equal(executor.attemptCount, 4);
+  assert.deepEqual(calls.map((call) => call.method), ['GET', 'HEAD', 'GET', 'GET']);
+  assert.deepEqual(sleeps, [11, 11, 29]);
+});
+
+test('an explicit zero delay introduces no artificial waits across request adapters', async () => {
+  const sleeps: number[] = [];
+  const executor = new XRequestExecutor({
+    delayMs: 0,
+    maxAttempts: 1,
+    fetchImpl: (async (_input: string | URL | Request, init?: RequestInit) => init?.method === 'HEAD'
+      ? new Response(null, { status: 200 })
+      : new Response(Uint8Array.from([1]), { status: 200 })) as typeof fetch,
+    sleep: async (milliseconds) => { sleeps.push(milliseconds); },
+  });
+
+  assert.equal((await executor.requestHeaders('https://example.com/media', { method: 'HEAD' })).status, 'ok');
+  assert.equal((await executor.requestBytes('https://example.com/media')).status, 'ok');
+  assert.deepEqual(sleeps, []);
+});
+
+test('an aborted request is terminal without issuing or retrying an HTTP attempt', async () => {
+  const controller = new AbortController();
+  controller.abort();
+  let calls = 0;
+  const executor = new XRequestExecutor({
+    fetchImpl: (async () => {
+      calls += 1;
+      return new Response('{}', { status: 200 });
+    }) as typeof fetch,
+  });
+
+  const result = await executor.requestBytes('https://example.com/media', { signal: controller.signal });
+  assert.equal(result.status, 'error');
+  assert.equal(result.failureKind, 'aborted');
+  assert.equal(result.attempts, 0);
+  assert.equal(calls, 0);
+  assert.equal(executor.attemptCount, 0);
+});
+
+test('terminal response state is local to one request and does not poison the shared executor', async () => {
+  let calls = 0;
+  const executor = new XRequestExecutor({
+    maxAttempts: 1,
+    fetchImpl: (async () => {
+      calls += 1;
+      return calls === 1
+        ? new Response('missing', { status: 404 })
+        : new Response(JSON.stringify({ ok: true }), { status: 200 });
+    }) as typeof fetch,
+  });
+
+  assert.equal((await executor.requestHeaders('https://example.com/missing')).status, 'not_found');
+  assert.equal((await executor.requestJson('https://example.com/next')).status, 'ok');
+  assert.equal(executor.attemptCount, 2);
+});

--- a/tests/x-request-policy.test.ts
+++ b/tests/x-request-policy.test.ts
@@ -1,0 +1,48 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { XRequestExecutor } from '../src/x-request-policy.js';
+
+test('XRequestExecutor applies configured delay to every actual retry attempt', async () => {
+  const sleeps: number[] = [];
+  let calls = 0;
+  const executor = new XRequestExecutor({
+    delayMs: 37,
+    fetchImpl: (async () => {
+      calls += 1;
+      if (calls === 1) throw new Error('transient network failure');
+      if (calls === 2) return new Response('temporary', { status: 503 });
+      return new Response(JSON.stringify({ ok: true }), { status: 200 });
+    }) as typeof fetch,
+    sleep: async (milliseconds) => { sleeps.push(milliseconds); },
+    retryBackoffMs: () => 5,
+  });
+
+  const result = await executor.requestJson('https://x.com/i/api/graphql/test');
+  assert.equal(result.status, 'ok');
+  assert.equal(result.attempts, 3);
+  assert.equal(executor.attemptCount, 3);
+  assert.deepEqual(sleeps, [37, 37]);
+});
+
+test('one XRequestExecutor schedules across logical helper boundaries', async () => {
+  const sleeps: number[] = [];
+  const executor = new XRequestExecutor({
+    delayMs: 25,
+    fetchImpl: (async () => new Response(JSON.stringify({ ok: true }), { status: 200 })) as typeof fetch,
+    sleep: async (milliseconds) => { sleeps.push(milliseconds); },
+  });
+
+  assert.equal((await executor.requestJson('https://x.com/first')).status, 'ok');
+  assert.equal((await executor.requestJson('https://x.com/second')).status, 'ok');
+  assert.deepEqual(sleeps, [25]);
+});
+
+test('XRequestExecutor maps malformed successful bodies to a terminal decoding error', async () => {
+  const executor = new XRequestExecutor({
+    fetchImpl: (async () => new Response('<html>not json</html>', { status: 200 })) as typeof fetch,
+  });
+  const result = await executor.requestJson('https://x.com/malformed');
+  assert.equal(result.status, 'error');
+  assert.equal(result.httpStatus, 200);
+  assert.equal(result.attempts, 1);
+});

--- a/tests/x-request-policy.test.ts
+++ b/tests/x-request-policy.test.ts
@@ -46,3 +46,41 @@ test('XRequestExecutor maps malformed successful bodies to a terminal decoding e
   assert.equal(result.httpStatus, 200);
   assert.equal(result.attempts, 1);
 });
+
+test('XRequestExecutor keeps GraphQL semantics out of generic JSON decoding', async () => {
+  const executor = new XRequestExecutor({
+    fetchImpl: (async () => new Response(JSON.stringify({ errors: ['application field'], ok: true }), {
+      status: 200,
+    })) as typeof fetch,
+  });
+  const result = await executor.requestJson('https://example.com/not-graphql');
+  assert.equal(result.status, 'ok');
+  assert.deepEqual(result.json, { errors: ['application field'], ok: true });
+});
+
+test('XRequestExecutor reports nonempty or malformed GraphQL errors without discarding partial data', async () => {
+  for (const errors of [
+    [{ message: 'partial branch unavailable' }],
+    { message: 'malformed GraphQL errors shape' },
+  ]) {
+    const json = { data: { focal: { id: '100' } }, errors };
+    const executor = new XRequestExecutor({
+      fetchImpl: (async () => new Response(JSON.stringify(json), { status: 200 })) as typeof fetch,
+    });
+    const result = await executor.requestGraphqlJson('https://x.com/i/api/graphql/test');
+    assert.equal(result.status, 'graphql_error');
+    assert.deepEqual(result.json, json);
+    assert.deepEqual(result.graphqlErrors, errors);
+    assert.equal(result.httpStatus, 200);
+  }
+});
+
+test('XRequestExecutor accepts an explicitly empty GraphQL errors list', async () => {
+  const executor = new XRequestExecutor({
+    fetchImpl: (async () => new Response(JSON.stringify({ data: { ok: true }, errors: [] }), {
+      status: 200,
+    })) as typeof fetch,
+  });
+  const result = await executor.requestGraphqlJson('https://x.com/i/api/graphql/test');
+  assert.equal(result.status, 'ok');
+});


### PR DESCRIPTION
## Summary

- add `ft materialize <id> --json` for one exact archived X bookmark
- optionally refresh only that root, its bounded parent chain, every enumerated same-author continuation branch, and its quote through the existing signed-in GraphQL route
- optionally fetch only media enumerated from that exact in-memory record
- emit source/component depth, exact media hashes, and explicit unresolved/unavailable gaps without persisting a second thread corpus

## Why this shape

Research systems need more than the bookmarked root: thread continuations, quote context, X Articles, outbound identities, and attached media can carry the decision-material content. This provides that source-owner boundary while remaining query-time and local-first.

Unlike a corpus-wide thread sync, this change adds no database migration, FTS column, scheduler, background job, classification, or LLM. `--refresh` does not modify the bookmark archive or index. Destination pages/PDFs and OCR/transcript/visual interpretation remain explicit gaps for their source owners rather than inferred content.

This is a deliberately thinner complement/alternative to #141 and addresses the exact-id use case behind #59. The TweetDetail parser and same-author continuation logic are based on Eric Litman's work in #141; the commit retains co-author attribution.

## Safety

- exact numeric archived ID required
- no corpus-wide selection or persistence
- source-local file paths never appear in output
- authenticated refresh fails closed if no X session is available
- public replies are excluded from same-author thread continuations
- every recognized bottom/show-more cursor is queued within bounded pagination; unvisited branches keep enumeration incomplete
- tweet-free or focal-tweet-free timelines remain incomplete; malformed TweetDetail bodies become partial observations
- the configured delay applies between every exact X request
- previews and summaries cannot be admitted as recovered X Article bodies
- equivalent recovered X/Twitter Article aliases are deduplicated; ambiguous multiple-Article identity fails closed with every locator explicit
- a current X Article identity without recovered body keeps the result partial
- ordinary materialization overlays article and quote enrichment already retained in the existing index
- hop-2 outbound identities are material but never mislabeled as mandatory-direct
- unavailable roots preserve the archived record and expose the failure

## Validation

Exact candidate head: `26fdc2d263b40f7940347cd22eb785ed9c75fc30` (tree `5c70c3af2f95905d43eb2b25e113838a26dbec37`).

- `npm run build` — PASS
- focused changed-surface suite — 136/136 PASS
- full `npm test` — 593/593 PASS
- `git diff --check` — PASS
- all ten inline review threads have exact-head replies and are resolved
- the disjoint BMA compatibility audit found and repaired the hop-2 mandatory-direct mismatch before cutover

Fresh Codex review is requested on the current head. Upstream merge remains maintainer-owned, and downstream plans assume no merge for at least 48 hours.
