### PR TITLE
fix: restore the broken star history chart in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,10 +314,10 @@ MIT — [fieldtheory.dev/cli](https://fieldtheory.dev/cli)
 
 ## Star History
 
-<a href="https://www.star-history.com/?repos=afar1%2Ffieldtheory-cli&type=date&legend=top-left">
+<a href="https://star-history.dera.page/#afar1/fieldtheory-cli&type=date&legend=top-left">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=afar1/fieldtheory-cli&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=afar1/fieldtheory-cli&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=afar1/fieldtheory-cli&type=date&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=afar1/fieldtheory-cli&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=afar1/fieldtheory-cli&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=afar1/fieldtheory-cli&type=date&legend=top-left" />
  </picture>
 </a>


### PR DESCRIPTION
The star history chart at the top of the README stopped rendering because of GitHub stargazer API restrictions. This change points the chart and its link at a working mirror so the history displays correctly again.