### PR TITLE
feat: sync Instagram Saved content locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,13 @@ ft stats
 
 On first run, `ft sync` extracts your X session from your browser and downloads your bookmarks into `~/.fieldtheory/bookmarks/`.
 
+`ft sync instagram` is an experimental, read-only connector for the account's
+**All Saved** feed. It includes saved photos, carousels, videos, and Reels, but
+not likes, viewing history, Stories, collection membership, or media downloads.
+Instagram does not offer a supported live Saved API, so endpoint changes or an
+account challenge can pause the importer. Re-running resumes an interrupted
+first backfill; later runs start with the newest Saved items.
+
 ## Commands
 
 ### Sync
@@ -49,6 +56,7 @@ On first run, `ft sync` extracts your X session from your browser and downloads 
 | Command | Description |
 |---------|-------------|
 | `ft sync` | Download and sync bookmarks, then fetch any missing media (photos, video posters, capped videos). No API required. |
+| `ft sync instagram` | **Experimental:** archive metadata for Instagram Saved posts and Reels using your local browser session |
 | `ft sync --no-media` | Sync bookmarks only; skip the media download pass |
 | `ft sync --skip-profile-images` | Sync bookmarks and post media but skip author profile images |
 | `ft sync --rebuild` | Full re-crawl of all bookmarks |
@@ -211,6 +219,8 @@ Data is stored locally under `~/.fieldtheory/`:
   bookmarks.jsonl         # raw bookmark cache (one per line)
   bookmarks.db            # SQLite FTS5 search index
   bookmarks-meta.json     # sync metadata
+  instagram-saved.jsonl   # Instagram Saved metadata cache
+  instagram-saved-state.json # Instagram pagination/checkpoint state
   oauth-token.json        # OAuth token (if using API mode, chmod 600)
 
 ~/.fieldtheory/library/
@@ -292,9 +302,17 @@ Session sync extracts cookies from your browser's local database. Use `ft sync -
 
 ## Security
 
-**Your data stays local.** No telemetry, no analytics, nothing phoned home. The CLI only makes network requests to X's API during sync.
+**Your data stays local.** No telemetry and no analytics. Sync only makes
+read-only requests to the selected source; cached metadata and search data stay
+under the local Field Theory data root.
 
 **Chrome session sync** reads cookies from Chrome's local database, uses them for the sync request, and discards them. Cookies are never stored separately.
+
+**Instagram Saved sync is experimental.** It reads only the Instagram session
+cookies required for the Saved request, keeps them in memory, refuses redirects,
+and stops without retrying when Instagram reports a rate limit or challenge.
+Using private web endpoints may trigger account security checks; stop using the
+connector if Instagram presents a challenge and complete it directly in your browser.
 
 **OAuth tokens** are stored with `chmod 600` (owner-only). Treat `~/.fieldtheory/bookmarks/oauth-token.json` like a password.
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ not likes, viewing history, Stories, collection membership, or media downloads.
 Instagram does not offer a supported live Saved API, so endpoint changes or an
 account challenge can pause the importer. Re-running resumes an interrupted
 first backfill; later runs start with the newest Saved items.
+Use `ft sync instagram --rebuild` to discard a stale pagination cursor and
+restart the crawl from the newest Saved page without deleting the local archive.
 
 ## Commands
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,7 +10,9 @@ Include the affected command, version, platform, and enough reproduction detail 
 
 ## Sensitive Areas
 
-Field Theory CLI can read browser session cookies for X bookmark sync, store OAuth tokens for API sync, and write local Field Theory data under `~/.fieldtheory`.
+Field Theory CLI can read browser session cookies for X and experimental
+Instagram Saved sync, store OAuth tokens for X API sync, and write local Field
+Theory data under `~/.fieldtheory`.
 
 Do not share:
 
@@ -20,5 +22,18 @@ Do not share:
 - local bookmark databases;
 - private Library or Commands content;
 - logs that include request headers or token values.
+
+## Experimental Instagram Connector
+
+`ft sync instagram` uses a read-only private web endpoint because Instagram has
+no supported live API for an account's Saved collection. It never calls a write
+endpoint, follows a redirect, retries a challenge, or stores session cookies.
+Captions and author fields are untrusted third-party content and are returned as
+structured data only.
+
+The connector can still trigger Instagram rate limits or account security
+checks. If a challenge appears, stop the sync and resolve it directly in the
+browser. Never send maintainers a Saved response, cookie database, account ID,
+or fixture copied from a personal account.
 
 OAuth token files should be owner-readable only. Treat `~/.fieldtheory/bookmarks/oauth-token.json` like a password.

--- a/src/bookmark-classify-llm.ts
+++ b/src/bookmark-classify-llm.ts
@@ -6,7 +6,8 @@
  * No API keys needed. No local models. Just a logged-in Claude or Codex CLI.
  */
 
-import { openDb, saveDb } from './db.js';
+import { saveDb } from './db.js';
+import { openBookmarksDb } from './bookmarks-db.js';
 import { twitterBookmarksIndexPath } from './paths.js';
 import type { ResolvedEngine } from './engine.js';
 import { invokeEngine } from './engine.js';
@@ -175,13 +176,13 @@ export async function classifyWithLlm(
   const { engine } = options;
 
   const dbPath = twitterBookmarksIndexPath();
-  const db = await openDb(dbPath);
+  const db = await openBookmarksDb();
 
   try {
     // Fetch unclassified bookmarks
     const rows = db.exec(
       `SELECT id, text, author_handle, links_json FROM bookmarks
-       WHERE primary_category = 'unclassified' OR primary_category IS NULL
+       WHERE source = 'x' AND (primary_category = 'unclassified' OR primary_category IS NULL)
        ORDER BY RANDOM()`
     );
 
@@ -288,7 +289,7 @@ export async function classifyDomainsWithLlm(
   const { engine } = options;
 
   const dbPath = twitterBookmarksIndexPath();
-  const db = await openDb(dbPath);
+  const db = await openBookmarksDb();
 
   // Ensure domain columns exist (migration from schema v2)
   try { db.run('ALTER TABLE bookmarks ADD COLUMN domains TEXT'); } catch { /* already exists */ }
@@ -296,8 +297,8 @@ export async function classifyDomainsWithLlm(
 
   try {
     const where = options.all
-      ? '1=1'
-      : 'primary_domain IS NULL';
+      ? "source = 'x'"
+      : "source = 'x' AND primary_domain IS NULL";
     const rows = db.exec(
       `SELECT id, text, author_handle, categories FROM bookmarks
        WHERE ${where} ORDER BY RANDOM()`

--- a/src/bookmarks-db.ts
+++ b/src/bookmarks-db.ts
@@ -12,9 +12,9 @@ const SCHEMA_VERSION = 7;
 export interface SearchResult {
   id: string;
   source: 'x' | 'instagram';
-  nativeId: string;
+  nativeId?: string;
   url: string;
-  canonicalUrl: string;
+  canonicalUrl?: string;
   text: string;
   authorHandle?: string;
   authorName?: string;
@@ -37,9 +37,9 @@ export interface BookmarkTimelineItem {
   id: string;
   tweetId: string;
   source: 'x' | 'instagram';
-  nativeId: string;
+  nativeId?: string;
   url: string;
-  canonicalUrl: string;
+  canonicalUrl?: string;
   text: string;
   authorHandle?: string;
   authorName?: string;
@@ -84,6 +84,8 @@ export interface BookmarkTimelineFilters {
   sort?: 'asc' | 'desc';
   limit?: number;
   offset?: number;
+  /** Legacy callers stay X-only; the CLI list command explicitly requests all sources. */
+  source?: 'x' | 'instagram' | 'all';
 }
 
 export interface BookmarkClassificationProgress {
@@ -149,13 +151,11 @@ function chronologicalDateRange(values: unknown[]): { earliest: string | null; l
 
 function mapTimelineRow(row: unknown[]): BookmarkTimelineItem {
   const source = row[32] === 'instagram' ? 'instagram' : 'x';
-  return {
+  const item: BookmarkTimelineItem = {
     id: row[0] as string,
     tweetId: row[1] as string,
     source,
-    nativeId: String(row[33] ?? row[1] ?? row[0]),
     url: row[2] as string,
-    canonicalUrl: row[2] as string,
     text: row[3] as string,
     authorHandle: (row[4] as string) ?? undefined,
     authorName: (row[5] as string) ?? undefined,
@@ -188,6 +188,11 @@ function mapTimelineRow(row: unknown[]): BookmarkTimelineItem {
     contentType: (row[34] as BookmarkRecord['contentType']) ?? undefined,
     untrustedFields: source === 'instagram' ? ['text', 'authorHandle', 'authorName'] : undefined,
   };
+  if (source === 'instagram') {
+    item.nativeId = String(row[33] ?? row[1] ?? row[0]);
+    item.canonicalUrl = row[2] as string;
+  }
+  return item;
 }
 
 function buildBookmarkWhereClause(filters: BookmarkTimelineFilters): {
@@ -196,6 +201,12 @@ function buildBookmarkWhereClause(filters: BookmarkTimelineFilters): {
 } {
   const conditions: string[] = [];
   const params: Array<string | number> = [];
+
+  const source = filters.source ?? 'x';
+  if (source !== 'all') {
+    conditions.push('b.source = ?');
+    params.push(source);
+  }
 
   if (filters.query) {
     conditions.push(`b.rowid IN (SELECT rowid FROM bookmarks_fts WHERE bookmarks_fts MATCH ?)`);
@@ -460,7 +471,10 @@ function insertRecord(db: Database, r: BookmarkRecord, preserved?: PreservedBook
   );
 }
 
-export async function buildIndex(options?: { force?: boolean }): Promise<{ dbPath: string; recordCount: number; newRecords: number }> {
+export async function buildIndex(options?: {
+  force?: boolean;
+  reportSource?: 'x' | 'instagram' | 'all';
+}): Promise<{ dbPath: string; recordCount: number; newRecords: number }> {
   const dbPath = twitterBookmarksIndexPath();
   const twitterRecords = (await readJsonLines<BookmarkRecord>(twitterBookmarksCachePath()))
     .map((record) => ({
@@ -523,7 +537,11 @@ export async function buildIndex(options?: { force?: boolean }): Promise<{ dbPat
       }
     } catch { /* table may be empty */ }
 
-    const newRecords: BookmarkRecord[] = records.filter(r => !existingRows.has(r.id));
+    const reportSource = options?.reportSource ?? 'x';
+    const reportedRecords = reportSource === 'all'
+      ? records
+      : records.filter((record) => record.source === reportSource);
+    const newRecords = reportedRecords.filter((record) => !existingRows.has(record.id));
 
     if (records.length > 0) {
       db.run('BEGIN TRANSACTION');
@@ -542,7 +560,10 @@ export async function buildIndex(options?: { force?: boolean }): Promise<{ dbPat
     db.run(`INSERT INTO bookmarks_fts(bookmarks_fts) VALUES('rebuild')`);
 
     saveDb(db, dbPath);
-    const totalRows = db.exec('SELECT COUNT(*) FROM bookmarks')[0]?.values[0]?.[0] as number;
+    const totalSql = reportSource === 'all'
+      ? 'SELECT COUNT(*) FROM bookmarks'
+      : 'SELECT COUNT(*) FROM bookmarks WHERE source = ?';
+    const totalRows = db.exec(totalSql, reportSource === 'all' ? [] : [reportSource])[0]?.values[0]?.[0] as number;
     return { dbPath, recordCount: totalRows, newRecords: newRecords.length };
   } finally {
     db.close();
@@ -652,12 +673,10 @@ export async function searchBookmarks(options: SearchOptions): Promise<SearchRes
 
     return rows[0].values.map((row) => {
       const source = row[7] === 'instagram' ? 'instagram' : 'x';
-      return {
+      const result: SearchResult = {
         id: row[0] as string,
         source,
-        nativeId: String(row[8] ?? row[0]),
         url: row[1] as string,
-        canonicalUrl: row[1] as string,
         text: row[2] as string,
         authorHandle: row[3] as string | undefined,
         authorName: row[4] as string | undefined,
@@ -666,6 +685,11 @@ export async function searchBookmarks(options: SearchOptions): Promise<SearchRes
         untrustedFields: source === 'instagram' ? ['text', 'authorHandle', 'authorName'] as const : undefined,
         score: row[6] as number,
       };
+      if (source === 'instagram') {
+        result.nativeId = String(row[8] ?? row[0]);
+        result.canonicalUrl = row[1] as string;
+      }
+      return result;
     });
   } finally {
     db.close();
@@ -895,16 +919,17 @@ export async function getStats(): Promise<{
   const db = await openDb(dbPath);
 
   try {
-    const total = db.exec('SELECT COUNT(*) FROM bookmarks')[0]?.values[0]?.[0] as number;
-    const authors = db.exec('SELECT COUNT(DISTINCT author_handle) FROM bookmarks')[0]?.values[0]?.[0] as number;
-    const postedAtRows = db.exec('SELECT posted_at FROM bookmarks WHERE posted_at IS NOT NULL');
+    ensureMigrations(db);
+    const total = db.exec("SELECT COUNT(*) FROM bookmarks WHERE source = 'x'")[0]?.values[0]?.[0] as number;
+    const authors = db.exec("SELECT COUNT(DISTINCT author_handle) FROM bookmarks WHERE source = 'x'")[0]?.values[0]?.[0] as number;
+    const postedAtRows = db.exec("SELECT posted_at FROM bookmarks WHERE source = 'x' AND posted_at IS NOT NULL");
     const range = chronologicalDateRange(
       (postedAtRows[0]?.values ?? []).map((row) => row[0])
     );
 
     const topAuthorsRows = db.exec(
       `SELECT author_handle, COUNT(*) as c FROM bookmarks
-       WHERE author_handle IS NOT NULL
+       WHERE source = 'x' AND author_handle IS NOT NULL
        GROUP BY author_handle ORDER BY c DESC LIMIT 15`
     );
     const topAuthors = (topAuthorsRows[0]?.values ?? []).map((r) => ({
@@ -914,7 +939,7 @@ export async function getStats(): Promise<{
 
     const langRows = db.exec(
       `SELECT language, COUNT(*) as c FROM bookmarks
-       WHERE language IS NOT NULL
+       WHERE source = 'x' AND language IS NOT NULL
        GROUP BY language ORDER BY c DESC LIMIT 10`
     );
     const languageBreakdown = (langRows[0]?.values ?? []).map((r) => ({
@@ -986,7 +1011,7 @@ export async function sampleByCategory(
     const rows = db.exec(
       `SELECT id, url, text, author_handle, categories, github_urls, links_json
        FROM bookmarks
-       WHERE categories LIKE ?
+       WHERE source = 'x' AND categories LIKE ?
        ORDER BY RANDOM()
        LIMIT ?`,
       [`%${category}%`, limit]
@@ -1022,7 +1047,7 @@ export async function getCategoryCounts(existingDb?: Database): Promise<Record<s
     // timeout on every compile.
     const rows = db.exec(
       `SELECT primary_category, COUNT(*) as c FROM bookmarks
-       WHERE primary_category IS NOT NULL AND primary_category != 'unclassified'
+       WHERE source = 'x' AND primary_category IS NOT NULL AND primary_category != 'unclassified'
        GROUP BY primary_category ORDER BY c DESC`
     );
     const counts: Record<string, number> = {};
@@ -1051,7 +1076,8 @@ export async function getClassificationProgress(): Promise<BookmarkClassificatio
          COUNT(*) AS total,
          SUM(CASE WHEN primary_category IS NOT NULL AND primary_category <> '' AND primary_category <> 'unclassified' THEN 1 ELSE 0 END) AS categories_done,
          SUM(CASE WHEN primary_domain IS NOT NULL AND primary_domain <> '' THEN 1 ELSE 0 END) AS domains_done
-       FROM bookmarks`
+       FROM bookmarks
+       WHERE source = 'x'`
     )[0]?.values?.[0];
 
     return {
@@ -1072,7 +1098,7 @@ export async function getDomainCounts(existingDb?: Database): Promise<Record<str
   try {
     const rows = db.exec(
       `SELECT primary_domain, COUNT(*) as c FROM bookmarks
-       WHERE primary_domain IS NOT NULL
+       WHERE source = 'x' AND primary_domain IS NOT NULL
        GROUP BY primary_domain ORDER BY c DESC`
     );
     const counts: Record<string, number> = {};
@@ -1091,7 +1117,7 @@ export async function getFolderCounts(existingDb?: Database): Promise<{ counts: 
   try {
     const counts: Record<string, number> = {};
     const rows = db.exec(
-      `SELECT folder_names FROM bookmarks WHERE folder_names IS NOT NULL AND folder_names != ''`
+      `SELECT folder_names FROM bookmarks WHERE source = 'x' AND folder_names IS NOT NULL AND folder_names != ''`
     );
     let tagged = 0;
     for (const row of rows[0]?.values ?? []) {
@@ -1102,7 +1128,7 @@ export async function getFolderCounts(existingDb?: Database): Promise<{ counts: 
         counts[name] = (counts[name] ?? 0) + 1;
       }
     }
-    const totalRow = db.exec('SELECT COUNT(*) FROM bookmarks')[0]?.values[0]?.[0] as number | undefined;
+    const totalRow = db.exec("SELECT COUNT(*) FROM bookmarks WHERE source = 'x'")[0]?.values[0]?.[0] as number | undefined;
     const total = Number(totalRow ?? 0);
     const untagged = Math.max(0, total - tagged);
     return { counts, untagged };
@@ -1122,7 +1148,7 @@ export async function sampleByDomain(
     const rows = db.exec(
       `SELECT id, url, text, author_handle, categories, github_urls, links_json
        FROM bookmarks
-       WHERE domains LIKE ?
+       WHERE source = 'x' AND domains LIKE ?
        ORDER BY RANDOM()
        LIMIT ?`,
       [`%${domain}%`, limit]
@@ -1153,7 +1179,7 @@ export async function sampleByAuthor(
     const rows = db.exec(
       `SELECT id, url, text, author_handle, categories, github_urls, links_json
        FROM bookmarks
-       WHERE author_handle = ? COLLATE NOCASE
+       WHERE source = 'x' AND author_handle = ? COLLATE NOCASE
        ORDER BY COALESCE(posted_at, bookmarked_at) DESC
        LIMIT ?`,
       [authorHandle, limit]
@@ -1182,7 +1208,7 @@ export async function getTopAuthorHandles(
   try {
     const rows = db.exec(
       `SELECT author_handle, COUNT(*) as c FROM bookmarks
-       WHERE author_handle IS NOT NULL
+       WHERE source = 'x' AND author_handle IS NOT NULL
        GROUP BY author_handle
        HAVING c >= ?
        ORDER BY c DESC`,

--- a/src/bookmarks-db.ts
+++ b/src/bookmarks-db.ts
@@ -2,20 +2,25 @@ import type { Database } from 'sql.js';
 import { openDb, saveDb } from './db.js';
 import { parseTimestampMs, toIsoDate } from './date-utils.js';
 import { readJsonLines } from './fs.js';
-import { twitterBookmarksCachePath, twitterBookmarksIndexPath } from './paths.js';
+import { instagramSavedCachePath, twitterBookmarksCachePath, twitterBookmarksIndexPath } from './paths.js';
 import type { BookmarkRecord, QuotedTweetSnapshot } from './types.js';
 import { classifyCorpus, formatClassificationSummary } from './bookmark-classify.js';
 import type { ClassificationSummary } from './bookmark-classify.js';
 
-const SCHEMA_VERSION = 6;
+const SCHEMA_VERSION = 7;
 
 export interface SearchResult {
   id: string;
+  source: 'x' | 'instagram';
+  nativeId: string;
   url: string;
+  canonicalUrl: string;
   text: string;
   authorHandle?: string;
   authorName?: string;
   postedAt?: string | null;
+  contentType?: BookmarkRecord['contentType'];
+  untrustedFields?: BookmarkRecord['untrustedFields'];
   score: number;
 }
 
@@ -31,7 +36,10 @@ export interface SearchOptions {
 export interface BookmarkTimelineItem {
   id: string;
   tweetId: string;
+  source: 'x' | 'instagram';
+  nativeId: string;
   url: string;
+  canonicalUrl: string;
   text: string;
   authorHandle?: string;
   authorName?: string;
@@ -61,6 +69,8 @@ export interface BookmarkTimelineItem {
   viewCount?: number | null;
   folderIds: string[];
   folderNames: string[];
+  contentType?: BookmarkRecord['contentType'];
+  untrustedFields?: BookmarkRecord['untrustedFields'];
 }
 
 export interface BookmarkTimelineFilters {
@@ -138,10 +148,14 @@ function chronologicalDateRange(values: unknown[]): { earliest: string | null; l
 }
 
 function mapTimelineRow(row: unknown[]): BookmarkTimelineItem {
+  const source = row[32] === 'instagram' ? 'instagram' : 'x';
   return {
     id: row[0] as string,
     tweetId: row[1] as string,
+    source,
+    nativeId: String(row[33] ?? row[1] ?? row[0]),
     url: row[2] as string,
+    canonicalUrl: row[2] as string,
     text: row[3] as string,
     authorHandle: (row[4] as string) ?? undefined,
     authorName: (row[5] as string) ?? undefined,
@@ -171,6 +185,8 @@ function mapTimelineRow(row: unknown[]): BookmarkTimelineItem {
     enrichedAt: (row[29] as string) ?? null,
     quotedStatusId: (row[30] as string) ?? null,
     quotedTweet: parseQuotedTweet(row[31]),
+    contentType: (row[34] as BookmarkRecord['contentType']) ?? undefined,
+    untrustedFields: source === 'instagram' ? ['text', 'authorHandle', 'authorName'] : undefined,
   };
 }
 
@@ -271,7 +287,10 @@ function initSchema(db: Database): void {
     article_site TEXT,
     enriched_at TEXT,
     folder_ids TEXT,
-    folder_names TEXT
+    folder_names TEXT,
+    source TEXT NOT NULL DEFAULT 'x',
+    native_id TEXT,
+    content_type TEXT
   )`);
 
   db.run(`CREATE INDEX IF NOT EXISTS idx_bookmarks_author ON bookmarks(author_handle)`);
@@ -345,6 +364,11 @@ function ensureMigrations(db: Database): void {
 
     ensureColumn(db, 'bookmarks', 'folder_ids', 'TEXT');
     ensureColumn(db, 'bookmarks', 'folder_names', 'TEXT');
+    ensureColumn(db, 'bookmarks', 'source', "TEXT NOT NULL DEFAULT 'x'");
+    ensureColumn(db, 'bookmarks', 'native_id', 'TEXT');
+    ensureColumn(db, 'bookmarks', 'content_type', 'TEXT');
+    db.run("UPDATE bookmarks SET source = 'x' WHERE source IS NULL OR source = ''");
+    db.run('UPDATE bookmarks SET native_id = tweet_id WHERE native_id IS NULL');
 
     // FTS rebuild: only if the FTS table is missing the article_text column.
     // Check via a zero-row SELECT so we don't rebuild unnecessarily.
@@ -390,7 +414,7 @@ function insertRecord(db: Database, r: BookmarkRecord, preserved?: PreservedBook
   const githubUrls = [...new Set([...githubMatches.map((m) => `https://${m}`), ...githubFromLinks])];
 
   db.run(
-    `INSERT OR REPLACE INTO bookmarks VALUES (${Array(37).fill('?').join(',')})`,
+    `INSERT OR REPLACE INTO bookmarks VALUES (${Array(40).fill('?').join(',')})`,
     [
       r.id,
       r.tweetId,
@@ -429,14 +453,33 @@ function insertRecord(db: Database, r: BookmarkRecord, preserved?: PreservedBook
       preserved?.enrichedAt ?? null,
       serializeJsonArray(r.folderIds) ?? preserved?.folderIds ?? null,
       serializeJsonArray(r.folderNames) ?? preserved?.folderNames ?? null,
+      r.source ?? 'x',
+      r.nativeId ?? r.tweetId ?? r.id,
+      r.contentType ?? null,
     ]
   );
 }
 
 export async function buildIndex(options?: { force?: boolean }): Promise<{ dbPath: string; recordCount: number; newRecords: number }> {
-  const cachePath = twitterBookmarksCachePath();
   const dbPath = twitterBookmarksIndexPath();
-  const records = await readJsonLines<BookmarkRecord>(cachePath);
+  const twitterRecords = (await readJsonLines<BookmarkRecord>(twitterBookmarksCachePath()))
+    .map((record) => ({
+      ...record,
+      source: 'x' as const,
+      nativeId: record.nativeId ?? record.tweetId ?? record.id,
+    }));
+  const instagramRecords = (await readJsonLines<BookmarkRecord>(instagramSavedCachePath()))
+    .map((record) => {
+      const nativeId = record.nativeId ?? record.id;
+      return {
+        ...record,
+        id: `instagram:${nativeId}`,
+        tweetId: nativeId,
+        nativeId,
+        source: 'instagram' as const,
+      };
+    });
+  const records = [...twitterRecords, ...instagramRecords];
 
   const db = await openDb(dbPath);
   try {
@@ -575,7 +618,8 @@ export async function searchBookmarks(options: SearchOptions): Promise<SearchRes
     if (options.query) {
       sql = `
         SELECT b.id, b.url, b.text, b.author_handle, b.author_name, b.posted_at,
-               bm25(bookmarks_fts, 5.0, 1.0, 1.0, 3.0) as score
+               bm25(bookmarks_fts, 5.0, 1.0, 1.0, 3.0) as score,
+               b.source, b.native_id, b.content_type
         FROM bookmarks b
         JOIN bookmarks_fts ON bookmarks_fts.rowid = b.rowid
         ${where}
@@ -585,7 +629,7 @@ export async function searchBookmarks(options: SearchOptions): Promise<SearchRes
     } else {
       sql = `
         SELECT b.id, b.url, b.text, b.author_handle, b.author_name, b.posted_at,
-               0 as score
+               0 as score, b.source, b.native_id, b.content_type
         FROM bookmarks b
         ${where}
         ORDER BY b.posted_at DESC
@@ -606,15 +650,23 @@ export async function searchBookmarks(options: SearchOptions): Promise<SearchRes
     }
     if (!rows.length) return [];
 
-    return rows[0].values.map((row) => ({
-      id: row[0] as string,
-      url: row[1] as string,
-      text: row[2] as string,
-      authorHandle: row[3] as string | undefined,
-      authorName: row[4] as string | undefined,
-      postedAt: row[5] as string | null,
-      score: row[6] as number,
-    }));
+    return rows[0].values.map((row) => {
+      const source = row[7] === 'instagram' ? 'instagram' : 'x';
+      return {
+        id: row[0] as string,
+        source,
+        nativeId: String(row[8] ?? row[0]),
+        url: row[1] as string,
+        canonicalUrl: row[1] as string,
+        text: row[2] as string,
+        authorHandle: row[3] as string | undefined,
+        authorName: row[4] as string | undefined,
+        postedAt: row[5] as string | null,
+        contentType: (row[9] as BookmarkRecord['contentType']) ?? undefined,
+        untrustedFields: source === 'instagram' ? ['text', 'authorHandle', 'authorName'] as const : undefined,
+        score: row[6] as number,
+      };
+    });
   } finally {
     db.close();
   }
@@ -664,7 +716,10 @@ export async function listBookmarks(
         b.synced_at,
         b.enriched_at,
         b.quoted_status_id,
-        b.quoted_tweet_json
+        b.quoted_tweet_json,
+        b.source,
+        b.native_id,
+        b.content_type
       FROM bookmarks b
       ${where}
       ${bookmarkSortClause(filters.sort)}
@@ -734,6 +789,7 @@ export async function exportBookmarksForSyncSeed(): Promise<BookmarkRecord[]> {
         b.folder_ids,
         b.folder_names
       FROM bookmarks b
+      WHERE b.source = 'x'
       ${bookmarkSortClause('desc')}
     `;
     const rows = db.exec(sql);
@@ -812,7 +868,10 @@ export async function getBookmarkById(id: string): Promise<BookmarkTimelineItem 
         b.synced_at,
         b.enriched_at,
         b.quoted_status_id,
-        b.quoted_tweet_json
+        b.quoted_tweet_json,
+        b.source,
+        b.native_id,
+        b.content_type
       FROM bookmarks b
       WHERE b.id = ?
       LIMIT 1`,

--- a/src/bookmarks-viz.ts
+++ b/src/bookmarks-viz.ts
@@ -1,6 +1,5 @@
-import { openDb } from './db.js';
+import { openBookmarksDb } from './bookmarks-db.js';
 import { parseTimestampMs, toIsoDate, toIsoMonth, toMonthDayLabel, toUtcHour, toWeekdayShort, toYearLabel } from './date-utils.js';
-import { twitterBookmarksIndexPath } from './paths.js';
 
 // ── ANSI helpers ─────────────────────────────────────────────────────────────
 
@@ -271,15 +270,15 @@ function aggregateTimelineData(rows: TimelineAggregateRow[]): {
 }
 
 async function queryVizData(): Promise<VizData> {
-  const db = await openDb(twitterBookmarksIndexPath());
+  const db = await openBookmarksDb();
 
   try {
-    const total = db.exec('SELECT COUNT(*) FROM bookmarks')[0]?.values[0]?.[0] as number;
-    const authors = db.exec('SELECT COUNT(DISTINCT author_handle) FROM bookmarks')[0]?.values[0]?.[0] as number;
+    const total = db.exec("SELECT COUNT(*) FROM bookmarks WHERE source = 'x'")[0]?.values[0]?.[0] as number;
+    const authors = db.exec("SELECT COUNT(DISTINCT author_handle) FROM bookmarks WHERE source = 'x'")[0]?.values[0]?.[0] as number;
     const timelineRows = db.exec(
       `SELECT author_handle, posted_at, synced_at
        FROM bookmarks
-       WHERE posted_at IS NOT NULL OR synced_at IS NOT NULL OR author_handle IS NOT NULL`
+       WHERE source = 'x' AND (posted_at IS NOT NULL OR synced_at IS NOT NULL OR author_handle IS NOT NULL)`
     );
     const timelineData = aggregateTimelineData(
       (timelineRows[0]?.values ?? []).map((row) => ({
@@ -291,13 +290,13 @@ async function queryVizData(): Promise<VizData> {
 
     const topAuthorsRows = db.exec(
       `SELECT author_handle, COUNT(*) as c FROM bookmarks
-       WHERE author_handle IS NOT NULL
+       WHERE source = 'x' AND author_handle IS NOT NULL
        GROUP BY author_handle ORDER BY c DESC LIMIT 20`
     );
 
     // Domains from links_json
     const domainRows = db.exec(
-      `SELECT links_json FROM bookmarks WHERE links_json IS NOT NULL AND links_json != '[]'`
+      `SELECT links_json FROM bookmarks WHERE source = 'x' AND links_json IS NOT NULL AND links_json != '[]'`
     );
     const domainCounts = new Map<string, number>();
     for (const row of domainRows[0]?.values ?? []) {
@@ -320,23 +319,23 @@ async function queryVizData(): Promise<VizData> {
       .map(([domain, count]) => ({ domain, count }));
 
     const mediaStats = {
-      withMedia: db.exec('SELECT COUNT(*) FROM bookmarks WHERE media_count > 0')[0]?.values[0]?.[0] as number,
-      withLinks: db.exec('SELECT COUNT(*) FROM bookmarks WHERE link_count > 0')[0]?.values[0]?.[0] as number,
+      withMedia: db.exec("SELECT COUNT(*) FROM bookmarks WHERE source = 'x' AND media_count > 0")[0]?.values[0]?.[0] as number,
+      withLinks: db.exec("SELECT COUNT(*) FROM bookmarks WHERE source = 'x' AND link_count > 0")[0]?.values[0]?.[0] as number,
       total,
     };
 
     const langRows = db.exec(
-      `SELECT language, COUNT(*) as c FROM bookmarks WHERE language IS NOT NULL
+      `SELECT language, COUNT(*) as c FROM bookmarks WHERE source = 'x' AND language IS NOT NULL
        GROUP BY language ORDER BY c DESC LIMIT 8`
     );
 
-    const avgLen = db.exec('SELECT AVG(length(text)) FROM bookmarks')[0]?.values[0]?.[0] as number;
+    const avgLen = db.exec("SELECT AVG(length(text)) FROM bookmarks WHERE source = 'x'")[0]?.values[0]?.[0] as number;
 
     // Time capsules: oldest posts, one per year to spread the range
     const capsuleRows = db.exec(
       `SELECT author_handle, text, tweet_id, posted_at, substr(posted_at, -4) as yr
        FROM bookmarks
-       WHERE posted_at IS NOT NULL
+       WHERE source = 'x' AND posted_at IS NOT NULL
        AND CAST(substr(posted_at, -4) AS INTEGER) < 2023
        GROUP BY substr(posted_at, -4)
        ORDER BY posted_at ASC
@@ -355,10 +354,10 @@ async function queryVizData(): Promise<VizData> {
        FROM bookmarks b
        JOIN (
          SELECT author_handle FROM bookmarks
-         WHERE author_handle IS NOT NULL
+         WHERE source = 'x' AND author_handle IS NOT NULL
          GROUP BY author_handle HAVING COUNT(*) = 1
        ) singles ON b.author_handle = singles.author_handle
-       WHERE length(b.text) > 250
+       WHERE b.source = 'x' AND length(b.text) > 250
        ORDER BY length(b.text) DESC
        LIMIT 8`
     );
@@ -374,7 +373,7 @@ async function queryVizData(): Promise<VizData> {
     try {
       const catRows = db.exec(
         `SELECT primary_category, COUNT(*) as c FROM bookmarks
-         WHERE primary_category IS NOT NULL AND primary_category != 'unclassified'
+         WHERE source = 'x' AND primary_category IS NOT NULL AND primary_category != 'unclassified'
          GROUP BY primary_category ORDER BY c DESC LIMIT 15`
       );
       categories = (catRows[0]?.values ?? []).map((r) => ({
@@ -388,7 +387,7 @@ async function queryVizData(): Promise<VizData> {
     try {
       const domRows = db.exec(
         `SELECT primary_domain, COUNT(*) as c FROM bookmarks
-         WHERE primary_domain IS NOT NULL AND primary_domain != ''
+         WHERE source = 'x' AND primary_domain IS NOT NULL AND primary_domain != ''
          GROUP BY primary_domain ORDER BY c DESC LIMIT 15`
       );
       domains = (domRows[0]?.values ?? []).map((r) => ({

--- a/src/chrome-cookies.ts
+++ b/src/chrome-cookies.ts
@@ -514,7 +514,7 @@ export function extractChromeXCookies(
  * Read only the fixed cookie set required by Instagram Saved ingestion.
  * The domain and names are intentionally not caller-configurable.
  */
-export function extractChromeInstagramCookies(
+function extractChromeInstagramCookiesUnchecked(
   chromeUserDataDir: string,
   profileDirectory = 'Default',
   browser: BrowserDef | undefined = undefined,
@@ -550,15 +550,20 @@ export function extractChromeInstagramCookies(
     ['sessionid', 'csrftoken', 'ds_user_id', 'mid', 'rur'],
     br,
   );
+  const requiredNames = new Set(['sessionid', 'csrftoken']);
   const decrypted = new Map<string, string>();
   for (const cookie of result.cookies) {
-    if (cookie.encrypted_value_hex) {
-      const encrypted = Buffer.from(cookie.encrypted_value_hex, 'hex');
-      decrypted.set(cookie.name, isWindows
-        ? decryptWindowsCookie(encrypted, key)
-        : decryptCookieValue(encrypted, key, result.dbVersion, v11Key));
-    } else if (cookie.value) {
-      decrypted.set(cookie.name, cookie.value);
+    try {
+      if (cookie.encrypted_value_hex) {
+        const encrypted = Buffer.from(cookie.encrypted_value_hex, 'hex');
+        decrypted.set(cookie.name, isWindows
+          ? decryptWindowsCookie(encrypted, key)
+          : decryptCookieValue(encrypted, key, result.dbVersion, v11Key));
+      } else if (cookie.value) {
+        decrypted.set(cookie.name, cookie.value);
+      }
+    } catch (error) {
+      if (requiredNames.has(cookie.name)) throw error;
     }
   }
 
@@ -575,11 +580,42 @@ export function extractChromeInstagramCookies(
   const cookieHeader = orderedNames
     .flatMap((name) => {
       const value = decrypted.get(name);
-      return value ? [`${name}=${sanitizeCookieValue(name, value, br)}`] : [];
+      if (!value) return [];
+      try {
+        return [`${name}=${sanitizeCookieValue(name, value, br)}`];
+      } catch (error) {
+        if (requiredNames.has(name)) throw error;
+        return [];
+      }
     })
     .join('; ');
   return {
     csrfToken: sanitizeCookieValue('csrftoken', csrfToken, br),
     cookieHeader,
   };
+}
+
+function instagramCookieGuidance(error: unknown): Error {
+  const message = error instanceof Error ? error.message : String(error);
+  const rewritten = message
+    .replace(/profile logged into X/g, 'profile logged into Instagram')
+    .replace(/log into x\.com/g, 'log into instagram.com')
+    .replace(/run ft sync again/g, 'run ft sync instagram again')
+    .replace(/(?:Or p|P)ass cookies manually:\s*ft sync --cookies <ct0> <auth_token>/g,
+      'Log into instagram.com in that browser profile, then run ft sync instagram');
+  return new Error(/instagram/i.test(rewritten)
+    ? rewritten
+    : `${rewritten}\nLog into instagram.com in that browser profile, then run ft sync instagram.`);
+}
+
+export function extractChromeInstagramCookies(
+  chromeUserDataDir: string,
+  profileDirectory = 'Default',
+  browser: BrowserDef | undefined = undefined,
+): ChromeCookieResult {
+  try {
+    return extractChromeInstagramCookiesUnchecked(chromeUserDataDir, profileDirectory, browser);
+  } catch (error) {
+    throw instagramCookieGuidance(error);
+  }
 }

--- a/src/chrome-cookies.ts
+++ b/src/chrome-cookies.ts
@@ -509,3 +509,77 @@ export function extractChromeXCookies(
 
   return { csrfToken: cleanCt0, cookieHeader };
 }
+
+/**
+ * Read only the fixed cookie set required by Instagram Saved ingestion.
+ * The domain and names are intentionally not caller-configurable.
+ */
+export function extractChromeInstagramCookies(
+  chromeUserDataDir: string,
+  profileDirectory = 'Default',
+  browser: BrowserDef | undefined = undefined,
+): ChromeCookieResult {
+  const os = platform();
+  const br = browser ?? {
+    id: 'chrome',
+    displayName: 'Google Chrome',
+    cookieBackend: 'chromium' as const,
+    keychainEntries: [],
+  };
+  const dbPath = resolveCookieDbPath(chromeUserDataDir, profileDirectory);
+
+  let key: Buffer;
+  let v11Key: Buffer | null | undefined;
+  let isWindows = false;
+  if (os === 'darwin') {
+    key = getMacOSKey(br);
+  } else if (os === 'linux') {
+    const linuxKeys = getLinuxKeys(br);
+    key = linuxKeys.v10;
+    v11Key = linuxKeys.v11;
+  } else if (os === 'win32') {
+    key = getWindowsKey(chromeUserDataDir, br);
+    isWindows = true;
+  } else {
+    throw new Error(`Automatic Instagram cookie extraction is not supported on ${os}.`);
+  }
+
+  const result = queryCookies(
+    dbPath,
+    '.instagram.com',
+    ['sessionid', 'csrftoken', 'ds_user_id', 'mid', 'rur'],
+    br,
+  );
+  const decrypted = new Map<string, string>();
+  for (const cookie of result.cookies) {
+    if (cookie.encrypted_value_hex) {
+      const encrypted = Buffer.from(cookie.encrypted_value_hex, 'hex');
+      decrypted.set(cookie.name, isWindows
+        ? decryptWindowsCookie(encrypted, key)
+        : decryptCookieValue(encrypted, key, result.dbVersion, v11Key));
+    } else if (cookie.value) {
+      decrypted.set(cookie.name, cookie.value);
+    }
+  }
+
+  const csrfToken = decrypted.get('csrftoken');
+  const sessionId = decrypted.get('sessionid');
+  if (!csrfToken || !sessionId) {
+    throw new Error(
+      `No active Instagram session found in ${br.displayName}.\n` +
+      'Open instagram.com, log in, and retry. If the login is in another profile, ' +
+      'pass --chrome-profile-directory <name>.'
+    );
+  }
+  const orderedNames = ['sessionid', 'csrftoken', 'ds_user_id', 'mid', 'rur'];
+  const cookieHeader = orderedNames
+    .flatMap((name) => {
+      const value = decrypted.get(name);
+      return value ? [`${name}=${sanitizeCookieValue(name, value, br)}`] : [];
+    })
+    .join('; ');
+  return {
+    csrfToken: sanitizeCookieValue('csrftoken', csrfToken, br),
+    cookieHeader,
+  };
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -34,7 +34,7 @@ import { exportBookmarks } from './md-export.js';
 import { renderViz } from './bookmarks-viz.js';
 import { listBrowserIds } from './browsers.js';
 import { configureHttpProxyFromEnv } from './http-proxy.js';
-import { canonicalLibraryDir, dataDir, ensureDataDir, isFirstRun, migrateLegacyIdeasData, twitterBookmarksIndexPath, twitterBackfillStatePath, mdDir, bookmarkMediaDir, bookmarkMediaManifestPath } from './paths.js';
+import { canonicalLibraryDir, dataDir, ensureDataDir, instagramSavedCachePath, isFirstRun, migrateLegacyIdeasData, twitterBookmarksIndexPath, twitterBackfillStatePath, mdDir, bookmarkMediaDir, bookmarkMediaManifestPath } from './paths.js';
 import { PromptCancelledError, promptText } from './prompt.js';
 import { skillWithFrontmatter, installSkill, uninstallSkill } from './skill.js';
 import { registerCompanionCommands } from './companion-cli.js';
@@ -623,9 +623,23 @@ function requireData(): boolean {
   return true;
 }
 
+export function hasAnyBookmarkData(): boolean {
+  return !isFirstRun() || fs.existsSync(instagramSavedCachePath());
+}
+
+function requireAnyBookmarkData(): boolean {
+  if (hasAnyBookmarkData()) return true;
+  console.log(`
+  No bookmarks synced yet.
+
+  Run ft sync for X bookmarks or ft sync instagram for Instagram Saved.
+`);
+  process.exitCode = 1;
+  return false;
+}
+
 /** Check that the search index exists. Returns true if it does. */
 function requireIndex(): boolean {
-  if (!requireData()) return false;
   if (!fs.existsSync(twitterBookmarksIndexPath())) {
     console.log(`
   Search index not built yet.
@@ -1590,9 +1604,9 @@ export function buildCli() {
     .description('Rebuild the SQLite search index from the JSONL cache')
     .option('--force', 'Drop and rebuild from scratch (loses classifications)')
     .action(safe(async (options) => {
-      if (!requireData()) return;
+      if (!requireAnyBookmarkData()) return;
       process.stderr.write('Building search index...\n');
-      const result = await buildIndex({ force: Boolean(options.force) });
+      const result = await buildIndex({ force: Boolean(options.force), reportSource: 'all' });
       console.log(`Indexed ${result.recordCount} bookmarks (${result.newRecords} new) \u2192 ${result.dbPath}`);
     }));
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,6 +5,7 @@ import { getBookmarkStatusView, formatBookmarkStatus } from './bookmarks-service
 import { runTwitterOAuthFlow } from './xauth.js';
 import { syncBookmarksGraphQL, syncGaps, syncBookmarkFolders } from './graphql-bookmarks.js';
 import type { SyncProgress, GapFillProgress, FolderSyncProgress } from './graphql-bookmarks.js';
+import { syncInstagramSaved } from './instagram-bookmarks.js';
 import type { BookmarkFolder, QuotedTweetSnapshot } from './types.js';
 import { DEFAULT_MEDIA_MAX_BYTES, fetchBookmarkMediaBatch } from './bookmark-media.js';
 import type { MediaFetchManifest, MediaFetchProgress } from './bookmark-media.js';
@@ -300,6 +301,12 @@ export function parseCookieOption(cookies: unknown): { csrfToken?: string; cooki
   const parts = [`ct0=${csrfToken}`];
   if (authToken) parts.push(`auth_token=${authToken}`);
   return { csrfToken, cookieHeader: parts.join('; ') };
+}
+
+export function resolveSyncSource(source: string | undefined): 'x' | 'instagram' {
+  if (source == null || source === '' || source.toLowerCase() === 'x') return 'x';
+  if (source.toLowerCase() === 'instagram') return 'instagram';
+  throw new Error(`Unknown sync source: ${source}. Use "ft sync" for X or "ft sync instagram".`);
 }
 
 function warnIfEmpty(totalBookmarks: number): void {
@@ -826,7 +833,8 @@ export function buildCli() {
 
   program
     .command('sync')
-    .description('Sync bookmarks from X into your local database')
+    .description('Sync X bookmarks, or explicitly select Instagram Saved')
+    .argument('[source]', 'Optional source: instagram (no argument keeps the existing X sync)')
     .option('--api', 'Use OAuth v2 API instead of Chrome session', false)
     .option('--rebuild', 'Full re-crawl of all bookmarks', false)
     .option('--continue', 'Resume a previous sync that was interrupted or hit the page limit', false)
@@ -848,7 +856,41 @@ export function buildCli() {
     .option('--folders', 'Also sync bookmark folder tags (mirrors X\u2019s current folder state)', false)
     .option('--folder <name>', 'Sync only this folder (case-insensitive, supports unambiguous prefix)')
     .addOption(engineOption())
-    .action(async (options) => {
+    .action(async (source: string | undefined, options) => {
+      let syncSource: 'x' | 'instagram';
+      try {
+        syncSource = resolveSyncSource(source);
+      } catch (error) {
+        console.error(`  Error: ${(error as Error).message}`);
+        process.exitCode = 1;
+        return;
+      }
+
+      if (syncSource === 'instagram') {
+        ensureDataDir();
+        try {
+          process.stderr.write('  Syncing Instagram Saved posts and Reels (experimental)...\n');
+          const result = await syncInstagramSaved({
+            maxPages: options.maxPages != null ? Number(options.maxPages) : undefined,
+            delayMs: Number(options.delayMs) || 600,
+            maxMinutes: Number(options.maxMinutes) || 30,
+            browser: options.browser ? String(options.browser) : undefined,
+            chromeUserDataDir: options.chromeUserDataDir ? String(options.chromeUserDataDir) : undefined,
+            chromeProfileDirectory: options.chromeProfileDirectory ? String(options.chromeProfileDirectory) : undefined,
+            firefoxProfileDir: options.firefoxProfileDir ? String(options.firefoxProfileDir) : undefined,
+          });
+          console.log(`\n  ${result.complete ? '\u2713' : '\u26a0'} ${result.added} new Instagram Saved items (${result.totalBookmarks} total)`);
+          console.log(`  ${result.complete ? 'Complete' : 'Incomplete'}: ${result.stopReason}`);
+          console.log(`  \u2713 Data: ${dataDir()}\n`);
+          await rebuildIndex();
+          if (!result.complete) process.exitCode = 1;
+        } catch (error) {
+          console.error(`\n  Instagram sync error: ${(error as Error).message}\n`);
+          process.exitCode = 1;
+        }
+        return;
+      }
+
       const firstRun = isFirstRun();
       if (firstRun) showSyncWelcome();
       ensureDataDir();

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -778,9 +778,9 @@ export function buildCli() {
 
   const program = new Command();
 
-  async function rebuildIndex(): Promise<number> {
+  async function rebuildIndex(reportSource: 'x' | 'all' = 'x'): Promise<number> {
     process.stderr.write('  Building search index...\n');
-    const idx = await buildIndex();
+    const idx = await buildIndex({ reportSource });
     process.stderr.write(`  \u2713 ${idx.recordCount} bookmarks indexed (${idx.newRecords} new)\n`);
     return idx.newRecords;
   }
@@ -874,6 +874,7 @@ export function buildCli() {
             maxPages: options.maxPages != null ? Number(options.maxPages) : undefined,
             delayMs: Number(options.delayMs) || 600,
             maxMinutes: Number(options.maxMinutes) || 30,
+            rebuild: Boolean(options.rebuild),
             browser: options.browser ? String(options.browser) : undefined,
             chromeUserDataDir: options.chromeUserDataDir ? String(options.chromeUserDataDir) : undefined,
             chromeProfileDirectory: options.chromeProfileDirectory ? String(options.chromeProfileDirectory) : undefined,
@@ -881,8 +882,11 @@ export function buildCli() {
           });
           console.log(`\n  ${result.complete ? '\u2713' : '\u26a0'} ${result.added} new Instagram Saved items (${result.totalBookmarks} total)`);
           console.log(`  ${result.complete ? 'Complete' : 'Incomplete'}: ${result.stopReason}`);
+          if (!result.complete) {
+            console.log('  Retry to resume, or use ft sync instagram --rebuild to restart from the newest Saved page.');
+          }
           console.log(`  \u2713 Data: ${dataDir()}\n`);
-          await rebuildIndex();
+          await rebuildIndex('all');
           if (!result.complete) process.exitCode = 1;
         } catch (error) {
           console.error(`\n  Instagram sync error: ${(error as Error).message}\n`);
@@ -1297,6 +1301,7 @@ export function buildCli() {
       }
 
       const items = await listBookmarks({
+        source: 'all',
         query: options.query ? String(options.query) : undefined,
         author: options.author ? String(options.author) : undefined,
         after: options.after ? String(options.after) : undefined,

--- a/src/firefox-cookies.ts
+++ b/src/firefox-cookies.ts
@@ -285,7 +285,7 @@ export function extractFirefoxXCookies(profileDir?: string): ChromeCookieResult 
 }
 
 /** Fixed-domain Instagram session extraction for the Saved connector. */
-export function extractFirefoxInstagramCookies(profileDir?: string): ChromeCookieResult {
+function extractFirefoxInstagramCookiesUnchecked(profileDir?: string): ChromeCookieResult {
   const dir = profileDir ?? detectFirefoxProfileDir();
   const dbPath = join(dir, 'cookies.sqlite');
   ensureFirefoxCookieBackendAvailable();
@@ -304,13 +304,32 @@ export function extractFirefoxInstagramCookies(profileDir?: string): ChromeCooki
     );
   }
   const orderedNames = ['sessionid', 'csrftoken', 'ds_user_id', 'mid', 'rur'];
+  const requiredNames = new Set(['sessionid', 'csrftoken']);
   const parts = orderedNames.flatMap((name) => {
     const value = cookieMap.get(name);
     if (!value) return [];
     if (!/^[\x21-\x7E]+$/.test(value)) {
-      throw new Error(`Firefox Instagram ${name} cookie appears invalid.`);
+      if (requiredNames.has(name)) {
+        throw new Error(`Firefox Instagram ${name} cookie appears invalid.`);
+      }
+      return [];
     }
     return [`${name}=${value}`];
   });
   return { csrfToken, cookieHeader: parts.join('; ') };
+}
+
+export function extractFirefoxInstagramCookies(profileDir?: string): ChromeCookieResult {
+  try {
+    return extractFirefoxInstagramCookiesUnchecked(profileDir);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    const rewritten = message
+      .replace(/log into x\.com/g, 'log into instagram.com')
+      .replace(/(?:Or p|P)ass cookies manually:\s*ft sync --cookies <ct0> <auth_token>/g,
+        'Log into instagram.com in that Firefox profile, then run ft sync instagram');
+    throw new Error(/instagram/i.test(rewritten)
+      ? rewritten
+      : `${rewritten}\nLog into instagram.com in that Firefox profile, then run ft sync instagram.`);
+  }
 }

--- a/src/firefox-cookies.ts
+++ b/src/firefox-cookies.ts
@@ -283,3 +283,34 @@ export function extractFirefoxXCookies(profileDir?: string): ChromeCookieResult 
 
   return { csrfToken: cleanCt0, cookieHeader: cookieParts.join('; ') };
 }
+
+/** Fixed-domain Instagram session extraction for the Saved connector. */
+export function extractFirefoxInstagramCookies(profileDir?: string): ChromeCookieResult {
+  const dir = profileDir ?? detectFirefoxProfileDir();
+  const dbPath = join(dir, 'cookies.sqlite');
+  ensureFirefoxCookieBackendAvailable();
+  const cookies = queryFirefoxCookies(
+    dbPath,
+    '.instagram.com',
+    ['sessionid', 'csrftoken', 'ds_user_id', 'mid', 'rur'],
+  );
+  const cookieMap = new Map(cookies.map((cookie) => [cookie.name, cookie.value.trim()]));
+  const csrfToken = cookieMap.get('csrftoken');
+  const sessionId = cookieMap.get('sessionid');
+  if (!csrfToken || !sessionId) {
+    throw new Error(
+      'No active Instagram session found in Firefox.\n' +
+      'Open instagram.com in Firefox, log in, and retry.'
+    );
+  }
+  const orderedNames = ['sessionid', 'csrftoken', 'ds_user_id', 'mid', 'rur'];
+  const parts = orderedNames.flatMap((name) => {
+    const value = cookieMap.get(name);
+    if (!value) return [];
+    if (!/^[\x21-\x7E]+$/.test(value)) {
+      throw new Error(`Firefox Instagram ${name} cookie appears invalid.`);
+    }
+    return [`${name}=${value}`];
+  });
+  return { csrfToken, cookieHeader: parts.join('; ') };
+}

--- a/src/instagram-bookmarks.ts
+++ b/src/instagram-bookmarks.ts
@@ -113,6 +113,16 @@ function mediaCandidates(item: any): BookmarkMediaObject[] {
   }];
 }
 
+function instagramContentType(item: any): BookmarkRecord['contentType'] {
+  if (item.product_type === 'clips' || item.product_type === 'reels') return 'reel';
+  switch (Number(item.media_type)) {
+    case 1: return 'photo';
+    case 2: return 'video';
+    case 8: return 'carousel';
+    default: return undefined;
+  }
+}
+
 function normalizeInstagramItem(raw: any, syncedAt: string): BookmarkRecord | null {
   const item = raw?.media ?? raw;
   const idValue = item?.pk ?? item?.id;
@@ -121,17 +131,9 @@ function normalizeInstagramItem(raw: any, syncedAt: string): BookmarkRecord | nu
   if (!/^\d+$/.test(id) && !/^[A-Za-z0-9_-]+$/.test(id)) return null;
 
   const mediaType = Number(item.media_type);
-  const isReel = item.product_type === 'clips' || item.product_type === 'reels';
-  const contentType: BookmarkRecord['contentType'] = isReel
-    ? 'reel'
-    : mediaType === 8
-      ? 'carousel'
-      : mediaType === 2
-        ? 'video'
-        : mediaType === 1
-          ? 'photo'
-          : undefined;
+  const contentType = instagramContentType(item);
   if (!contentType) return null;
+  const isReel = contentType === 'reel';
 
   const url = canonicalInstagramUrl(item.code, isReel);
   if (!url || !isAllowedHost(url, ['instagram.com'])) return null;

--- a/src/instagram-bookmarks.ts
+++ b/src/instagram-bookmarks.ts
@@ -1,0 +1,404 @@
+import { loadChromeSessionConfig } from './config.js';
+import { extractChromeInstagramCookies } from './chrome-cookies.js';
+import { extractFirefoxInstagramCookies } from './firefox-cookies.js';
+import { ensureDir, pathExists, readJson, readJsonLines, writeJson, writeJsonLines } from './fs.js';
+import { dataDir, instagramSavedCachePath, instagramSavedStatePath } from './paths.js';
+import type { BookmarkMediaObject, BookmarkMediaVariant, BookmarkRecord } from './types.js';
+
+const INSTAGRAM_SAVED_ENDPOINT = 'https://www.instagram.com/api/v1/feed/saved/posts/';
+const INSTAGRAM_APP_ID = '936619743392459';
+const DEFAULT_DELAY_MS = 600;
+const DEFAULT_MAX_MINUTES = 30;
+
+export interface InstagramSession {
+  csrfToken: string;
+  cookieHeader: string;
+}
+
+export interface InstagramSavedPage {
+  records: BookmarkRecord[];
+  nextCursor?: string;
+}
+
+export interface InstagramSyncProgress {
+  page: number;
+  totalFetched: number;
+  newAdded: number;
+  running: boolean;
+  complete: boolean;
+  stopReason?: string;
+}
+
+export interface InstagramSyncResult {
+  added: number;
+  totalBookmarks: number;
+  pages: number;
+  complete: boolean;
+  stopReason: string;
+  cachePath: string;
+  statePath: string;
+}
+
+interface InstagramSyncState {
+  provider: 'instagram';
+  schemaVersion: 1;
+  complete: boolean;
+  totalRuns: number;
+  lastRunAt?: string;
+  lastCursor?: string;
+  stopReason?: string;
+}
+
+export interface InstagramSyncOptions {
+  session?: InstagramSession;
+  sessionProvider?: () => InstagramSession;
+  browser?: string;
+  chromeUserDataDir?: string;
+  chromeProfileDirectory?: string;
+  firefoxProfileDir?: string;
+  maxPages?: number;
+  delayMs?: number;
+  maxMinutes?: number;
+  signal?: AbortSignal;
+  fetchImpl?: typeof fetch;
+  sleep?: (ms: number) => Promise<void>;
+  now?: () => Date;
+  onProgress?: (progress: InstagramSyncProgress) => void;
+}
+
+class InstagramStopError extends Error {
+  constructor(readonly stopReason: string) {
+    super(stopReason);
+  }
+}
+
+function isAllowedHost(urlValue: unknown, suffixes: string[]): urlValue is string {
+  if (typeof urlValue !== 'string') return false;
+  try {
+    const url = new URL(urlValue);
+    if (url.protocol !== 'https:') return false;
+    const host = url.hostname.toLowerCase();
+    return suffixes.some((suffix) => host === suffix || host.endsWith(`.${suffix}`));
+  } catch {
+    return false;
+  }
+}
+
+function canonicalInstagramUrl(code: unknown, reel: boolean): string | undefined {
+  if (typeof code !== 'string' || !/^[A-Za-z0-9_-]+$/.test(code)) return undefined;
+  return `https://www.instagram.com/${reel ? 'reel' : 'p'}/${code}/`;
+}
+
+function mediaCandidates(item: any): BookmarkMediaObject[] {
+  const preview = item?.image_versions2?.candidates?.find((candidate: any) =>
+    isAllowedHost(candidate?.url, ['cdninstagram.com', 'fbcdn.net'])
+  );
+  const variants: BookmarkMediaVariant[] = Array.isArray(item?.video_versions)
+    ? item.video_versions
+        .filter((variant: any) => isAllowedHost(variant?.url, ['cdninstagram.com', 'fbcdn.net']))
+        .map((variant: any) => ({
+          url: variant.url,
+          contentType: 'video/mp4',
+          bitrate: typeof variant.bitrate === 'number' ? variant.bitrate : undefined,
+        }))
+    : [];
+
+  if (!preview && variants.length === 0) return [];
+  return [{
+    type: Number(item?.media_type) === 2 ? 'video' : 'photo',
+    previewUrl: preview?.url,
+    width: typeof preview?.width === 'number' ? preview.width : undefined,
+    height: typeof preview?.height === 'number' ? preview.height : undefined,
+    videoVariants: variants.length ? variants : undefined,
+  }];
+}
+
+function normalizeInstagramItem(raw: any, syncedAt: string): BookmarkRecord | null {
+  const item = raw?.media ?? raw;
+  const idValue = item?.pk ?? item?.id;
+  if ((typeof idValue !== 'string' && typeof idValue !== 'number') || !item) return null;
+  const id = String(idValue);
+  if (!/^\d+$/.test(id) && !/^[A-Za-z0-9_-]+$/.test(id)) return null;
+
+  const mediaType = Number(item.media_type);
+  const isReel = item.product_type === 'clips' || item.product_type === 'reels';
+  const contentType: BookmarkRecord['contentType'] = isReel
+    ? 'reel'
+    : mediaType === 8
+      ? 'carousel'
+      : mediaType === 2
+        ? 'video'
+        : mediaType === 1
+          ? 'photo'
+          : undefined;
+  if (!contentType) return null;
+
+  const url = canonicalInstagramUrl(item.code, isReel);
+  if (!url || !isAllowedHost(url, ['instagram.com'])) return null;
+  const children = mediaType === 8 && Array.isArray(item.carousel_media)
+    ? item.carousel_media.flatMap((child: any) => mediaCandidates(child))
+    : mediaCandidates(item);
+  const takenAt = typeof item.taken_at === 'number'
+    ? new Date(item.taken_at * 1000).toISOString()
+    : null;
+
+  return {
+    id,
+    tweetId: id,
+    nativeId: id,
+    source: 'instagram',
+    contentType,
+    url,
+    canonicalUrl: url,
+    text: typeof item.caption?.text === 'string' ? item.caption.text : '',
+    authorHandle: typeof item.user?.username === 'string' ? item.user.username : undefined,
+    authorName: typeof item.user?.full_name === 'string' ? item.user.full_name : undefined,
+    authorProfileImageUrl: isAllowedHost(item.user?.profile_pic_url, ['cdninstagram.com', 'fbcdn.net'])
+      ? item.user.profile_pic_url
+      : undefined,
+    postedAt: takenAt,
+    bookmarkedAt: null,
+    syncedAt,
+    mediaObjects: children,
+    media: children
+      .flatMap((media: BookmarkMediaObject) => [
+        media.previewUrl,
+        ...(media.videoVariants ?? []).map((variant: BookmarkMediaVariant) => variant.url),
+      ])
+      .filter((value: string | undefined): value is string => Boolean(value)),
+    links: [],
+    tags: [],
+    ingestedVia: 'instagram-web',
+    untrustedFields: ['text', 'authorHandle', 'authorName'],
+  };
+}
+
+export function parseInstagramSavedResponse(json: any, syncedAt = new Date().toISOString()): InstagramSavedPage {
+  if (!json || typeof json !== 'object' || !Array.isArray(json.items)) {
+    throw new InstagramStopError('response shape changed');
+  }
+  const records = json.items
+    .map((item: any) => normalizeInstagramItem(item, syncedAt))
+    .filter((record: BookmarkRecord | null): record is BookmarkRecord => record !== null);
+  if (json.items.length > 0 && records.length === 0) {
+    throw new InstagramStopError('response shape changed');
+  }
+  const moreAvailable = json.more_available === true;
+  const nextCursor = typeof json.next_max_id === 'string' && json.next_max_id
+    ? json.next_max_id
+    : undefined;
+  if (moreAvailable && !nextCursor) throw new InstagramStopError('response shape changed');
+  return { records, nextCursor: moreAvailable ? nextCursor : undefined };
+}
+
+function buildSavedUrl(cursor?: string): string {
+  const url = new URL(INSTAGRAM_SAVED_ENDPOINT);
+  url.searchParams.set('count', '12');
+  if (cursor) url.searchParams.set('max_id', cursor);
+  return url.toString();
+}
+
+function validateSession(session: InstagramSession): InstagramSession {
+  const csrfValid = Boolean(session.csrfToken) && /^[\x21-\x7E]+$/.test(session.csrfToken);
+  const headerValid = Boolean(session.cookieHeader) && /^[\x20-\x7E]+$/.test(session.cookieHeader);
+  if (!csrfValid || !headerValid) {
+    throw new Error('Instagram session cookies are missing or invalid. Log into instagram.com in the selected browser and retry.');
+  }
+  return session;
+}
+
+function acquireSession(options: InstagramSyncOptions): InstagramSession {
+  if (options.session) return validateSession(options.session);
+  if (options.sessionProvider) return validateSession(options.sessionProvider());
+  const config = loadChromeSessionConfig({ browserId: options.browser });
+  if (config.browser.cookieBackend === 'firefox') {
+    return validateSession(extractFirefoxInstagramCookies(options.firefoxProfileDir));
+  }
+  return validateSession(extractChromeInstagramCookies(
+    options.chromeUserDataDir ?? config.chromeUserDataDir,
+    options.chromeProfileDirectory ?? config.chromeProfileDirectory,
+    config.browser,
+  ));
+}
+
+async function fetchSavedPage(
+  session: InstagramSession,
+  cursor: string | undefined,
+  fetchImpl: typeof fetch,
+  syncedAt: string,
+): Promise<InstagramSavedPage> {
+  const response = await fetchImpl(buildSavedUrl(cursor), {
+    method: 'GET',
+    redirect: 'manual',
+    headers: {
+      accept: '*/*',
+      cookie: session.cookieHeader,
+      referer: 'https://www.instagram.com/saved/',
+      'x-csrftoken': session.csrfToken,
+      'x-ig-app-id': INSTAGRAM_APP_ID,
+      'x-requested-with': 'XMLHttpRequest',
+    },
+  });
+
+  if (response.status >= 300 && response.status < 400) {
+    throw new InstagramStopError('redirect refused');
+  }
+  if (response.status === 429) throw new InstagramStopError('rate limited');
+
+  let json: any;
+  try {
+    json = await response.json();
+  } catch {
+    throw new InstagramStopError('response shape changed');
+  }
+  const challenged = Boolean(json?.challenge || json?.challenge_url || json?.checkpoint_url) ||
+    /challenge|required checkpoint/i.test(String(json?.message ?? ''));
+  if (challenged) throw new InstagramStopError('challenge required');
+  if (response.status === 401 || response.status === 403 || json?.message === 'login_required') {
+    throw new InstagramStopError('authentication required');
+  }
+  if (!response.ok) throw new InstagramStopError(`request failed (${response.status})`);
+  return parseInstagramSavedResponse(json, syncedAt);
+}
+
+function mergeRecords(existing: BookmarkRecord[], incoming: BookmarkRecord[]): { records: BookmarkRecord[]; added: number } {
+  const byId = new Map(existing.map((record) => [record.id, record]));
+  let added = 0;
+  for (const record of incoming) {
+    const previous = byId.get(record.id);
+    if (!previous) added += 1;
+    byId.set(record.id, previous ? {
+      ...previous,
+      ...record,
+      text: record.text || previous.text,
+      mediaObjects: record.mediaObjects?.length ? record.mediaObjects : previous.mediaObjects,
+      media: record.media?.length ? record.media : previous.media,
+    } : record);
+  }
+  const records = [...byId.values()].sort((a, b) =>
+    String(b.postedAt ?? b.syncedAt).localeCompare(String(a.postedAt ?? a.syncedAt))
+  );
+  return { records, added };
+}
+
+export async function syncInstagramSaved(options: InstagramSyncOptions = {}): Promise<InstagramSyncResult> {
+  // Acquire credentials before creating directories or writing any state.
+  const session = acquireSession(options);
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const sleep = options.sleep ?? ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
+  const delayMs = Math.max(options.fetchImpl ? 0 : DEFAULT_DELAY_MS, options.delayMs ?? DEFAULT_DELAY_MS);
+  const maxPages = options.maxPages ?? Infinity;
+  const maxMinutes = options.maxMinutes ?? DEFAULT_MAX_MINUTES;
+  const now = options.now ?? (() => new Date());
+  const cachePath = instagramSavedCachePath();
+  const statePath = instagramSavedStatePath();
+
+  const existing = await readJsonLines<BookmarkRecord>(cachePath);
+  let records = existing;
+  const knownIds = new Set(existing.map((record) => record.id));
+  const previousState = await pathExists(statePath)
+    ? await readJson<InstagramSyncState>(statePath)
+    : undefined;
+  const resumingBackfill = Boolean(previousState && !previousState.complete && previousState.lastCursor);
+  let cursor = resumingBackfill ? previousState?.lastCursor : undefined;
+  const incremental = Boolean(previousState?.complete || (existing.length > 0 && !resumingBackfill));
+  const started = Date.now();
+  let page = 0;
+  let totalFetched = 0;
+  let totalAdded = 0;
+  let stopReason = 'unknown';
+  let complete = false;
+
+  while (page < maxPages) {
+    if (options.signal?.aborted) {
+      stopReason = 'interrupted';
+      break;
+    }
+    if (Date.now() - started > maxMinutes * 60_000) {
+      stopReason = 'max runtime reached';
+      break;
+    }
+
+    let result: InstagramSavedPage;
+    try {
+      result = await fetchSavedPage(session, cursor, fetchImpl, now().toISOString());
+    } catch (error) {
+      if (!(error instanceof InstagramStopError)) throw error;
+      stopReason = error.stopReason;
+      break;
+    }
+
+    page += 1;
+    totalFetched += result.records.length;
+    const reachedKnown = incremental && result.records.some((record) => knownIds.has(record.id));
+    const merged = mergeRecords(records, result.records);
+    records = merged.records;
+    totalAdded += merged.added;
+    cursor = result.nextCursor;
+
+    await ensureDir(dataDir());
+    await writeJsonLines(cachePath, records);
+    await writeJson(statePath, {
+      provider: 'instagram',
+      schemaVersion: 1,
+      complete: false,
+      totalRuns: previousState?.totalRuns ?? 0,
+      lastRunAt: now().toISOString(),
+      lastCursor: cursor,
+      stopReason: 'in progress',
+    } satisfies InstagramSyncState);
+
+    options.onProgress?.({
+      page,
+      totalFetched,
+      newAdded: totalAdded,
+      running: true,
+      complete: false,
+    });
+
+    if (reachedKnown) {
+      stopReason = 'caught up to saved archive';
+      complete = true;
+      cursor = undefined;
+      break;
+    }
+    if (!cursor) {
+      stopReason = 'end of saved collection';
+      complete = true;
+      break;
+    }
+    if (page < maxPages) await sleep(delayMs);
+  }
+
+  if (stopReason === 'unknown') stopReason = page >= maxPages ? 'max pages reached' : 'incomplete';
+  if (page > 0) {
+    await writeJson(statePath, {
+      provider: 'instagram',
+      schemaVersion: 1,
+      complete,
+      totalRuns: (previousState?.totalRuns ?? 0) + 1,
+      lastRunAt: now().toISOString(),
+      lastCursor: complete ? undefined : cursor,
+      stopReason,
+    } satisfies InstagramSyncState);
+  }
+
+  options.onProgress?.({
+    page,
+    totalFetched,
+    newAdded: totalAdded,
+    running: false,
+    complete,
+    stopReason,
+  });
+
+  return {
+    added: totalAdded,
+    totalBookmarks: records.length,
+    pages: page,
+    complete,
+    stopReason,
+    cachePath,
+    statePath,
+  };
+}

--- a/src/instagram-bookmarks.ts
+++ b/src/instagram-bookmarks.ts
@@ -1,4 +1,4 @@
-import { readFile } from 'node:fs/promises';
+import { readFile, rm } from 'node:fs/promises';
 import { loadChromeSessionConfig } from './config.js';
 import { extractChromeInstagramCookies } from './chrome-cookies.js';
 import { extractFirefoxInstagramCookies } from './firefox-cookies.js';
@@ -50,6 +50,13 @@ interface InstagramSyncState {
   lastCursor?: string;
   stopReason?: string;
   mode?: 'backfill' | 'incremental';
+}
+
+interface InstagramSyncJournal {
+  provider: 'instagram';
+  schemaVersion: 1;
+  records: BookmarkRecord[];
+  state: InstagramSyncState;
 }
 
 export interface InstagramSyncOptions {
@@ -294,6 +301,16 @@ function mergeRecords(existing: BookmarkRecord[], incoming: BookmarkRecord[]): {
   return { records, added };
 }
 
+function isInstagramCacheRecord(record: Partial<BookmarkRecord> | null): record is BookmarkRecord {
+  return Boolean(record &&
+    typeof record === 'object' &&
+    typeof record.id === 'string' &&
+    typeof record.tweetId === 'string' &&
+    typeof record.url === 'string' &&
+    typeof record.text === 'string' &&
+    typeof record.syncedAt === 'string');
+}
+
 async function readInstagramCache(cachePath: string): Promise<BookmarkRecord[]> {
   if (!await pathExists(cachePath)) return [];
   try {
@@ -305,20 +322,45 @@ async function readInstagramCache(cachePath: string): Promise<BookmarkRecord[]> 
       .filter(Boolean)
       .map((line) => {
         const record = JSON.parse(line) as Partial<BookmarkRecord>;
-        if (!record ||
-            typeof record !== 'object' ||
-            typeof record.id !== 'string' ||
-            typeof record.tweetId !== 'string' ||
-            typeof record.url !== 'string' ||
-            typeof record.text !== 'string' ||
-            typeof record.syncedAt !== 'string') {
+        if (!isInstagramCacheRecord(record)) {
           throw new Error('invalid record');
         }
-        return record as BookmarkRecord;
+        return record;
       });
   } catch {
     throw new Error(`Instagram cache is unreadable or malformed at ${cachePath}. No changes were written.`);
   }
+}
+
+async function recoverInstagramJournal(
+  cachePath: string,
+  statePath: string,
+  journalPath: string,
+): Promise<void> {
+  if (!await pathExists(journalPath)) return;
+
+  let journal: InstagramSyncJournal;
+  try {
+    journal = await readJson<InstagramSyncJournal>(journalPath);
+    if (journal?.provider !== 'instagram' ||
+        journal.schemaVersion !== 1 ||
+        !Array.isArray(journal.records) ||
+        !journal.records.every((record) => isInstagramCacheRecord(record)) ||
+        journal.state?.provider !== 'instagram' ||
+        journal.state.schemaVersion !== 1 ||
+        typeof journal.state.complete !== 'boolean' ||
+        typeof journal.state.totalRuns !== 'number') {
+      throw new Error('invalid journal');
+    }
+  } catch {
+    throw new Error(`Instagram checkpoint journal is unreadable or malformed at ${journalPath}. No changes were written.`);
+  }
+
+  const existing = await readInstagramCache(cachePath);
+  const recovered = mergeRecords(existing, journal.records);
+  await writeJsonLines(cachePath, recovered.records);
+  await writeJson(statePath, journal.state);
+  await rm(journalPath, { force: true });
 }
 
 export async function syncInstagramSaved(options: InstagramSyncOptions = {}): Promise<InstagramSyncResult> {
@@ -333,7 +375,9 @@ export async function syncInstagramSaved(options: InstagramSyncOptions = {}): Pr
   const now = options.now ?? (() => new Date());
   const cachePath = instagramSavedCachePath();
   const statePath = instagramSavedStatePath();
+  const journalPath = `${statePath}.journal`;
 
+  await recoverInstagramJournal(cachePath, statePath, journalPath);
   const existing = await readInstagramCache(cachePath);
   let records = existing;
   const knownIds = new Set(existing.map((record) => record.id));
@@ -404,18 +448,36 @@ export async function syncInstagramSaved(options: InstagramSyncOptions = {}): Pr
     totalAdded += merged.added;
     cursor = result.nextCursor;
 
-    await ensureDir(dataDir());
-    await writeJsonLines(cachePath, records);
-    await writeJson(statePath, {
+    let checkpointComplete = false;
+    let checkpointStopReason = 'in progress';
+    if (reachedKnown) {
+      checkpointComplete = true;
+      checkpointStopReason = 'caught up to saved archive';
+    } else if (!cursor) {
+      checkpointComplete = true;
+      checkpointStopReason = 'end of saved collection';
+    }
+    const checkpointState: InstagramSyncState = {
       provider: 'instagram',
       schemaVersion: 1,
-      complete: false,
-      totalRuns: previousState?.totalRuns ?? 0,
+      complete: checkpointComplete,
+      totalRuns: (previousState?.totalRuns ?? 0) + (checkpointComplete ? 1 : 0),
       lastRunAt: now().toISOString(),
-      lastCursor: cursor,
-      stopReason: 'in progress',
+      lastCursor: checkpointComplete ? undefined : cursor,
+      stopReason: checkpointStopReason,
       mode: runMode,
-    } satisfies InstagramSyncState);
+    };
+
+    await ensureDir(dataDir());
+    await writeJson(journalPath, {
+      provider: 'instagram',
+      schemaVersion: 1,
+      records: result.records,
+      state: checkpointState,
+    } satisfies InstagramSyncJournal);
+    await writeJsonLines(cachePath, records);
+    await writeJson(statePath, checkpointState);
+    await rm(journalPath, { force: true });
 
     options.onProgress?.({
       page,

--- a/src/instagram-bookmarks.ts
+++ b/src/instagram-bookmarks.ts
@@ -1,7 +1,8 @@
+import { readFile } from 'node:fs/promises';
 import { loadChromeSessionConfig } from './config.js';
 import { extractChromeInstagramCookies } from './chrome-cookies.js';
 import { extractFirefoxInstagramCookies } from './firefox-cookies.js';
-import { ensureDir, pathExists, readJson, readJsonLines, writeJson, writeJsonLines } from './fs.js';
+import { ensureDir, pathExists, readJson, writeJson, writeJsonLines } from './fs.js';
 import { dataDir, instagramSavedCachePath, instagramSavedStatePath } from './paths.js';
 import type { BookmarkMediaObject, BookmarkMediaVariant, BookmarkRecord } from './types.js';
 
@@ -9,6 +10,7 @@ const INSTAGRAM_SAVED_ENDPOINT = 'https://www.instagram.com/api/v1/feed/saved/po
 const INSTAGRAM_APP_ID = '936619743392459';
 const DEFAULT_DELAY_MS = 600;
 const DEFAULT_MAX_MINUTES = 30;
+const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
 
 export interface InstagramSession {
   csrfToken: string;
@@ -47,6 +49,7 @@ interface InstagramSyncState {
   lastRunAt?: string;
   lastCursor?: string;
   stopReason?: string;
+  mode?: 'backfill' | 'incremental';
 }
 
 export interface InstagramSyncOptions {
@@ -59,6 +62,8 @@ export interface InstagramSyncOptions {
   maxPages?: number;
   delayMs?: number;
   maxMinutes?: number;
+  requestTimeoutMs?: number;
+  rebuild?: boolean;
   signal?: AbortSignal;
   fetchImpl?: typeof fetch;
   sleep?: (ms: number) => Promise<void>;
@@ -179,12 +184,11 @@ export function parseInstagramSavedResponse(json: any, syncedAt = new Date().toI
   if (!json || typeof json !== 'object' || !Array.isArray(json.items)) {
     throw new InstagramStopError('response shape changed');
   }
-  const records = json.items
-    .map((item: any) => normalizeInstagramItem(item, syncedAt))
-    .filter((record: BookmarkRecord | null): record is BookmarkRecord => record !== null);
-  if (json.items.length > 0 && records.length === 0) {
+  const normalized = json.items.map((item: any) => normalizeInstagramItem(item, syncedAt));
+  if (normalized.some((record: BookmarkRecord | null) => record === null)) {
     throw new InstagramStopError('response shape changed');
   }
+  const records = normalized as BookmarkRecord[];
   const moreAvailable = json.more_available === true;
   const nextCursor = typeof json.next_max_id === 'string' && json.next_max_id
     ? json.next_max_id
@@ -228,10 +232,12 @@ async function fetchSavedPage(
   cursor: string | undefined,
   fetchImpl: typeof fetch,
   syncedAt: string,
+  signal: AbortSignal,
 ): Promise<InstagramSavedPage> {
   const response = await fetchImpl(buildSavedUrl(cursor), {
     method: 'GET',
     redirect: 'manual',
+    signal,
     headers: {
       accept: '*/*',
       cookie: session.cookieHeader,
@@ -273,6 +279,11 @@ function mergeRecords(existing: BookmarkRecord[], incoming: BookmarkRecord[]): {
       ...previous,
       ...record,
       text: record.text || previous.text,
+      authorHandle: record.authorHandle ?? previous.authorHandle,
+      authorName: record.authorName ?? previous.authorName,
+      authorProfileImageUrl: record.authorProfileImageUrl ?? previous.authorProfileImageUrl,
+      postedAt: record.postedAt ?? previous.postedAt,
+      bookmarkedAt: record.bookmarkedAt ?? previous.bookmarkedAt,
       mediaObjects: record.mediaObjects?.length ? record.mediaObjects : previous.mediaObjects,
       media: record.media?.length ? record.media : previous.media,
     } : record);
@@ -283,6 +294,33 @@ function mergeRecords(existing: BookmarkRecord[], incoming: BookmarkRecord[]): {
   return { records, added };
 }
 
+async function readInstagramCache(cachePath: string): Promise<BookmarkRecord[]> {
+  if (!await pathExists(cachePath)) return [];
+  try {
+    const raw = await readFile(cachePath, 'utf8');
+    if (!raw.trim()) return [];
+    return raw
+      .split('\n')
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .map((line) => {
+        const record = JSON.parse(line) as Partial<BookmarkRecord>;
+        if (!record ||
+            typeof record !== 'object' ||
+            typeof record.id !== 'string' ||
+            typeof record.tweetId !== 'string' ||
+            typeof record.url !== 'string' ||
+            typeof record.text !== 'string' ||
+            typeof record.syncedAt !== 'string') {
+          throw new Error('invalid record');
+        }
+        return record as BookmarkRecord;
+      });
+  } catch {
+    throw new Error(`Instagram cache is unreadable or malformed at ${cachePath}. No changes were written.`);
+  }
+}
+
 export async function syncInstagramSaved(options: InstagramSyncOptions = {}): Promise<InstagramSyncResult> {
   // Acquire credentials before creating directories or writing any state.
   const session = acquireSession(options);
@@ -291,19 +329,26 @@ export async function syncInstagramSaved(options: InstagramSyncOptions = {}): Pr
   const delayMs = Math.max(options.fetchImpl ? 0 : DEFAULT_DELAY_MS, options.delayMs ?? DEFAULT_DELAY_MS);
   const maxPages = options.maxPages ?? Infinity;
   const maxMinutes = options.maxMinutes ?? DEFAULT_MAX_MINUTES;
+  const requestTimeoutMs = Math.max(1, options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS);
   const now = options.now ?? (() => new Date());
   const cachePath = instagramSavedCachePath();
   const statePath = instagramSavedStatePath();
 
-  const existing = await readJsonLines<BookmarkRecord>(cachePath);
+  const existing = await readInstagramCache(cachePath);
   let records = existing;
   const knownIds = new Set(existing.map((record) => record.id));
   const previousState = await pathExists(statePath)
     ? await readJson<InstagramSyncState>(statePath)
     : undefined;
-  const resumingBackfill = Boolean(previousState && !previousState.complete && previousState.lastCursor);
-  let cursor = resumingBackfill ? previousState?.lastCursor : undefined;
-  const incremental = Boolean(previousState?.complete || (existing.length > 0 && !resumingBackfill));
+  const resuming = Boolean(!options.rebuild && previousState && !previousState.complete && previousState.lastCursor);
+  const resumingIncremental = Boolean(resuming && previousState?.mode === 'incremental');
+  let cursor = resuming ? previousState?.lastCursor : undefined;
+  const incremental = Boolean(!options.rebuild && (
+    previousState?.complete ||
+    resumingIncremental ||
+    (existing.length > 0 && !resuming)
+  ));
+  const runMode: InstagramSyncState['mode'] = incremental ? 'incremental' : 'backfill';
   const started = Date.now();
   let page = 0;
   let totalFetched = 0;
@@ -322,12 +367,33 @@ export async function syncInstagramSaved(options: InstagramSyncOptions = {}): Pr
     }
 
     let result: InstagramSavedPage;
+    const requestController = new AbortController();
+    const abortRequest = () => requestController.abort();
+    options.signal?.addEventListener('abort', abortRequest, { once: true });
+    const remainingRuntimeMs = Math.max(1, maxMinutes * 60_000 - (Date.now() - started));
+    const requestBudgetMs = Math.min(requestTimeoutMs, remainingRuntimeMs);
+    const requestTimer = setTimeout(abortRequest, requestBudgetMs);
     try {
-      result = await fetchSavedPage(session, cursor, fetchImpl, now().toISOString());
+      result = await fetchSavedPage(
+        session,
+        cursor,
+        fetchImpl,
+        now().toISOString(),
+        requestController.signal,
+      );
     } catch (error) {
+      if (requestController.signal.aborted) {
+        if (options.signal?.aborted) stopReason = 'interrupted';
+        else if (requestBudgetMs === remainingRuntimeMs) stopReason = 'max runtime reached';
+        else stopReason = 'request timed out';
+        break;
+      }
       if (!(error instanceof InstagramStopError)) throw error;
       stopReason = error.stopReason;
       break;
+    } finally {
+      clearTimeout(requestTimer);
+      options.signal?.removeEventListener('abort', abortRequest);
     }
 
     page += 1;
@@ -348,6 +414,7 @@ export async function syncInstagramSaved(options: InstagramSyncOptions = {}): Pr
       lastRunAt: now().toISOString(),
       lastCursor: cursor,
       stopReason: 'in progress',
+      mode: runMode,
     } satisfies InstagramSyncState);
 
     options.onProgress?.({
@@ -382,6 +449,7 @@ export async function syncInstagramSaved(options: InstagramSyncOptions = {}): Pr
       lastRunAt: now().toISOString(),
       lastCursor: complete ? undefined : cursor,
       stopReason,
+      mode: runMode,
     } satisfies InstagramSyncState);
   }
 

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -104,6 +104,14 @@ export function twitterBookmarksMetaPath(): string {
   return path.join(dataDir(), 'bookmarks-meta.json');
 }
 
+export function instagramSavedCachePath(): string {
+  return path.join(dataDir(), 'instagram-saved.jsonl');
+}
+
+export function instagramSavedStatePath(): string {
+  return path.join(dataDir(), 'instagram-saved-state.json');
+}
+
 export function twitterOauthTokenPath(): string {
   return path.join(dataDir(), 'oauth-token.json');
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -55,6 +55,13 @@ export interface QuotedTweetSnapshot {
 export interface BookmarkRecord {
   id: string;
   tweetId: string;
+  /** Provider is optional on legacy X cache rows and normalized at index load. */
+  source?: 'x' | 'instagram';
+  nativeId?: string;
+  contentType?: 'photo' | 'carousel' | 'video' | 'reel';
+  canonicalUrl?: string;
+  /** Fields copied from third-party content and never interpreted as instructions. */
+  untrustedFields?: Array<'text' | 'authorHandle' | 'authorName'>;
   authorHandle?: string;
   authorName?: string;
   authorProfileImageUrl?: string;
@@ -83,7 +90,7 @@ export interface BookmarkRecord {
   mediaObjects?: BookmarkMediaObject[];
   links?: string[];
   tags?: string[];
-  ingestedVia?: 'api' | 'browser' | 'graphql';
+  ingestedVia?: 'api' | 'browser' | 'graphql' | 'instagram-web';
   /** Parallel arrays of folder IDs and display names this bookmark is in on X. */
   folderIds?: string[];
   folderNames?: string[];

--- a/tests/bookmark-classify-llm.test.ts
+++ b/tests/bookmark-classify-llm.test.ts
@@ -1,6 +1,11 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { extractJsonArray } from '../src/bookmark-classify-llm.js';
+import { mkdtemp, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { classifyDomainsWithLlm, classifyWithLlm, extractJsonArray } from '../src/bookmark-classify-llm.js';
+import { buildIndex } from '../src/bookmarks-db.js';
+import type { ResolvedEngine } from '../src/engine.js';
 
 test('extractJsonArray: stops at the end of the first balanced JSON array', () => {
   const raw = `Here you go:
@@ -31,4 +36,32 @@ test('extractJsonArray: ignores brackets inside JSON strings', () => {
     extractJsonArray(raw),
     '[{"id":"1","domains":["ai"],"primary":"ai","note":"keep [this] literal"}]',
   );
+});
+
+test('LLM classification remains scoped to X when the shared index contains Instagram records', async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), 'ft-classify-source-'));
+  await writeFile(path.join(dir, 'instagram-saved.jsonl'), JSON.stringify({
+    id: 'ig-only',
+    tweetId: 'ig-only',
+    source: 'instagram',
+    url: 'https://www.instagram.com/p/Fixture/',
+    text: 'Instagram fixture',
+    syncedAt: '2026-08-24T00:00:00Z',
+  }) + '\n');
+  const previous = process.env.FT_DATA_DIR;
+  process.env.FT_DATA_DIR = dir;
+  const neverRunEngine: ResolvedEngine = {
+    name: 'never-run',
+    label: 'never-run',
+    config: { bin: '/definitely/missing/engine', args: () => [] },
+  };
+
+  try {
+    await buildIndex();
+    assert.equal((await classifyWithLlm({ engine: neverRunEngine })).totalUnclassified, 0);
+    assert.equal((await classifyDomainsWithLlm({ engine: neverRunEngine, all: true })).totalUnclassified, 0);
+  } finally {
+    if (previous === undefined) delete process.env.FT_DATA_DIR;
+    else process.env.FT_DATA_DIR = previous;
+  }
 });

--- a/tests/bookmarks-db.test.ts
+++ b/tests/bookmarks-db.test.ts
@@ -152,13 +152,17 @@ test('buildIndex keeps X and Instagram ids distinct and exposes source metadata'
       instagram.map((record) => JSON.stringify(record)).join('\n') + '\n',
     );
 
-    const built = await buildIndex();
+    const built = await buildIndex({ reportSource: 'all' });
     assert.equal(built.recordCount, 5);
+    const xReport = await buildIndex();
+    assert.equal(xReport.recordCount, 3, 'X sync/index reporting remains scoped to X');
+    assert.equal(xReport.newRecords, 0);
 
     const xCollision = await getBookmarkById('1');
     const instagramCollision = await getBookmarkById('instagram:1');
     assert.equal(xCollision?.source, 'x');
-    assert.equal(xCollision?.nativeId, '1');
+    assert.equal(Object.hasOwn(xCollision ?? {}, 'nativeId'), false, 'X structured output gains only source');
+    assert.equal(Object.hasOwn(xCollision ?? {}, 'canonicalUrl'), false, 'X structured output keeps its prior URL shape');
     assert.equal(instagramCollision?.source, 'instagram');
     assert.equal(instagramCollision?.contentType, 'reel');
     assert.equal(instagramCollision?.canonicalUrl, 'https://www.instagram.com/reel/CollisionFixture/');
@@ -170,9 +174,14 @@ test('buildIndex keeps X and Instagram ids distinct and exposes source metadata'
     assert.equal(results[0]?.source, 'instagram');
     assert.equal(results[0]?.canonicalUrl, 'https://www.instagram.com/p/SearchFixture/');
 
-    const listed = await listBookmarks({ author: 'ig_fixture', limit: 10 });
+    const listed = await listBookmarks({ source: 'all', author: 'ig_fixture', limit: 10 });
     assert.equal(listed[0]?.id, 'instagram:1');
     assert.equal(listed[0]?.source, 'instagram');
+
+    const legacyList = await listBookmarks({ limit: 10 });
+    assert.equal(legacyList.some((item) => item.source === 'instagram'), false, 'non-query callers remain X-only');
+    assert.equal((await getStats()).totalBookmarks, 3, 'legacy stats remain X-only');
+    assert.equal((await getClassificationProgress()).total, 3, 'classification scope remains X-only');
   });
 });
 

--- a/tests/bookmarks-db.test.ts
+++ b/tests/bookmarks-db.test.ts
@@ -118,6 +118,64 @@ test('searchBookmarks: full-text search returns matching results', async () => {
   });
 });
 
+test('buildIndex keeps X and Instagram ids distinct and exposes source metadata', async () => {
+  await withIsolatedDataDir(async () => {
+    const instagram = [
+      {
+        id: '1',
+        tweetId: '1',
+        source: 'instagram',
+        contentType: 'reel',
+        url: 'https://www.instagram.com/reel/CollisionFixture/',
+        canonicalUrl: 'https://www.instagram.com/reel/CollisionFixture/',
+        text: 'Instagram collision fixture',
+        authorHandle: 'ig_fixture',
+        authorName: 'Instagram Fixture',
+        postedAt: '2026-04-01T00:00:00Z',
+        syncedAt: '2026-04-02T00:00:00Z',
+        untrustedFields: ['text', 'authorHandle', 'authorName'],
+        ingestedVia: 'instagram-web',
+      },
+      {
+        id: 'ig-only',
+        tweetId: 'ig-only',
+        source: 'instagram',
+        contentType: 'photo',
+        url: 'https://www.instagram.com/p/SearchFixture/',
+        text: 'A searchable Instagram archive item',
+        authorHandle: 'ig_search',
+        syncedAt: '2026-04-03T00:00:00Z',
+      },
+    ];
+    await writeFile(
+      path.join(process.env.FT_DATA_DIR!, 'instagram-saved.jsonl'),
+      instagram.map((record) => JSON.stringify(record)).join('\n') + '\n',
+    );
+
+    const built = await buildIndex();
+    assert.equal(built.recordCount, 5);
+
+    const xCollision = await getBookmarkById('1');
+    const instagramCollision = await getBookmarkById('instagram:1');
+    assert.equal(xCollision?.source, 'x');
+    assert.equal(xCollision?.nativeId, '1');
+    assert.equal(instagramCollision?.source, 'instagram');
+    assert.equal(instagramCollision?.contentType, 'reel');
+    assert.equal(instagramCollision?.canonicalUrl, 'https://www.instagram.com/reel/CollisionFixture/');
+    assert.deepEqual(instagramCollision?.untrustedFields, ['text', 'authorHandle', 'authorName']);
+
+    const results = await searchBookmarks({ query: 'searchable Instagram', limit: 10 });
+    assert.equal(results.length, 1);
+    assert.equal(results[0]?.id, 'instagram:ig-only');
+    assert.equal(results[0]?.source, 'instagram');
+    assert.equal(results[0]?.canonicalUrl, 'https://www.instagram.com/p/SearchFixture/');
+
+    const listed = await listBookmarks({ author: 'ig_fixture', limit: 10 });
+    assert.equal(listed[0]?.id, 'instagram:1');
+    assert.equal(listed[0]?.source, 'instagram');
+  });
+});
+
 test('searchBookmarks: author filter works', async () => {
   await withIsolatedDataDir(async () => {
     await buildIndex();

--- a/tests/bookmarks-viz.test.ts
+++ b/tests/bookmarks-viz.test.ts
@@ -7,9 +7,12 @@ import path from 'node:path';
 import { buildIndex } from '../src/bookmarks-db.js';
 import { renderViz } from '../src/bookmarks-viz.js';
 
-async function withVizDataDir(records: any[], fn: () => Promise<void>): Promise<void> {
+async function withVizDataDir(records: any[], fn: () => Promise<void>, instagramRecords: any[] = []): Promise<void> {
   const dir = await mkdtemp(path.join(tmpdir(), 'ft-viz-test-'));
   await writeFile(path.join(dir, 'bookmarks.jsonl'), records.map((r) => JSON.stringify(r)).join('\n') + '\n');
+  if (instagramRecords.length > 0) {
+    await writeFile(path.join(dir, 'instagram-saved.jsonl'), instagramRecords.map((r) => JSON.stringify(r)).join('\n') + '\n');
+  }
 
   const saved = process.env.FT_DATA_DIR;
   process.env.FT_DATA_DIR = dir;
@@ -82,4 +85,24 @@ test('renderViz uses publication timing instead of fabricated bookmark timing', 
     assert.doesNotMatch(output, /when you reach for the bookmark button/);
     assert.doesNotMatch(output, /000Z/);
   });
+});
+
+test('renderViz remains X-only when the shared index contains Instagram records', async () => {
+  const xRecord = {
+    id: 'x-only', tweetId: 'x-only', url: 'https://x.com/x_author/status/x-only',
+    text: 'X visualization fixture', authorHandle: 'x_author', postedAt: '2026-01-01T00:00:00Z',
+    syncedAt: '2026-01-02T00:00:00Z', links: [], tags: [], ingestedVia: 'graphql',
+  };
+  const instagramRecord = {
+    id: '999999999999999999', tweetId: '999999999999999999', source: 'instagram',
+    url: 'https://www.instagram.com/p/VizFixture/', text: 'Instagram visualization sentinel',
+    authorHandle: 'ig_viz_sentinel', postedAt: '2026-01-01T00:00:00Z', syncedAt: '2026-01-02T00:00:00Z',
+  };
+
+  await withVizDataDir([xRecord], async () => {
+    await buildIndex({ force: true, reportSource: 'all' });
+    const output = await renderViz();
+    assert.match(output, /1 bookmarks/);
+    assert.doesNotMatch(output, /ig_viz_sentinel|999999999999999999|Instagram visualization sentinel/);
+  }, [instagramRecord]);
 });

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -5,6 +5,7 @@ import path from 'node:path';
 import os from 'node:os';
 import {
   compareVersions,
+  hasAnyBookmarkData,
   runWithSpinner,
   buildCli,
   parseCookieOption,
@@ -896,6 +897,44 @@ test('ft sync keeps the no-argument X target and registers explicit Instagram se
   assert.ok(sync);
   assert.equal(sync.registeredArguments.length, 1);
   assert.equal(sync.registeredArguments[0]?.required, false);
+});
+
+test('Instagram-only data can rebuild and query the existing CLI index', async () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ft-instagram-cli-'));
+  const previousDataDir = process.env.FT_DATA_DIR;
+  const previousExitCode = process.exitCode;
+  process.env.FT_DATA_DIR = tmpDir;
+  fs.writeFileSync(path.join(tmpDir, 'instagram-saved.jsonl'), JSON.stringify({
+    id: 'ig-cli-only',
+    tweetId: 'ig-cli-only',
+    source: 'instagram',
+    contentType: 'reel',
+    url: 'https://www.instagram.com/reel/CliFixture/',
+    text: 'Instagram CLI searchable sentinel',
+    authorHandle: 'ig_cli_fixture',
+    syncedAt: '2026-08-24T00:00:00Z',
+  }) + '\n');
+
+  try {
+    assert.equal(hasAnyBookmarkData(), true);
+    const indexOutput = await captureStdout(async () => {
+      await buildCli().parseAsync(['node', 'ft', 'index', '--force']);
+    });
+    assert.match(indexOutput, /Indexed 1 bookmarks/);
+
+    const searchOutput = await captureStdout(async () => {
+      await buildCli().parseAsync(['node', 'ft', 'search', 'searchable sentinel', '--json']);
+    });
+    const results = JSON.parse(searchOutput);
+    assert.equal(results[0]?.id, 'instagram:ig-cli-only');
+    assert.equal(results[0]?.source, 'instagram');
+    assert.equal(results[0]?.canonicalUrl, 'https://www.instagram.com/reel/CliFixture/');
+  } finally {
+    process.exitCode = previousExitCode;
+    if (previousDataDir === undefined) delete process.env.FT_DATA_DIR;
+    else process.env.FT_DATA_DIR = previousDataDir;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
 });
 
 test('ft wiki: description mentions engine prerequisite', () => {

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -3,7 +3,14 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
-import { compareVersions, runWithSpinner, buildCli, parseCookieOption, shouldInferStdinFromStats } from '../src/cli.js';
+import {
+  compareVersions,
+  runWithSpinner,
+  buildCli,
+  parseCookieOption,
+  resolveSyncSource,
+  shouldInferStdinFromStats,
+} from '../src/cli.js';
 import { dataDir } from '../src/paths.js';
 import { skillWithFrontmatter } from '../src/skill.js';
 
@@ -878,6 +885,17 @@ test('ft sync: media is on by default and exposes --no-media', () => {
   assert.ok(mediaOption, 'a media option must be registered');
   assert.equal(mediaOption.negate, true, 'the media option must be --no-media (negated)');
   assert.equal(mediaOption.long, '--no-media');
+});
+
+test('ft sync keeps the no-argument X target and registers explicit Instagram selection', () => {
+  assert.equal(resolveSyncSource(undefined), 'x');
+  assert.equal(resolveSyncSource('instagram'), 'instagram');
+  assert.throws(() => resolveSyncSource('linkedin'), /Unknown sync source/);
+
+  const sync = buildCli().commands.find((command: any) => command.name() === 'sync');
+  assert.ok(sync);
+  assert.equal(sync.registeredArguments.length, 1);
+  assert.equal(sync.registeredArguments[0]?.required, false);
 });
 
 test('ft wiki: description mentions engine prerequisite', () => {

--- a/tests/firefox-cookies.test.ts
+++ b/tests/firefox-cookies.test.ts
@@ -85,6 +85,7 @@ test('extractFirefoxInstagramCookies reads only the fixed Instagram session cook
     { host: '.instagram.com', name: 'sessionid', value: 'ig-session' },
     { host: '.instagram.com', name: 'csrftoken', value: 'ig-csrf' },
     { host: '.instagram.com', name: 'ds_user_id', value: '123' },
+    { host: '.instagram.com', name: 'rur', value: 'bad\noptional' },
     { host: '.example.com', name: 'sessionid', value: 'wrong-domain' },
   ]);
   try {
@@ -92,10 +93,23 @@ test('extractFirefoxInstagramCookies reads only the fixed Instagram session cook
     assert.equal(cookies.csrfToken, 'ig-csrf');
     assert.match(cookies.cookieHeader, /sessionid=ig-session/);
     assert.match(cookies.cookieHeader, /csrftoken=ig-csrf/);
+    assert.doesNotMatch(cookies.cookieHeader, /bad|rur=/);
     assert.doesNotMatch(cookies.cookieHeader, /wrong-domain/);
   } finally {
     fs.rmSync(profileDir, { recursive: true, force: true });
   }
+});
+
+test('extractFirefoxInstagramCookies rewrites shared X recovery guidance for Instagram', () => {
+  assert.throws(
+    () => extractFirefoxInstagramCookies('/definitely/missing/firefox-profile'),
+    (error: unknown) => {
+      assert.ok(error instanceof Error);
+      assert.doesNotMatch(error.message, /ft sync --cookies|x\.com/);
+      assert.match(error.message, /Instagram|instagram/);
+      return true;
+    },
+  );
 });
 
 test('ensureFirefoxCookieBackendAvailable: rejects unsupported Windows runtime clearly', () => {

--- a/tests/firefox-cookies.test.ts
+++ b/tests/firefox-cookies.test.ts
@@ -4,7 +4,11 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { createDb, saveDb } from '../src/db.js';
-import { extractFirefoxXCookies, ensureFirefoxCookieBackendAvailable } from '../src/firefox-cookies.js';
+import {
+  extractFirefoxInstagramCookies,
+  extractFirefoxXCookies,
+  ensureFirefoxCookieBackendAvailable,
+} from '../src/firefox-cookies.js';
 
 async function createFirefoxProfile(cookies: Array<{ host: string; name: string; value: string }>): Promise<string> {
   const profileDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ft-firefox-profile-'));
@@ -71,6 +75,24 @@ test('extractFirefoxXCookies falls back to twitter.com cookies when x.com is abs
     assert.equal(cookies.csrfToken, 'legacy-csrf-token');
     assert.match(cookies.cookieHeader, /ct0=legacy-csrf-token/);
     assert.match(cookies.cookieHeader, /auth_token=legacy-auth-token/);
+  } finally {
+    fs.rmSync(profileDir, { recursive: true, force: true });
+  }
+});
+
+test('extractFirefoxInstagramCookies reads only the fixed Instagram session cookie set', async () => {
+  const profileDir = await createFirefoxProfile([
+    { host: '.instagram.com', name: 'sessionid', value: 'ig-session' },
+    { host: '.instagram.com', name: 'csrftoken', value: 'ig-csrf' },
+    { host: '.instagram.com', name: 'ds_user_id', value: '123' },
+    { host: '.example.com', name: 'sessionid', value: 'wrong-domain' },
+  ]);
+  try {
+    const cookies = extractFirefoxInstagramCookies(profileDir);
+    assert.equal(cookies.csrfToken, 'ig-csrf');
+    assert.match(cookies.cookieHeader, /sessionid=ig-session/);
+    assert.match(cookies.cookieHeader, /csrftoken=ig-csrf/);
+    assert.doesNotMatch(cookies.cookieHeader, /wrong-domain/);
   } finally {
     fs.rmSync(profileDir, { recursive: true, force: true });
   }

--- a/tests/fixtures/instagram-saved-page.json
+++ b/tests/fixtures/instagram-saved-page.json
@@ -1,0 +1,82 @@
+{
+  "items": [
+    {
+      "pk": "1001",
+      "code": "PhotoFixture",
+      "media_type": 1,
+      "taken_at": 1787500000,
+      "caption": { "text": "Synthetic photo caption" },
+      "user": { "username": "fixture_photo", "full_name": "Photo Fixture" },
+      "image_versions2": {
+        "candidates": [
+          { "url": "https://scontent-test.cdninstagram.com/photo.jpg", "width": 1080, "height": 1080 },
+          { "url": "https://example.com/rejected.jpg", "width": 320, "height": 320 }
+        ]
+      }
+    },
+    {
+      "pk": "1002",
+      "code": "CarouselFixture",
+      "media_type": 8,
+      "taken_at": 1787500100,
+      "caption": { "text": "Synthetic carousel caption" },
+      "user": { "username": "fixture_carousel", "full_name": "Carousel Fixture" },
+      "carousel_media": [
+        {
+          "media_type": 1,
+          "image_versions2": {
+            "candidates": [
+              { "url": "https://scontent-test.cdninstagram.com/carousel-1.jpg", "width": 1080, "height": 1350 }
+            ]
+          }
+        },
+        {
+          "media_type": 2,
+          "image_versions2": {
+            "candidates": [
+              { "url": "https://scontent-test.cdninstagram.com/carousel-2.jpg", "width": 1080, "height": 1350 }
+            ]
+          },
+          "video_versions": [
+            { "url": "https://instagram-test.fbcdn.net/carousel-2.mp4", "width": 720, "height": 900 }
+          ]
+        }
+      ]
+    },
+    {
+      "pk": "1003",
+      "code": "VideoFixture",
+      "media_type": 2,
+      "product_type": "feed",
+      "taken_at": 1787500200,
+      "caption": { "text": "Synthetic video caption" },
+      "user": { "username": "fixture_video", "full_name": "Video Fixture" },
+      "image_versions2": {
+        "candidates": [
+          { "url": "https://scontent-test.cdninstagram.com/video-preview.jpg", "width": 1080, "height": 1080 }
+        ]
+      },
+      "video_versions": [
+        { "url": "https://instagram-test.fbcdn.net/video.mp4", "width": 720, "height": 720 }
+      ]
+    },
+    {
+      "pk": "1004",
+      "code": "ReelFixture",
+      "media_type": 2,
+      "product_type": "clips",
+      "taken_at": 1787500300,
+      "caption": { "text": "Synthetic reel caption" },
+      "user": { "username": "fixture_reel", "full_name": "Reel Fixture" },
+      "image_versions2": {
+        "candidates": [
+          { "url": "https://scontent-test.cdninstagram.com/reel-preview.jpg", "width": 1080, "height": 1920 }
+        ]
+      },
+      "video_versions": [
+        { "url": "https://instagram-test.fbcdn.net/reel.mp4", "width": 720, "height": 1280 }
+      ]
+    }
+  ],
+  "more_available": false
+}

--- a/tests/instagram-bookmarks.test.ts
+++ b/tests/instagram-bookmarks.test.ts
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtemp, readFile, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import {
@@ -200,6 +200,65 @@ test('an interrupted incremental run resumes with stop-on-known behavior intact'
     });
     assert.equal(second.complete, true);
     assert.equal(second.stopReason, 'caught up to saved archive');
+  });
+});
+
+test('recovers an incremental page committed before its checkpoint state', async () => {
+  await isolatedRun(async (dir) => {
+    const cachePath = path.join(dir, 'instagram-saved.jsonl');
+    const statePath = path.join(dir, 'instagram-saved-state.json');
+    const stateTempPath = `${statePath}.tmp`;
+    await writeFile(cachePath, JSON.stringify({
+      id: 'known', tweetId: 'known', source: 'instagram', contentType: 'photo',
+      url: 'https://www.instagram.com/p/Known/', text: 'known', syncedAt: '2026-01-01T00:00:00Z',
+    }) + '\n');
+    await writeFile(statePath, JSON.stringify({
+      provider: 'instagram', schemaVersion: 1, complete: true, totalRuns: 1,
+    }));
+
+    // Make the durable state writer fail after the cache has already committed.
+    await mkdir(stateTempPath);
+    await assert.rejects(
+      syncInstagramSaved({
+        session: SESSION,
+        maxPages: 1,
+        fetchImpl: async () => jsonResponse({
+          items: [{ pk: 'new-1', code: 'NewOne', media_type: 1, user: { username: 'fixture' } }],
+          more_available: true,
+          next_max_id: 'page-2',
+        }),
+      }),
+      /EISDIR|illegal operation on a directory/i,
+    );
+    await rm(stateTempPath, { recursive: true });
+
+    const cursors: Array<string | undefined> = [];
+    const result = await syncInstagramSaved({
+      session: SESSION,
+      delayMs: 0,
+      fetchImpl: async (input) => {
+        const cursor = new URL(String(input)).searchParams.get('max_id') ?? undefined;
+        cursors.push(cursor);
+        if (cursor === 'page-2') {
+          return jsonResponse({
+            items: [{ pk: 'new-2', code: 'NewTwo', media_type: 1, user: { username: 'fixture' } }],
+            more_available: true,
+            next_max_id: 'archive-boundary',
+          });
+        }
+        assert.equal(cursor, 'archive-boundary');
+        return jsonResponse({
+          items: [{ pk: 'known', code: 'Known', media_type: 1, user: { username: 'fixture' } }],
+          more_available: true,
+          next_max_id: 'unused',
+        });
+      },
+    });
+
+    assert.deepEqual(cursors, ['page-2', 'archive-boundary']);
+    assert.equal(result.complete, true);
+    assert.equal(result.stopReason, 'caught up to saved archive');
+    assert.equal(result.totalBookmarks, 3);
   });
 });
 

--- a/tests/instagram-bookmarks.test.ts
+++ b/tests/instagram-bookmarks.test.ts
@@ -1,0 +1,192 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, readFile, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import {
+  parseInstagramSavedResponse,
+  syncInstagramSaved,
+  type InstagramSession,
+} from '../src/instagram-bookmarks.js';
+
+const FIXTURE_PATH = new URL('./fixtures/instagram-saved-page.json', import.meta.url);
+const SESSION: InstagramSession = {
+  csrfToken: 'test-csrf-secret',
+  cookieHeader: 'sessionid=test-session-secret; csrftoken=test-csrf-secret',
+};
+
+function jsonResponse(body: unknown, status = 200, headers: Record<string, string> = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json', ...headers },
+  });
+}
+
+async function isolatedRun(
+  fn: (dir: string) => Promise<void>,
+): Promise<void> {
+  const dir = await mkdtemp(path.join(tmpdir(), 'ft-instagram-'));
+  const previous = process.env.FT_DATA_DIR;
+  process.env.FT_DATA_DIR = dir;
+  try {
+    await fn(dir);
+  } finally {
+    if (previous === undefined) delete process.env.FT_DATA_DIR;
+    else process.env.FT_DATA_DIR = previous;
+  }
+}
+
+test('parseInstagramSavedResponse normalizes photo, carousel, video, and Reel metadata', async () => {
+  const fixture = JSON.parse(await readFile(FIXTURE_PATH, 'utf8'));
+  const page = parseInstagramSavedResponse(fixture, '2026-08-24T12:00:00.000Z');
+
+  assert.deepEqual(page.records.map((record) => record.contentType), [
+    'photo', 'carousel', 'video', 'reel',
+  ]);
+  assert.equal(page.records[0]?.source, 'instagram');
+  assert.equal(page.records[0]?.url, 'https://www.instagram.com/p/PhotoFixture/');
+  assert.equal(page.records[3]?.url, 'https://www.instagram.com/reel/ReelFixture/');
+  assert.deepEqual(page.records[0]?.untrustedFields, ['text', 'authorHandle', 'authorName']);
+  assert.equal(page.records[0]?.mediaObjects?.length, 1, 'reject non-Instagram media hosts');
+  assert.equal(page.nextCursor, undefined);
+});
+
+test('syncInstagramSaved completes a first backfill and never persists session secrets', async () => {
+  await isolatedRun(async (dir) => {
+    const fixture = JSON.parse(await readFile(FIXTURE_PATH, 'utf8'));
+    const result = await syncInstagramSaved({
+      session: SESSION,
+      fetchImpl: async () => jsonResponse(fixture),
+      delayMs: 0,
+    });
+
+    assert.equal(result.complete, true);
+    assert.equal(result.added, 4);
+    assert.equal(result.totalBookmarks, 4);
+    const disk = [
+      await readFile(path.join(dir, 'instagram-saved.jsonl'), 'utf8'),
+      await readFile(path.join(dir, 'instagram-saved-state.json'), 'utf8'),
+    ].join('\n');
+    assert.doesNotMatch(disk, /test-session-secret|test-csrf-secret/);
+  });
+});
+
+test('syncInstagramSaved resumes an interrupted first backfill from its checkpoint', async () => {
+  await isolatedRun(async () => {
+    const cursors: Array<string | undefined> = [];
+    const first = await syncInstagramSaved({
+      session: SESSION,
+      maxPages: 1,
+      delayMs: 0,
+      fetchImpl: async (input) => {
+        const url = new URL(String(input));
+        cursors.push(url.searchParams.get('max_id') ?? undefined);
+        return jsonResponse({
+          items: [{ pk: '2001', code: 'FirstPage', media_type: 1, caption: { text: 'first' }, user: { username: 'fixture' } }],
+          more_available: true,
+          next_max_id: 'resume-cursor',
+        });
+      },
+    });
+    assert.equal(first.complete, false);
+    assert.equal(first.stopReason, 'max pages reached');
+
+    const second = await syncInstagramSaved({
+      session: SESSION,
+      delayMs: 0,
+      fetchImpl: async (input) => {
+        const url = new URL(String(input));
+        cursors.push(url.searchParams.get('max_id') ?? undefined);
+        return jsonResponse({
+          items: [{ pk: '2002', code: 'SecondPage', media_type: 2, product_type: 'clips', caption: { text: 'second' }, user: { username: 'fixture' } }],
+          more_available: false,
+        });
+      },
+    });
+
+    assert.deepEqual(cursors, [undefined, 'resume-cursor']);
+    assert.equal(second.complete, true);
+    assert.equal(second.totalBookmarks, 2);
+  });
+});
+
+test('later sync starts at newest, stops at a known id, and retains omitted cached records', async () => {
+  await isolatedRun(async (dir) => {
+    await writeFile(path.join(dir, 'instagram-saved.jsonl'), [
+      JSON.stringify({ id: 'old-1', tweetId: 'old-1', source: 'instagram', contentType: 'photo', url: 'https://www.instagram.com/p/OldOne/', text: 'old one', syncedAt: '2026-01-01T00:00:00Z' }),
+      JSON.stringify({ id: 'old-2', tweetId: 'old-2', source: 'instagram', contentType: 'photo', url: 'https://www.instagram.com/p/OldTwo/', text: 'old two', syncedAt: '2026-01-01T00:00:00Z' }),
+    ].join('\n') + '\n');
+    await writeFile(path.join(dir, 'instagram-saved-state.json'), JSON.stringify({
+      provider: 'instagram', schemaVersion: 1, complete: true, totalRuns: 1,
+    }));
+
+    let calls = 0;
+    const result = await syncInstagramSaved({
+      session: SESSION,
+      delayMs: 0,
+      fetchImpl: async (input) => {
+        calls += 1;
+        assert.equal(new URL(String(input)).searchParams.has('max_id'), false);
+        return jsonResponse({
+          items: [
+            { pk: 'new-1', code: 'NewOne', media_type: 1, caption: { text: 'new' }, user: { username: 'fixture' } },
+            { pk: 'old-1', code: 'OldOne', media_type: 1, caption: { text: 'old refreshed' }, user: { username: 'fixture' } },
+          ],
+          more_available: true,
+          next_max_id: 'unused',
+        });
+      },
+    });
+
+    assert.equal(calls, 1);
+    assert.equal(result.stopReason, 'caught up to saved archive');
+    assert.equal(result.added, 1);
+    assert.equal(result.totalBookmarks, 3, 'old-2 remains even though remote page omitted it');
+    assert.match(await readFile(path.join(dir, 'instagram-saved.jsonl'), 'utf8'), /old-2/);
+  });
+});
+
+test('remote safety failures preserve the prior cache and report an incomplete run without leaking cookies', async () => {
+  const cases = [
+    ['authentication required', jsonResponse({ message: 'login_required' }, 401)],
+    ['rate limited', jsonResponse({ message: 'Please wait' }, 429)],
+    ['redirect refused', new Response('', { status: 302, headers: { location: 'https://evil.example/' } })],
+    ['challenge required', jsonResponse({ challenge: { url: '/challenge/' } }, 403)],
+    ['response shape changed', jsonResponse({ unexpected: [] })],
+  ] as const;
+
+  for (const [expectedReason, response] of cases) {
+    await isolatedRun(async (dir) => {
+      const original = JSON.stringify({ id: 'safe', tweetId: 'safe', source: 'instagram', url: 'https://www.instagram.com/p/Safe/', text: 'safe', syncedAt: '2026-01-01T00:00:00Z' }) + '\n';
+      await writeFile(path.join(dir, 'instagram-saved.jsonl'), original);
+      const output: string[] = [];
+      const result = await syncInstagramSaved({
+        session: SESSION,
+        delayMs: 0,
+        onProgress: (progress) => output.push(JSON.stringify(progress)),
+        fetchImpl: async () => response.clone(),
+      });
+
+      assert.equal(result.complete, false);
+      assert.equal(result.stopReason, expectedReason);
+      assert.equal(await readFile(path.join(dir, 'instagram-saved.jsonl'), 'utf8'), original);
+      assert.doesNotMatch(output.join('\n'), /test-session-secret|test-csrf-secret/);
+    });
+  }
+});
+
+test('session acquisition failure leaves cache and checkpoint untouched', async () => {
+  await isolatedRun(async (dir) => {
+    const cachePath = path.join(dir, 'instagram-saved.jsonl');
+    const statePath = path.join(dir, 'instagram-saved-state.json');
+    await writeFile(cachePath, 'archive\n');
+    await writeFile(statePath, 'checkpoint\n');
+
+    await assert.rejects(
+      syncInstagramSaved({ sessionProvider: () => { throw new Error('Instagram session unavailable'); } }),
+      /Instagram session unavailable/,
+    );
+    assert.equal(await readFile(cachePath, 'utf8'), 'archive\n');
+    assert.equal(await readFile(statePath, 'utf8'), 'checkpoint\n');
+  });
+});

--- a/tests/instagram-bookmarks.test.ts
+++ b/tests/instagram-bookmarks.test.ts
@@ -51,6 +51,19 @@ test('parseInstagramSavedResponse normalizes photo, carousel, video, and Reel me
   assert.equal(page.nextCursor, undefined);
 });
 
+test('parseInstagramSavedResponse rejects a partially unknown page instead of dropping an item', () => {
+  assert.throws(
+    () => parseInstagramSavedResponse({
+      items: [
+        { pk: 'valid', code: 'ValidFixture', media_type: 1, user: { username: 'fixture' } },
+        { pk: 'unknown', code: 'UnknownFixture', media_type: 99, user: { username: 'fixture' } },
+      ],
+      more_available: false,
+    }),
+    /response shape changed/,
+  );
+});
+
 test('syncInstagramSaved completes a first backfill and never persists session secrets', async () => {
   await isolatedRun(async (dir) => {
     const fixture = JSON.parse(await readFile(FIXTURE_PATH, 'utf8'));
@@ -113,7 +126,7 @@ test('syncInstagramSaved resumes an interrupted first backfill from its checkpoi
 test('later sync starts at newest, stops at a known id, and retains omitted cached records', async () => {
   await isolatedRun(async (dir) => {
     await writeFile(path.join(dir, 'instagram-saved.jsonl'), [
-      JSON.stringify({ id: 'old-1', tweetId: 'old-1', source: 'instagram', contentType: 'photo', url: 'https://www.instagram.com/p/OldOne/', text: 'old one', syncedAt: '2026-01-01T00:00:00Z' }),
+      JSON.stringify({ id: 'old-1', tweetId: 'old-1', source: 'instagram', contentType: 'photo', url: 'https://www.instagram.com/p/OldOne/', text: 'old one', authorName: 'Archived Name', postedAt: '2025-12-31T00:00:00Z', syncedAt: '2026-01-01T00:00:00Z' }),
       JSON.stringify({ id: 'old-2', tweetId: 'old-2', source: 'instagram', contentType: 'photo', url: 'https://www.instagram.com/p/OldTwo/', text: 'old two', syncedAt: '2026-01-01T00:00:00Z' }),
     ].join('\n') + '\n');
     await writeFile(path.join(dir, 'instagram-saved-state.json'), JSON.stringify({
@@ -142,7 +155,69 @@ test('later sync starts at newest, stops at a known id, and retains omitted cach
     assert.equal(result.stopReason, 'caught up to saved archive');
     assert.equal(result.added, 1);
     assert.equal(result.totalBookmarks, 3, 'old-2 remains even though remote page omitted it');
-    assert.match(await readFile(path.join(dir, 'instagram-saved.jsonl'), 'utf8'), /old-2/);
+    const saved = (await readFile(path.join(dir, 'instagram-saved.jsonl'), 'utf8'))
+      .trim()
+      .split('\n')
+      .map((line) => JSON.parse(line));
+    assert.ok(saved.some((record) => record.id === 'old-2'));
+    const refreshed = saved.find((record) => record.id === 'old-1');
+    assert.equal(refreshed.authorName, 'Archived Name');
+    assert.equal(refreshed.postedAt, '2025-12-31T00:00:00Z');
+  });
+});
+
+test('an interrupted incremental run resumes with stop-on-known behavior intact', async () => {
+  await isolatedRun(async (dir) => {
+    await writeFile(path.join(dir, 'instagram-saved.jsonl'), JSON.stringify({
+      id: 'known', tweetId: 'known', source: 'instagram', contentType: 'photo',
+      url: 'https://www.instagram.com/p/Known/', text: 'known', syncedAt: '2026-01-01T00:00:00Z',
+    }) + '\n');
+    await writeFile(path.join(dir, 'instagram-saved-state.json'), JSON.stringify({
+      provider: 'instagram', schemaVersion: 1, complete: true, totalRuns: 1,
+    }));
+
+    const first = await syncInstagramSaved({
+      session: SESSION,
+      maxPages: 1,
+      fetchImpl: async () => jsonResponse({
+        items: [{ pk: 'new', code: 'New', media_type: 1, user: { username: 'fixture' } }],
+        more_available: true,
+        next_max_id: 'incremental-cursor',
+      }),
+    });
+    assert.equal(first.complete, false);
+
+    const second = await syncInstagramSaved({
+      session: SESSION,
+      fetchImpl: async (input) => {
+        assert.equal(new URL(String(input)).searchParams.get('max_id'), 'incremental-cursor');
+        return jsonResponse({
+          items: [{ pk: 'known', code: 'Known', media_type: 1, user: { username: 'fixture' } }],
+          more_available: true,
+          next_max_id: 'must-not-be-used',
+        });
+      },
+    });
+    assert.equal(second.complete, true);
+    assert.equal(second.stopReason, 'caught up to saved archive');
+  });
+});
+
+test('rebuild restarts from the newest page instead of a stale backfill cursor', async () => {
+  await isolatedRun(async (dir) => {
+    await writeFile(path.join(dir, 'instagram-saved-state.json'), JSON.stringify({
+      provider: 'instagram', schemaVersion: 1, complete: false, totalRuns: 1,
+      lastCursor: 'stale-cursor', mode: 'backfill',
+    }));
+    const result = await syncInstagramSaved({
+      session: SESSION,
+      rebuild: true,
+      fetchImpl: async (input) => {
+        assert.equal(new URL(String(input)).searchParams.has('max_id'), false);
+        return jsonResponse({ items: [], more_available: false });
+      },
+    });
+    assert.equal(result.complete, true);
   });
 });
 
@@ -175,6 +250,26 @@ test('remote safety failures preserve the prior cache and report an incomplete r
   }
 });
 
+test('a stalled Instagram request stops at its request budget and preserves the prior cache', async () => {
+  await isolatedRun(async (dir) => {
+    const cachePath = path.join(dir, 'instagram-saved.jsonl');
+    const original = JSON.stringify({ id: 'safe', tweetId: 'safe', source: 'instagram', url: 'https://www.instagram.com/p/Safe/', text: 'safe', syncedAt: '2026-01-01T00:00:00Z' }) + '\n';
+    await writeFile(cachePath, original);
+
+    const result = await syncInstagramSaved({
+      session: SESSION,
+      requestTimeoutMs: 5,
+      fetchImpl: async (_input, init) => new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener('abort', () => reject(new DOMException('aborted', 'AbortError')), { once: true });
+      }),
+    });
+
+    assert.equal(result.complete, false);
+    assert.equal(result.stopReason, 'request timed out');
+    assert.equal(await readFile(cachePath, 'utf8'), original);
+  });
+});
+
 test('session acquisition failure leaves cache and checkpoint untouched', async () => {
   await isolatedRun(async (dir) => {
     const cachePath = path.join(dir, 'instagram-saved.jsonl');
@@ -188,5 +283,26 @@ test('session acquisition failure leaves cache and checkpoint untouched', async 
     );
     assert.equal(await readFile(cachePath, 'utf8'), 'archive\n');
     assert.equal(await readFile(statePath, 'utf8'), 'checkpoint\n');
+  });
+});
+
+test('a malformed local cache stops before network access and is never overwritten', async () => {
+  await isolatedRun(async (dir) => {
+    const cachePath = path.join(dir, 'instagram-saved.jsonl');
+    await writeFile(cachePath, '{malformed archive\n');
+    let fetched = false;
+
+    await assert.rejects(
+      syncInstagramSaved({
+        session: SESSION,
+        fetchImpl: async () => {
+          fetched = true;
+          return jsonResponse({ items: [], more_available: false });
+        },
+      }),
+      /cache is unreadable or malformed.*No changes were written/,
+    );
+    assert.equal(fetched, false);
+    assert.equal(await readFile(cachePath, 'utf8'), '{malformed archive\n');
   });
 });


### PR DESCRIPTION
## Summary

Field Theory can now archive Instagram Saved photos, carousels, videos, and Reels into a separate local cache and return them through the existing search, list, and show commands. The no-argument `ft sync` path remains scoped to X.

## Design decisions

- `ft sync instagram` is an explicit experimental path. It does not introduce a provider framework or combined sync.
- The connector reads a fixed Instagram cookie set from supported local browser profiles, sends read-only requests to one fixed HTTPS endpoint, refuses redirects, and stops on authentication, rate-limit, challenge, or shape failures.
- First runs backfill to the end. Later runs start at the newest page and stop at known IDs. Checkpoints retain whether an interrupted run is a backfill or incremental sync.
- The Instagram archive is append-preserving. Remote omission, malformed local data, and partial response-shape drift cannot silently truncate it.
- The shared index qualifies Instagram IDs as `instagram:<native-id>`. Deferred X-only surfaces such as classification, visualization, statistics, markdown export, and seed queries remain X-only.

Session-settled decisions carried from planning: keep X sync unchanged (user-directed, over a provider adapter); limit this PR to Instagram ingestion and local search (user-directed, over cross-surface parity).

## Validation

- `npm run build` passes.
- Focused Instagram, cookie, mixed-index, classification-scope, visualization, CLI registration, and Instagram-only index tests pass.
- Full suite: 577 passed. The two failures are the same pre-existing `tests/cli.test.ts` JSON-capture failures reproduced on `origin/main` before this branch.
- A compiled Instagram-only fixture run rebuilt four records and returned the expected Reel through the existing `search`, `list`, and `show` commands.
- An isolated compiled `ft sync instagram --max-pages 1 --browser chrome` run with a logged-out profile failed with actionable guidance and wrote neither `instagram-saved.jsonl` nor `instagram-saved-state.json`.
- An account-owned, read-only Chrome full backfill archived 12,288 unique Saved records across photo, carousel, video, and Reel variants. It resumed safely after one transient response-shape stop and one max-runtime checkpoint, then reported `Complete: end of saved collection`.
- Existing `search`, `list`, and `show` returned the live Instagram records with source and canonical URLs. A follow-up incremental sync stopped at the known archive with zero new records and rebuilt the shared 12,969-record X/Instagram index with zero additions.
- The full-pull cache, checkpoint, and index were owner-only (`0600`) and contained no cookie markers. No raw traffic or private content was recorded in the repository or PR.

## Post-Deploy Monitoring & Validation

This CLI has no centralized runtime telemetry. During the first 24-48 hours, validate through command output and the local cache/state files:

- Healthy: the command reports `Complete`, later runs stop at the known archive, the Instagram cache and search index remain readable, and ordinary `ft sync` reports only X counts.
- Failure: the command reports authentication, rate-limit, challenge, redirect, timeout, or response-shape stop reasons and exits incomplete without changing a previously valid archive.
- Rollback: revert or disable the Instagram command path. The separate Instagram cache can remain on disk without affecting X sync.
- Owner: the submitting maintainer reviews any reported Instagram endpoint drift before release.
